### PR TITLE
fix: finish Info-stories follow-up gates

### DIFF
--- a/.agents/skills/linkedin-animated-infographics/SKILL.md
+++ b/.agents/skills/linkedin-animated-infographics/SKILL.md
@@ -1,126 +1,65 @@
 ---
 name: linkedin-animated-infographics-conventions
-description: Development conventions and patterns for linkedin-animated-infographics. TypeScript project with conventional commits.
+description: Development conventions for a Python, Markdown, HTML, CSS, SVG, and shell based LinkedIn infographic plugin with Info-stories composition.
 ---
 
 # Linkedin Animated Infographics Conventions
 
-> Generated from [imMamdouhaboammar/linkedin-animated-infographics](https://github.com/imMamdouhaboammar/linkedin-animated-infographics) on 2026-08-07
-
-## Overview
-
-This skill teaches Claude the development patterns and conventions used in linkedin-animated-infographics.
+Use this skill when changing this repository, adding a skill or agent, modifying the render pipeline, or writing regression tests.
 
 ## Tech Stack
 
-- **Primary Language**: TypeScript
-- **Architecture**: hybrid module organization
-- **Test Location**: separate
+- **Python 3**: registries, validators, frame capture, GIF assembly, and utility tools
+- **Markdown**: skills, agents, references, plans, and research notes
+- **HTML / CSS / SVG**: 1080x1350 artboards and deterministic animation
+- **Shell**: setup, lint, and render wrappers
+- **JSON**: plugin metadata, hooks, Story House / style registry data, and structured briefs
+- **unittest**: regression and acceptance tests
 
-## When to Use This Skill
-
-Activate this skill when:
-- Making changes to this repository
-- Adding new features following established patterns
-- Writing tests that match project conventions
-- Creating commits with proper message format
-
-## Commit Conventions
-
-Follow these commit message conventions based on 3 analyzed commits.
-
-### Commit Style: Conventional Commits
-
-### Prefixes Used
-
-- `fix`
-
-### Message Guidelines
-
-- Average message length: ~46 characters
-- Keep first line concise and descriptive
-- Use imperative mood ("Add feature" not "Added feature")
-
-
-*Commit message example*
-
-```text
-fix: enforce readable artboard contrast tokens
-```
-
-*Commit message example*
-
-```text
-fix: add artboard contrast hard constraint
-```
-
-*Commit message example*
-
-```text
-fix: make mobile contrast failures explicit in QA
-```
+There is no TypeScript application layer in the current repository. Do not introduce frontend framework conventions unless a task explicitly adds one.
 
 ## Architecture
 
-### Project Structure: Single Package
+- `skills/`: user-facing capabilities and their references
+- `agents/`: focused worker contracts with narrow inputs and outputs
+- `scripts/`: implementation and validation logic shared by skills and tools
+- `tools/`: thin public CLIs over shared Python logic
+- `assets/`: templates and generated-but-tracked visual reference assets
+- `tests/`: unit, contract, portability, and acceptance tests
+- `research/`: tracked provenance and design/capability studies; ignored upstream clones never ship
 
-This project uses **hybrid** module organization.
+## Info-stories
 
-### Guidelines
+Info-stories is the composition layer. Keep its four axes independent:
 
-- This project uses a hybrid organization
-- Follow existing patterns when adding new code
+1. Story House
+2. Visual Style
+3. Story Archetype
+4. Motion Pattern
 
-## Code Style
+`skills/info-stories/catalog.json` is the machine-readable source of truth. Human references explain the registry but must not contradict it. Existing artboard, motion, render, Arabic, and mascot skills remain the execution layer.
 
-### Language: TypeScript
+When adding a registry item, add or update tests before implementation. Preserve 4.5:1 text contrast, 3:1 state-pair contrast, deterministic briefs, and explicit compatibility failures.
 
-### Naming Conventions
+## Development Method
 
-| Element | Convention |
-|---------|------------|
-| Files | kebab-case |
-| Functions | camelCase |
-| Classes | PascalCase |
-| Constants | SCREAMING_SNAKE_CASE |
+- Follow existing architecture before adding a parallel implementation
+- Prefer one shared implementation with thin CLIs rather than duplicated logic
+- Write a failing regression test for behavior changes, then implement the minimum fix
+- Run the focused test first, then the complete test suite
+- Run `python3 -m compileall -q scripts tools`
+- Run `python3 scripts/info_stories.py check` when the registry changes
+- Run `git diff --check` before committing
+- Treat browser render verification separately from non-browser tests and report environment blockers precisely
 
-### Import Style: Relative Imports
+## Commit Conventions
 
-### Export Style: Named Exports
+Use conventional commits such as `feat:`, `fix:`, `test:`, `docs:`, and `chore:`. Keep one coherent concern per commit when practical.
 
+## Safety and Provenance
 
-*Preferred import style*
-
-```typescript
-// Use relative imports
-import { Button } from '../components/Button'
-import { useAuth } from './hooks/useAuth'
-```
-
-*Preferred export style*
-
-```typescript
-// Use named exports
-export function calculateTotal() { ... }
-export const TAX_RATE = 0.1
-export interface Order { ... }
-```
-
-## Best Practices
-
-Based on analysis of the codebase, follow these practices:
-
-### Do
-
-- Use conventional commit format (feat:, fix:, etc.)
-- Use kebab-case for file names
-- Prefer named exports
-
-### Don't
-
-- Don't write vague commit messages
-- Don't deviate from established patterns without discussion
-
----
-
-*This skill was auto-generated by [ECC Tools](https://ecc.tools). Review and customize as needed for your team.*
+- Never commit credentials, private MCP configuration, or user secrets
+- Never ship `research/upstreams/`
+- Track source URL, inspected SHA, license, adopted ideas, and rejected ideas for capability research
+- Prefer independently worded local rules over wholesale copying
+- Do not fabricate visual proof or factual content to satisfy a template slot

--- a/.claude/skills/linkedin-animated-infographics/SKILL.md
+++ b/.claude/skills/linkedin-animated-infographics/SKILL.md
@@ -1,126 +1,65 @@
 ---
 name: linkedin-animated-infographics-conventions
-description: Development conventions and patterns for linkedin-animated-infographics. TypeScript project with conventional commits.
+description: Development conventions for a Python, Markdown, HTML, CSS, SVG, and shell based LinkedIn infographic plugin with Info-stories composition.
 ---
 
 # Linkedin Animated Infographics Conventions
 
-> Generated from [imMamdouhaboammar/linkedin-animated-infographics](https://github.com/imMamdouhaboammar/linkedin-animated-infographics) on 2026-08-07
-
-## Overview
-
-This skill teaches Claude the development patterns and conventions used in linkedin-animated-infographics.
+Use this skill when changing this repository, adding a skill or agent, modifying the render pipeline, or writing regression tests.
 
 ## Tech Stack
 
-- **Primary Language**: TypeScript
-- **Architecture**: hybrid module organization
-- **Test Location**: separate
+- **Python 3**: registries, validators, frame capture, GIF assembly, and utility tools
+- **Markdown**: skills, agents, references, plans, and research notes
+- **HTML / CSS / SVG**: 1080x1350 artboards and deterministic animation
+- **Shell**: setup, lint, and render wrappers
+- **JSON**: plugin metadata, hooks, Story House / style registry data, and structured briefs
+- **unittest**: regression and acceptance tests
 
-## When to Use This Skill
-
-Activate this skill when:
-- Making changes to this repository
-- Adding new features following established patterns
-- Writing tests that match project conventions
-- Creating commits with proper message format
-
-## Commit Conventions
-
-Follow these commit message conventions based on 3 analyzed commits.
-
-### Commit Style: Conventional Commits
-
-### Prefixes Used
-
-- `fix`
-
-### Message Guidelines
-
-- Average message length: ~46 characters
-- Keep first line concise and descriptive
-- Use imperative mood ("Add feature" not "Added feature")
-
-
-*Commit message example*
-
-```text
-fix: enforce readable artboard contrast tokens
-```
-
-*Commit message example*
-
-```text
-fix: add artboard contrast hard constraint
-```
-
-*Commit message example*
-
-```text
-fix: make mobile contrast failures explicit in QA
-```
+There is no TypeScript application layer in the current repository. Do not introduce frontend framework conventions unless a task explicitly adds one.
 
 ## Architecture
 
-### Project Structure: Single Package
+- `skills/`: user-facing capabilities and their references
+- `agents/`: focused worker contracts with narrow inputs and outputs
+- `scripts/`: implementation and validation logic shared by skills and tools
+- `tools/`: thin public CLIs over shared Python logic
+- `assets/`: templates and generated-but-tracked visual reference assets
+- `tests/`: unit, contract, portability, and acceptance tests
+- `research/`: tracked provenance and design/capability studies; ignored upstream clones never ship
 
-This project uses **hybrid** module organization.
+## Info-stories
 
-### Guidelines
+Info-stories is the composition layer. Keep its four axes independent:
 
-- This project uses a hybrid organization
-- Follow existing patterns when adding new code
+1. Story House
+2. Visual Style
+3. Story Archetype
+4. Motion Pattern
 
-## Code Style
+`skills/info-stories/catalog.json` is the machine-readable source of truth. Human references explain the registry but must not contradict it. Existing artboard, motion, render, Arabic, and mascot skills remain the execution layer.
 
-### Language: TypeScript
+When adding a registry item, add or update tests before implementation. Preserve 4.5:1 text contrast, 3:1 state-pair contrast, deterministic briefs, and explicit compatibility failures.
 
-### Naming Conventions
+## Development Method
 
-| Element | Convention |
-|---------|------------|
-| Files | kebab-case |
-| Functions | camelCase |
-| Classes | PascalCase |
-| Constants | SCREAMING_SNAKE_CASE |
+- Follow existing architecture before adding a parallel implementation
+- Prefer one shared implementation with thin CLIs rather than duplicated logic
+- Write a failing regression test for behavior changes, then implement the minimum fix
+- Run the focused test first, then the complete test suite
+- Run `python3 -m compileall -q scripts tools`
+- Run `python3 scripts/info_stories.py check` when the registry changes
+- Run `git diff --check` before committing
+- Treat browser render verification separately from non-browser tests and report environment blockers precisely
 
-### Import Style: Relative Imports
+## Commit Conventions
 
-### Export Style: Named Exports
+Use conventional commits such as `feat:`, `fix:`, `test:`, `docs:`, and `chore:`. Keep one coherent concern per commit when practical.
 
+## Safety and Provenance
 
-*Preferred import style*
-
-```typescript
-// Use relative imports
-import { Button } from '../components/Button'
-import { useAuth } from './hooks/useAuth'
-```
-
-*Preferred export style*
-
-```typescript
-// Use named exports
-export function calculateTotal() { ... }
-export const TAX_RATE = 0.1
-export interface Order { ... }
-```
-
-## Best Practices
-
-Based on analysis of the codebase, follow these practices:
-
-### Do
-
-- Use conventional commit format (feat:, fix:, etc.)
-- Use kebab-case for file names
-- Prefer named exports
-
-### Don't
-
-- Don't write vague commit messages
-- Don't deviate from established patterns without discussion
-
----
-
-*This skill was auto-generated by [ECC Tools](https://ecc.tools). Review and customize as needed for your team.*
+- Never commit credentials, private MCP configuration, or user secrets
+- Never ship `research/upstreams/`
+- Track source URL, inspected SHA, license, adopted ideas, and rejected ideas for capability research
+- Prefer independently worded local rules over wholesale copying
+- Do not fabricate visual proof or factual content to satisfy a template slot

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ python3 tools/composition_check.py --style signal-sheet \
 
 # Detect named copy-pattern failures without guessing authorship
 python3 tools/copy_slop_check.py "copy to inspect"
+
+# Check one semantic colour pair against a contrast floor
+python3 tools/contrast_check.py --house ember-paper --fg accent_deep --bg bg --minimum 4.5
+
+# Reject a palette-only reskin when a previous structural fingerprint exists
+python3 tools/fingerprint_check.py --current build/fingerprint.json \
+  --previous build/previous-fingerprint.json --min-changes 2
 ```
 
 Tracked chooser: `assets/info-stories-palettes.html`. Acceptance examples: `examples/info-stories/`.

--- a/scripts/audit_upstreams.py
+++ b/scripts/audit_upstreams.py
@@ -38,6 +38,8 @@ def _license_name(repo):
 
 def build_inventory(upstreams=DEFAULT_UPSTREAMS):
     upstreams = Path(upstreams)
+    if not upstreams.exists():
+        return []
     items = []
     for repo in sorted((p for p in upstreams.iterdir() if p.is_dir()), key=lambda p: p.name):
         if not (repo / ".git").exists():
@@ -68,8 +70,10 @@ def main(argv=None):
     parser.add_argument("--upstreams", type=Path, default=DEFAULT_UPSTREAMS)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
     args = parser.parse_args(argv)
-    live = build_inventory(args.upstreams)
     if args.command == "inventory":
+        if not args.upstreams.exists():
+            print(f"local upstream corpus not found: {args.upstreams}")
+            return 2
         payload = write_inventory(args.upstreams, args.output)
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
@@ -77,6 +81,13 @@ def main(argv=None):
         print(f"missing snapshot: {args.output}")
         return 1
     snapshot = json.loads(args.output.read_text()).get("sources", [])
+    if not isinstance(snapshot, list) or not snapshot:
+        print("tracked snapshot is empty or invalid")
+        return 1
+    if not args.upstreams.exists():
+        print("Local upstream corpus not present; tracked snapshot: OK")
+        return 0
+    live = build_inventory(args.upstreams)
     if snapshot != live:
         print("upstream snapshot differs from local working copies")
         return 1

--- a/skills/post/SKILL.md
+++ b/skills/post/SKILL.md
@@ -1,85 +1,72 @@
 ---
 name: post
 description: >-
-  Router for building a LinkedIn post as a caption plus a 1080x1350 looping GIF infographic.
-  Use EVERY TIME the user wants a LinkedIn post, an animated infographic, a GIF for LinkedIn,
-  a carousel-killer single visual, a system map, stack map, workflow diagram, or cheat sheet
-  visual, or asks how creators make those looping Claude/AI/GTM infographics. Also trigger on
-  Arabic requests like "اعملي بوست لينكدإن", "انفوجرافيك متحرك", "GIF للينكدإن", "خريطة نظام",
-  "بوست فيه فيجوال", or when the user pastes a topic, repo, tool, playbook, or skill and wants
-  it turned into a LinkedIn visual. Even for a small ask like "make me a hook" or "animate this
-  diagram", start here.
+  Router for building a LinkedIn post as a caption plus a 1080x1350 static or looping
+  infographic. Use when the user wants a LinkedIn post, animated infographic, GIF, system map,
+  stack map, workflow diagram, cheat sheet, or wants source material turned into a LinkedIn
+  visual. Start here even when the immediate ask is only a hook, visual direction, or motion.
 ---
 
-# LinkedIn Motion
+# LinkedIn Animated Infographics
 
-The post format that dominates AI and GTM LinkedIn: a tightly structured caption paired with
-a single 1080x1350 looping GIF that reads as a designed infographic rather than a slide.
-
-## The one insight that makes this work
-
-These GIFs are **static infographics with a small fraction of the canvas moving**, and that
-motion is a **reading pointer** guiding the eye through the diagram in the order the author
-wants it read. Everything else is frozen. That is why they look expensive.
-
-Judge the moving fraction on `build_gif.py`'s reported `motion:` figure, not on how much of
-the canvas looks busy. Under 2% is healthy.
+The core format is a complete static infographic with a small, deliberate motion footprint when animation adds meaning. Motion acts as a reading, route, hierarchy, or state signal. It does not compensate for weak information architecture.
 
 ## Pipeline
 
-```
-topic  →  archetype pick  →  caption  →  artboard  →  motion  →  render  →  QA  →  publish
+```text
+topic -> Info-stories brief -> caption -> still -> motion -> render -> independent QA -> publish
 ```
 
-Each stage has its own skill. Load the one you are in, not all of them.
+Load only the skill needed for the current stage.
 
-| Stage | Skill | Load it when |
+| Stage | Skill | Job |
 |---|---|---|
-| Caption | `linkedin-animated-infographics:caption` | writing or editing any caption. Seven archetypes, the truncation cut, the ban list |
-| Layout | `linkedin-animated-infographics:artboard` | choosing a visual archetype, picking colours, building the still |
-| Motion | `linkedin-animated-infographics:motion` | writing any animation CSS. Ten seekable primitives and the loop rules |
-| Mascots | `linkedin-animated-infographics:mascots` | putting a character on the artboard. Three roles, seek-safety, budget |
-| Render | `linkedin-animated-infographics:render` | capturing frames, assembling the GIF, running the gates, publishing |
-| Arabic | `linkedin-animated-infographics:arabic` | any Arabic or bilingual output. It is not a translation job |
+| Composition | `linkedin-animated-infographics:info-stories` | resolve Story Archetype, Visual Style, Story House, Motion Patterns, and design dials |
+| Caption | `linkedin-animated-infographics:caption` | write or edit the caption and enforce copy rules |
+| Layout | `linkedin-animated-infographics:artboard` | execute the approved static composition |
+| Motion | `linkedin-animated-infographics:motion` | implement seekable animation and loop rules |
+| Mascots | `linkedin-animated-infographics:mascots` | add an optional character within the motion budget |
+| Render | `linkedin-animated-infographics:render` | capture frames, assemble the GIF, and run render gates |
+| Arabic | `linkedin-animated-infographics:arabic` | apply Arabic and bilingual layout behavior |
 
-Three workflow skills run the whole thing end to end: `linkedin-animated-infographics:new-post`,
-`linkedin-animated-infographics:render-gif`, `linkedin-animated-infographics:qa-post`.
+Three workflow skills run common end-to-end tasks: `linkedin-animated-infographics:new-post`, `linkedin-animated-infographics:render-gif`, and `linkedin-animated-infographics:qa-post`.
 
 ## Agents
 
-Delegate rather than doing everything on the main thread. The render loop in particular
-produces a lot of output that does not belong in the conversation.
-
 | Agent | Give it |
 |---|---|
-| `caption-writer` | the topic and the CTA. Returns a caption that has already passed the ban list |
-| `artboard-builder` | the approved caption and archetype. Returns a still that passes `check_render.py` |
-| `motion-engineer` | an approved still. Returns the animated artboard with a clean loop |
-| `render-qa` | a built artboard. Runs the render, reports gate failures, changes nothing |
+| `design-study` | supplied visual references when their design DNA should inform a new direction |
+| `story-architect` | topic, takeaway, CTA, explicit choices, and optional study report |
+| `copy-compressor` | source material and target story slots when the artboard copy is too dense |
+| `evidence-checker` | claims, names, metrics, and proof that must survive into the visual |
+| `layout-composer` | approved story brief and compressed content blocks |
+| `artboard-builder` | approved static layout spec and story brief |
+| `motion-director` | approved still and story brief when output is animated |
+| `motion-engineer` | approved still plus resolved Motion Patterns |
+| `render-qa` | built artboard for render diagnostics |
+| `story-verifier` | final artifact plus acceptance criteria and direct evidence |
 
 ## Non-negotiables
 
 1. Exactly one `#artboard` element at `width:1080px; height:1350px`.
-2. All animation is CSS or WAAPI or SMIL, `infinite`, sharing one `--loop` or an integer
-   division of it. `requestAnimationFrame` cannot be seeked and will not render.
-3. Fonts are system-safe or base64-embedded. Never `@import` from a network.
-4. Colour comes from **House 0 — Muted Reference**, the default palette. Do not invent one
-   and do not raise the saturation.
-5. Nothing moves in the outer 48px margin.
-6. If there is a mascot, the mascot **is** the reading pointer and the abstract particle is
-   deleted.
-7. No em dashes and no denial-then-reveal contrast in the caption, English or Arabic.
+2. All animation is seekable CSS, WAAPI, or SMIL, shares one `--loop` or an integer division, and keeps frame 0 complete.
+3. Fonts are system-safe or base64-embedded. Never `@import` a network font.
+4. When Info-stories is active, colour comes from the resolved **Story House** token block. Do not silently replace it with House 0 or invent one-off colours. Legacy posts without a story brief may keep the existing House 0 default.
+5. Declared text pairs meet 4.5:1 contrast and declared state pairs meet 3:1.
+6. Nothing moves in the outer 48px margin.
+7. A mascot replaces another pointer primitive rather than becoming a third competing motion.
+8. No fabricated metrics, proof, testimonials, product facts, or source claims.
 
 ## Working method
 
-1. Ask only what you cannot infer: the one takeaway, and the CTA. No long intake.
-2. Propose the caption archetype and visual archetype in one line each. Get a yes.
-3. Write the caption first. It decides what the visual has to carry.
-4. Build the still. Show it. Get a yes. **This is the approval gate.**
-5. Animate last, and animate less than feels right.
-6. Render, QA, deliver the GIF plus the caption plus the first-comment text.
-
-Animating a layout nobody has approved wastes more time than anything else in this workflow.
+1. Ask only what cannot be inferred: the one takeaway and CTA.
+2. If references are supplied, study them before choosing a direction.
+3. Resolve and approve the Info-stories brief before production.
+4. Write the caption and compress artboard copy without weakening facts.
+5. Build and approve the still before motion.
+6. Add zero to two meaning-driven Motion Patterns.
+7. Render, run existing QA, then run independent story verification.
+8. Deliver the artifact, caption, first comment, resolved four-axis selection, and render numbers when applicable.
 
 ## Setup
 
@@ -87,5 +74,4 @@ Animating a layout nobody has approved wastes more time than anything else in th
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh
 ```
 
-Installs Playwright, a Chrome binary, and checks for ffmpeg. Everything else in
-`${CLAUDE_PLUGIN_ROOT}/scripts/` runs on plain Python 3.
+The registry and validation tools run on plain Python 3. Browser rendering additionally needs the Playwright browser and its operating-system libraries.

--- a/tests/test_info_stories_followup.py
+++ b/tests/test_info_stories_followup.py
@@ -1,0 +1,86 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCES = ROOT / "research" / "capability-notes" / "sources.json"
+
+
+class InfoStoriesFollowupTests(unittest.TestCase):
+    def test_main_post_router_uses_resolved_story_house(self):
+        text = (ROOT / "skills/post/SKILL.md").read_text()
+        self.assertIn("linkedin-animated-infographics:info-stories", text)
+        self.assertIn("Story House", text)
+        self.assertNotIn("Colour comes from **House 0", text)
+
+    def test_repo_convention_skills_describe_actual_stack(self):
+        for path in [
+            ROOT / ".agents/skills/linkedin-animated-infographics/SKILL.md",
+            ROOT / ".claude/skills/linkedin-animated-infographics/SKILL.md",
+        ]:
+            text = path.read_text()
+            self.assertIn("Python", text)
+            self.assertIn("Markdown", text)
+            self.assertIn("Info-stories", text)
+            self.assertNotIn("Primary Language**: TypeScript", text)
+
+    def test_missing_upstream_corpus_is_supported(self):
+        from scripts import audit_upstreams
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "not-cloned"
+            self.assertEqual([], audit_upstreams.build_inventory(missing))
+
+    def test_upstream_check_cli_accepts_clean_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "not-cloned"
+            result = subprocess.run(
+                [sys.executable, str(ROOT / "scripts/audit_upstreams.py"), "check", "--upstreams", str(missing), "--output", str(SOURCES)],
+                cwd=ROOT, text=True, capture_output=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+            self.assertIn("tracked snapshot", result.stdout.lower())
+
+    def test_public_contrast_tool_reports_ratio(self):
+        tool = ROOT / "tools/contrast_check.py"
+        self.assertTrue(tool.exists())
+        result = subprocess.run(
+            [sys.executable, str(tool), "--house", "ember-paper", "--fg", "accent_deep", "--bg", "bg", "--minimum", "4.5"],
+            cwd=ROOT, text=True, capture_output=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertGreaterEqual(payload["ratio"], 4.5)
+        self.assertIn("tools/contrast_check.py", (ROOT / "README.md").read_text())
+
+    def test_public_fingerprint_tool_rejects_palette_only_reskin(self):
+        tool = ROOT / "tools/fingerprint_check.py"
+        self.assertTrue(tool.exists())
+        fingerprint = {
+            "zone_topology": "three-column-board",
+            "card_grammar": "equal-rounded-cards",
+            "divider": "hairline",
+            "visual_anchor": "headline",
+            "density": "medium",
+            "motion_grammar": "sequential-highlight",
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            current = tmp / "current.json"
+            previous = tmp / "previous.json"
+            current.write_text(json.dumps(fingerprint))
+            previous.write_text(json.dumps(fingerprint))
+            result = subprocess.run(
+                [sys.executable, str(tool), "--current", str(current), "--previous", str(previous), "--min-changes", "2"],
+                cwd=ROOT, text=True, capture_output=True,
+            )
+        self.assertEqual(1, result.returncode)
+        self.assertFalse(json.loads(result.stdout)["ok"])
+        self.assertIn("tools/fingerprint_check.py", (ROOT / "README.md").read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/contrast_check.py
+++ b/tools/contrast_check.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts.info_stories import contrast_ratio, load_catalog  # noqa: E402
+
+
+def find_house(catalog, slug):
+    for house in catalog["houses"]:
+        if house["slug"] == slug:
+            return house
+    choices = ", ".join(item["slug"] for item in catalog["houses"])
+    raise ValueError(f"Unknown house {slug!r}. Valid choices: {choices}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Check one Story House foreground/background contrast pair")
+    parser.add_argument("--house", required=True)
+    parser.add_argument("--fg", required=True, help="foreground semantic token name")
+    parser.add_argument("--bg", required=True, help="background semantic token name")
+    parser.add_argument("--minimum", type=float, default=4.5)
+    args = parser.parse_args(argv)
+    try:
+        house = find_house(load_catalog(), args.house)
+        tokens = house["tokens"]
+        if args.fg not in tokens or args.bg not in tokens:
+            available = ", ".join(sorted(tokens))
+            raise ValueError(f"Unknown token. Available tokens: {available}")
+        ratio = contrast_ratio(tokens[args.fg], tokens[args.bg])
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    payload = {
+        "ok": ratio >= args.minimum,
+        "house": args.house,
+        "foreground": {"token": args.fg, "value": tokens[args.fg]},
+        "background": {"token": args.bg, "value": tokens[args.bg]},
+        "ratio": round(ratio, 3),
+        "minimum": args.minimum,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fingerprint_check.py
+++ b/tools/fingerprint_check.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts.info_stories import FINGERPRINT_AXES, validate_fingerprint  # noqa: E402
+
+
+def load_object(path):
+    payload = json.loads(Path(path).read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Check an Info-stories structural fingerprint")
+    parser.add_argument("--current", type=Path, required=True)
+    parser.add_argument("--previous", type=Path)
+    parser.add_argument("--min-changes", type=int, default=2)
+    args = parser.parse_args(argv)
+    try:
+        current = load_object(args.current)
+        previous = load_object(args.previous) if args.previous else None
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    errors = validate_fingerprint(current, previous, min_changes=args.min_changes)
+    changed = []
+    if previous:
+        changed = [axis for axis in FINGERPRINT_AXES if current.get(axis) != previous.get(axis)]
+    print(json.dumps({"ok": not errors, "changed_axes": changed, "errors": errors}, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why this follow-up exists

PR #5 merged the main Info-stories feature before a final self-review patch reached the remote head. This PR carries only those remaining fixes and public validation tools.

## Changes

- remove the stale House 0 lock from the main `post` router when Info-stories is active
- align the repo convention skills with the actual Python/Markdown/HTML/CSS/SVG/shell stack instead of TypeScript conventions
- make `audit_upstreams.py check` valid in clean clones where ignored `research/upstreams/` working copies are intentionally absent
- add public `tools/contrast_check.py`
- add public `tools/fingerprint_check.py`
- document both CLIs in README
- add six isolated regression tests in `tests/test_info_stories_followup.py`

## Scope control

The follow-up contains 8 files only. JSON registry/examples/provenance files were deliberately excluded because their local differences were formatting-only drift.

## Verification

The GitHub tree SHA is byte-identical to the tested local tree: `c502370cebd7c2795a31fc715714a2d0be16433a`.

Clean checkout of remote commit `7de1662ea916fcb85ddf16cf97894b1ff1bbede1`:

- 46 tests discovered
- 42 passed
- 4 intentionally skipped because ignored live upstream clones are not shipped
- `python3 -m compileall -q scripts tools` passed
- `python3 scripts/info_stories.py check` passed
- `python3 scripts/audit_upstreams.py check` passed in clean-checkout mode
- `git diff --check origin/main...HEAD` passed
- working tree clean

The existing browser-render environment blocker remains unchanged: the Codespace image lacks `libatk-1.0.so.0`; this follow-up does not modify render/capture code.