### PR TITLE
feat: integrate Claude agent graph, marketplace, mascots, and UI stories

### DIFF
--- a/.agents/skills/linkedin-animated-infographics/SKILL.md
+++ b/.agents/skills/linkedin-animated-infographics/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when changing this repository, adding a skill or agent, modifying
 - **Markdown**: skills, agents, references, plans, and research notes
 - **HTML / CSS / SVG**: 1080x1350 artboards and deterministic animation
 - **Shell**: setup, lint, and render wrappers
-- **JSON**: plugin metadata, hooks, Story House / style registry data, and structured briefs
+- **JSON**: plugin metadata, hooks, Story House / style registry data, extensions, and structured briefs
 - **unittest**: regression and acceptance tests
 
 There is no TypeScript application layer in the current repository. Do not introduce frontend framework conventions unless a task explicitly adds one.
@@ -37,9 +37,9 @@ Info-stories is the composition layer. Keep its four axes independent:
 3. Story Archetype
 4. Motion Pattern
 
-`skills/info-stories/catalog.json` is the machine-readable source of truth. Human references explain the registry but must not contradict it. Existing artboard, motion, render, Arabic, and mascot skills remain the execution layer.
+The machine-readable source of truth is the **merged registry returned by `scripts/info_stories.py::load_catalog()`**. It combines the stable base `skills/info-stories/catalog.json` with first-party registry families in `skills/info-stories/extensions/*.json`, merged deterministically by filename. Human references explain the merged registry and must not contradict the merged result. Existing artboard, motion, render, Arabic, and mascot skills remain the execution layer.
 
-When adding a registry item, add or update tests before implementation. Preserve 4.5:1 text contrast, 3:1 state-pair contrast, deterministic briefs, and explicit compatibility failures.
+When adding a base item or extension item, add or update tests before implementation. Preserve 4.5:1 text contrast, 3:1 state-pair contrast, deterministic briefs, unique slugs/names across the merged registry, and explicit compatibility failures.
 
 ## Development Method
 
@@ -48,7 +48,9 @@ When adding a registry item, add or update tests before implementation. Preserve
 - Write a failing regression test for behavior changes, then implement the minimum fix
 - Run the focused test first, then the complete test suite
 - Run `python3 -m compileall -q scripts tools`
-- Run `python3 scripts/info_stories.py check` when the registry changes
+- Run `python3 scripts/info_stories.py check` when the base registry or extensions change
+- Run `python3 scripts/plugin_graph.py check` when agent routing or preloads change
+- Run `python3 scripts/validate_marketplace.py` when plugin packaging changes
 - Run `git diff --check` before committing
 - Treat browser render verification separately from non-browser tests and report environment blockers precisely
 
@@ -62,4 +64,4 @@ Use conventional commits such as `feat:`, `fix:`, `test:`, `docs:`, and `chore:`
 - Never ship `research/upstreams/`
 - Track source URL, inspected SHA, license, adopted ideas, and rejected ideas for capability research
 - Prefer independently worded local rules over wholesale copying
-- Do not fabricate visual proof or factual content to satisfy a template slot
+- Do not fabricate visual proof or factual content to satisfy a template or UI slot

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "mamdouh-creative-tools",
+  "version": "1.0.0",
+  "description": "Creative production plugins for structured visual storytelling and deterministic media workflows.",
+  "owner": {
+    "name": "Mamdouh Aboammar",
+    "url": "https://github.com/imMamdouhaboammar"
+  },
+  "plugins": [
+    {
+      "name": "linkedin-animated-infographics",
+      "source": "./",
+      "strict": true,
+      "version": "2.2.0",
+      "description": "Design, validate, render, and animate LinkedIn Info-stories with agent orchestration, exact-SVG mascots, and deterministic QA.",
+      "author": {
+        "name": "Mamdouh Aboammar",
+        "url": "https://github.com/imMamdouhaboammar"
+      },
+      "homepage": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
+      "repository": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
+      "license": "MIT",
+      "category": "design",
+      "tags": ["linkedin", "infographic", "animation", "info-stories", "svg", "mascot", "ui-mockup"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-animated-infographics",
-  "description": "Claude Code plugin for designing, rendering, and animating deterministic 1080x1350 GIF infographics and SVG mascots for LinkedIn (Arabic & RTL supported).",
-  "version": "2.1.0",
+  "description": "Claude Code plugin for designing, rendering, and animating deterministic 1080x1350 GIF infographics, UI mockup stories, and exact-SVG mascots for LinkedIn (Arabic & RTL supported).",
+  "version": "2.2.0",
   "author": {
     "name": "Mamdouh Aboammar",
     "url": "https://github.com/imMamdouhaboammar"
@@ -19,6 +19,7 @@
     "rtl",
     "svg",
     "mascot",
-    "info-stories"
+    "info-stories",
+    "ui-mockup"
   ]
 }

--- a/.claude/skills/linkedin-animated-infographics/SKILL.md
+++ b/.claude/skills/linkedin-animated-infographics/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when changing this repository, adding a skill or agent, modifying
 - **Markdown**: skills, agents, references, plans, and research notes
 - **HTML / CSS / SVG**: 1080x1350 artboards and deterministic animation
 - **Shell**: setup, lint, and render wrappers
-- **JSON**: plugin metadata, hooks, Story House / style registry data, and structured briefs
+- **JSON**: plugin metadata, hooks, Story House / style registry data, extensions, and structured briefs
 - **unittest**: regression and acceptance tests
 
 There is no TypeScript application layer in the current repository. Do not introduce frontend framework conventions unless a task explicitly adds one.
@@ -37,9 +37,9 @@ Info-stories is the composition layer. Keep its four axes independent:
 3. Story Archetype
 4. Motion Pattern
 
-`skills/info-stories/catalog.json` is the machine-readable source of truth. Human references explain the registry but must not contradict it. Existing artboard, motion, render, Arabic, and mascot skills remain the execution layer.
+The machine-readable source of truth is the **merged registry returned by `scripts/info_stories.py::load_catalog()`**. It combines the stable base `skills/info-stories/catalog.json` with first-party registry families in `skills/info-stories/extensions/*.json`, merged deterministically by filename. Human references explain the merged registry and must not contradict the merged result. Existing artboard, motion, render, Arabic, and mascot skills remain the execution layer.
 
-When adding a registry item, add or update tests before implementation. Preserve 4.5:1 text contrast, 3:1 state-pair contrast, deterministic briefs, and explicit compatibility failures.
+When adding a base item or extension item, add or update tests before implementation. Preserve 4.5:1 text contrast, 3:1 state-pair contrast, deterministic briefs, unique slugs/names across the merged registry, and explicit compatibility failures.
 
 ## Development Method
 
@@ -48,7 +48,9 @@ When adding a registry item, add or update tests before implementation. Preserve
 - Write a failing regression test for behavior changes, then implement the minimum fix
 - Run the focused test first, then the complete test suite
 - Run `python3 -m compileall -q scripts tools`
-- Run `python3 scripts/info_stories.py check` when the registry changes
+- Run `python3 scripts/info_stories.py check` when the base registry or extensions change
+- Run `python3 scripts/plugin_graph.py check` when agent routing or preloads change
+- Run `python3 scripts/validate_marketplace.py` when plugin packaging changes
 - Run `git diff --check` before committing
 - Treat browser render verification separately from non-browser tests and report environment blockers precisely
 
@@ -62,4 +64,4 @@ Use conventional commits such as `feat:`, `fix:`, `test:`, `docs:`, and `chore:`
 - Never ship `research/upstreams/`
 - Track source URL, inspected SHA, license, adopted ideas, and rejected ideas for capability research
 - Prefer independently worded local rules over wholesale copying
-- Do not fabricate visual proof or factual content to satisfy a template slot
+- Do not fabricate visual proof or factual content to satisfy a template or UI slot

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -51,3 +51,18 @@ jobs:
 
       - name: Run official Claude plugin validator
         run: claude plugin validate .
+
+      - name: Smoke-test marketplace registration and install
+        run: |
+          export HOME="${RUNNER_TEMP}/claude-marketplace-smoke"
+          mkdir -p "$HOME"
+          claude plugin marketplace add . --scope user
+          claude plugin marketplace list --json > "${RUNNER_TEMP}/marketplaces.json"
+          python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          data = json.loads(Path(os.environ["RUNNER_TEMP"]).joinpath("marketplaces.json").read_text())
+          text = json.dumps(data)
+          assert "mamdouh-creative-tools" in text, data
+          PY
+          claude plugin install linkedin-animated-infographics@mamdouh-creative-tools

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           export HOME="${RUNNER_TEMP}/claude-marketplace-smoke"
           mkdir -p "$HOME"
-          claude plugin marketplace add . --scope user
+          claude plugin marketplace add ./ --scope user
           claude plugin marketplace list --json > "${RUNNER_TEMP}/marketplaces.json"
           python3 - <<'PY'
           import json, os

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -1,0 +1,53 @@
+name: Claude Plugin Validation
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node for Claude Code validator
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Python unit tests
+        run: python3 -m unittest discover -s tests -v
+
+      - name: Compile Python tools
+        run: python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
+
+      - name: Validate Info-stories registry
+        run: python3 scripts/info_stories.py check
+
+      - name: Validate executable plugin graph
+        run: python3 scripts/plugin_graph.py check
+
+      - name: Validate marketplace contract
+        run: python3 scripts/validate_marketplace.py
+
+      - name: Validate hook and shell syntax
+        run: |
+          python3 -m json.tool hooks/hooks.json >/dev/null
+          bash -n scripts/lint_artboard.sh
+          bash -n scripts/setup.sh
+
+      - name: Install current Claude Code
+        run: npm install -g @anthropic-ai/claude-code@latest
+
+      - name: Run official Claude plugin validator
+        run: claude plugin validate .

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -46,6 +46,9 @@ jobs:
           bash -n scripts/lint_artboard.sh
           bash -n scripts/setup.sh
 
+      - name: Whitespace integrity
+        run: git diff --check HEAD^ HEAD
+
       - name: Install current Claude Code
         run: npm install -g @anthropic-ai/claude-code@latest
 

--- a/README.md
+++ b/README.md
@@ -1,118 +1,126 @@
 # linkedin-animated-infographics
 
-A Claude Code plugin for designing, rendering, and animating deterministic 1080x1350 GIF infographics and SVG mascots for LinkedIn (Arabic & RTL supported).
+A Claude Code plugin for designing, rendering, and animating deterministic 1080x1350 GIF infographics, Info-stories, UI mockup stories, and SVG mascots for LinkedIn (Arabic & RTL supported).
 
-## Install
+## Install from the Claude Marketplace
 
-```bash
-/plugin install imMamdouhaboammar/linkedin-animated-infographics
+Add the marketplace hosted by this repository, then install the plugin:
+
+```text
+/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics
+/plugin install linkedin-animated-infographics@mamdouh-creative-tools
 ```
 
-Then, once per machine:
+The marketplace catalog is `.claude-plugin/marketplace.json`. It exposes the plugin at the repository root with strict manifest mode.
+
+For local development, Claude Code can validate the same repository with:
+
+```bash
+claude plugin validate .
+```
+
+Then, once per machine for browser rendering:
 
 ```bash
 bash scripts/setup.sh
 ```
 
-That installs Playwright and a Chrome binary and checks for `ffmpeg`. Everything else runs on plain Python 3.
+That installs Playwright and a Chrome binary and checks for `ffmpeg`. Registry, graph, and marketplace validation run on plain Python 3.
 
 ## Features & Skills
 
 | Skill | Covers |
 |---|---|
 | `post` | The main router. Pipeline, non-negotiables, working method |
-| `caption` | 7 caption archetypes, the truncation cut, hook & CTA libraries, ban list |
+| `caption` | Caption archetypes, truncation cut, hook and CTA libraries, ban list |
 | `info-stories` | Story Houses, Visual Styles, Story Archetypes, Motion Patterns, study, and verification |
-| `artboard` | 13 execution archetypes, type scale, offline fonts, and still construction |
-| `motion` | 10 seekable primitives, one-loop-clock rule, reverse-delay trap |
-| `mascots` | 3 mascot roles, seek-safe rig, motion budgeting, archetype compatibility |
+| `artboard` | Execution archetypes, type scale, offline fonts, and still construction |
+| `motion` | Seekable primitives, one-loop-clock rule, reverse-delay trap |
+| `mascots` | Mascot roles, seek-safe rig, motion budgeting, archetype compatibility |
 | `render` | Frame capture, GIF assembly with size budgeting, QA gates, publishing |
 | `arabic` | RTL mirroring, Arabic type scale, bidi isolation, caption rhythm |
-| `svg-mascot-animator` | Physics-driven SVG mascot & logo animation (Anime.js v4 & baked CSS keyframes) |
+| `svg-mascot-animator` | SVG inspection, rigging, physics, and deterministic animation |
 
 ## Info-stories
 
-Info-stories separates a visual direction into four choices so a new post can change structure without throwing away the existing render pipeline:
+Info-stories separates a visual direction into four choices:
 
-1. **Story House** - semantic colour palette and contrast roles
-2. **Visual Style** - structural grammar such as Signal Sheet, Command Canvas, or Proof Mosaic
-3. **Story Archetype** - narrative job such as Framework in One Page or One Prompt, Full Workflow
-4. **Motion Pattern** - zero to two meaning-driven motions
+1. **Story House**: semantic colour palette and contrast roles
+2. **Visual Style**: structural grammar such as Signal Sheet, Command Canvas, or Proof Mosaic
+3. **Story Archetype**: narrative job such as Framework in One Page or One Prompt, Full Workflow
+4. **Motion Pattern**: zero to two meaning-driven motions
 
 Each Visual Style also carries three 1-10 design dials: design variance, motion intensity, and visual density. Reference images or GIFs can be diagnosed first by `design-study`; the diagnosis maps design DNA into ranked local choices rather than copying the source.
 
-Inspect and validate the registry:
+Inspect and validate the registry and executable graph:
 
 ```bash
 python3 scripts/info_stories.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/validate_marketplace.py
 python3 scripts/info_stories.py list house
 python3 scripts/info_stories.py list style
-python3 scripts/info_stories.py compose --style signal-sheet --archetype framework-in-one-page --motion sequential-highlight
 ```
 
-Generate a deterministic story brief with `scripts/info_stories.py scaffold`. External capability research lives under `research/capability-notes/`; the cloned upstream working copies are ignored and are not shipped with the plugin.
+External capability research lives under `research/capability-notes/`; cloned upstream working copies are ignored and are not shipped with the plugin.
 
 ### Info-stories tools
 
 ```bash
-# Browse all ten named Story Houses as a visual HTML chooser
 python3 tools/palette_preview.py --out assets/info-stories-palettes.html
-
-# Write a resolved story brief to a file
 python3 tools/story_scaffold.py --topic "..." --takeaway "..." --cta "..." \
   --house ember-paper --style signal-sheet --archetype framework-in-one-page \
   --motion sequential-highlight --out build/story-brief.json
-
-# Check whether a style, archetype, and motion set can compose
 python3 tools/composition_check.py --style signal-sheet \
   --archetype framework-in-one-page --motion sequential-highlight
-
-# Detect named copy-pattern failures without guessing authorship
 python3 tools/copy_slop_check.py "copy to inspect"
-
-# Check one semantic colour pair against a contrast floor
 python3 tools/contrast_check.py --house ember-paper --fg accent_deep --bg bg --minimum 4.5
-
-# Reject a palette-only reskin when a previous structural fingerprint exists
 python3 tools/fingerprint_check.py --current build/fingerprint.json \
   --previous build/previous-fingerprint.json --min-changes 2
 ```
 
-Tracked chooser: `assets/info-stories-palettes.html`. Acceptance examples: `examples/info-stories/`.
+Tracked palette chooser: `assets/info-stories-palettes.html`. Acceptance examples: `examples/info-stories/`.
 
-## Workflows (user-invoked)
+## Workflows
 
-```bash
+```text
 /linkedin-animated-infographics:new-post    [topic or URL] [--arabic] [--mascot]
 /linkedin-animated-infographics:render-gif  [path.html] [--duration 6.0] [--fps 12.5]
 /linkedin-animated-infographics:qa-post     [path.html] [caption.md]
 ```
 
+`new-post` is the parent orchestrator. Worker agents return explicit artifacts to it instead of coordinating hidden peer calls. The executable route and capability ownership are tracked in `architecture/plugin-graph.json`.
+
 ## Agents
 
 | Agent | Does |
 |---|---|
-| `caption-writer` | Writes the caption, enforces the ban list, verifies every number |
-| `artboard-builder` | Builds the still until it passes `check_render.py` |
-| `motion-engineer` | Implements the resolved zero-to-two motion patterns and makes the loop close |
-| `render-qa` | Renders and judges, read-only, keeping render noise off main thread |
-| `story-architect` | Resolves the four-axis Info-stories brief before production |
-| `design-study` | Extracts design DNA from references without pixel cloning |
-| `palette-curator` | Selects and verifies Story House tokens and contrast |
-| `layout-composer` | Converts story beats into a structural fingerprint and layout spec |
-| `motion-director` | Selects motion patterns and their communication job |
-| `copy-compressor` | Compresses artboard copy while preserving facts and voice |
+| `design-study` | Extracts reusable design DNA from references without pixel cloning |
 | `evidence-checker` | Blocks unsupported claims and fabricated proof |
+| `story-architect` | Resolves the four-axis Info-stories brief |
+| `palette-curator` | Verifies Story House tokens and contrast |
+| `copy-compressor` | Compresses artboard copy while preserving facts and voice |
+| `layout-composer` | Produces the structural fingerprint and layout specification |
+| `caption-writer` | Writes the caption under caption-specific rules |
+| `artboard-builder` | Builds and checks the still |
+| `motion-director` | Defines the communication job of motion |
+| `motion-engineer` | Implements seekable motion and closes the loop |
+| `render-qa` | Produces deterministic render evidence |
+| `post-critic` | Red-teams copy, visual structure, and motion before shipment |
 | `story-verifier` | Independently verifies acceptance criteria against artifact evidence |
-| `post-critic` | Red-teams the finished post before it ships |
 
 ## Hooks
 
-A `PostToolUse` lint runs on any HTML file containing an `#artboard`. It catches the three failures that otherwise cost a full render: `requestAnimationFrame` motion that cannot be seeked, a webfont loading over the network, and a missing or wrongly-sized artboard element.
+A `PostToolUse` lint runs on HTML files containing an `#artboard`. It catches non-seekable `requestAnimationFrame` motion, network fonts, and missing or wrongly sized artboards before a full render.
 
 ## Development & Validation
 
 ```bash
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q scripts tools
+python3 scripts/info_stories.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/validate_marketplace.py
 claude plugin validate .
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # linkedin-animated-infographics
 
-A Claude Code plugin for designing, rendering, and animating deterministic 1080x1350 GIF infographics, Info-stories, UI mockup stories, and SVG mascots for LinkedIn (Arabic & RTL supported).
+A Claude Code plugin for designing, rendering, and animating deterministic 1080x1350 GIF infographics, Info-stories, UI mockup stories, and exact-SVG mascots for LinkedIn (Arabic & RTL supported).
 
 ## Install from the Claude Marketplace
 
@@ -36,23 +36,58 @@ That installs Playwright and a Chrome binary and checks for `ffmpeg`. Registry, 
 | `info-stories` | Story Houses, Visual Styles, Story Archetypes, Motion Patterns, study, and verification |
 | `artboard` | Execution archetypes, type scale, offline fonts, and still construction |
 | `motion` | Seekable primitives, one-loop-clock rule, reverse-delay trap |
-| `mascots` | Mascot roles, seek-safe rig, motion budgeting, archetype compatibility |
+| `mascots` | Exact mascot identity, roles, motion budget, and infographic fit |
 | `render` | Frame capture, GIF assembly with size budgeting, QA gates, publishing |
 | `arabic` | RTL mirroring, Arabic type scale, bidi isolation, caption rhythm |
-| `svg-mascot-animator` | SVG inspection, rigging, physics, and deterministic animation |
+| `svg-mascot-animator` | Exact-SVG inspection, rigging, physics, creative directions, and deterministic animation |
 
 ## Info-stories
 
 Info-stories separates a visual direction into four choices:
 
 1. **Story House**: semantic colour palette and contrast roles
-2. **Visual Style**: structural grammar such as Signal Sheet, Command Canvas, or Proof Mosaic
-3. **Story Archetype**: narrative job such as Framework in One Page or One Prompt, Full Workflow
+2. **Visual Style**: structural grammar such as Signal Sheet, Command Canvas, UI Storyboard, or Interface Cutaway
+3. **Story Archetype**: narrative job such as Framework in One Page, Screen to Outcome, or State Change Story
 4. **Motion Pattern**: zero to two meaning-driven motions
 
 Each Visual Style also carries three 1-10 design dials: design variance, motion intensity, and visual density. Reference images or GIFs can be diagnosed first by `design-study`; the diagnosis maps design DNA into ranked local choices rather than copying the source.
 
-Inspect and validate the registry and executable graph:
+The stable base lives in `skills/info-stories/catalog.json`. First-party story families can extend it through `skills/info-stories/extensions/*.json`. `scripts/info_stories.py::load_catalog()` merges the registry deterministically and is the machine-readable source used by agents and tools.
+
+### UI Mockup Stories
+
+UI Mockup Stories make interface states part of the infographic narrative rather than decorative screenshots.
+
+- **UI Storyboard**: two to four screens or interface states in a clear sequence
+- **Interface Cutaway**: one dominant interface with annotated internal zones
+- **Screen to Outcome**: starting screen, interaction, visible result
+- **Inside the Interface**: hero interface, internal zones, why they matter
+- **State Change Story**: before state, trigger, after state
+- **Cursor Focus**: restrained secondary cue for one control or region
+- **State Transition**: one primary interface state change
+
+The UI rules preserve feed-width legibility, distinguish documented product UI from concept UI, label fictional data when it could be mistaken for real evidence, and block unsupported features, metrics, integrations, or customer proof.
+
+### Mascot Animator 2
+
+When the user names a specific official mascot, the plugin requires the exact user-supplied or task-attached SVG before mascot animation starts. It never redraws, approximates, substitutes, or generates a lookalike automatically.
+
+The mascot path is:
+
+`exact SVG -> identity contract -> SVG inspection -> rig plan -> creative direction -> mascot-animator -> motion integration -> render QA -> adversarial review -> independent verification`
+
+Creative starting directions include Guide the Eye, Curious Peek, Inspect and React, Carry and Place, Reveal Assistant, Status Confirmation, Route Follow, Card-to-Card Handoff, Calm Idle Breathing, and Contextual Micro-Reaction. Each direction must state its communication job, movable SVG parts, reset behavior, and motion budget.
+
+Inspect the available directions or validate a request:
+
+```bash
+python3 scripts/mascot_contract.py directions
+python3 scripts/mascot_contract.py check build/mascot-request.json
+```
+
+## Validation and tools
+
+Inspect and validate the registry, executable graph, and marketplace:
 
 ```bash
 python3 scripts/info_stories.py check
@@ -89,7 +124,7 @@ Tracked palette chooser: `assets/info-stories-palettes.html`. Acceptance example
 /linkedin-animated-infographics:qa-post     [path.html] [caption.md]
 ```
 
-`new-post` is the parent orchestrator. Worker agents return explicit artifacts to it instead of coordinating hidden peer calls. The executable route and capability ownership are tracked in `architecture/plugin-graph.json`.
+`new-post` is the parent orchestrator. Worker agents return explicit artifacts to it instead of coordinating hidden peer calls. The executable route, conditional mascot path, skill preloads, and capability ownership are tracked in `architecture/plugin-graph.json`.
 
 ## Agents
 
@@ -104,9 +139,10 @@ Tracked palette chooser: `assets/info-stories-palettes.html`. Acceptance example
 | `caption-writer` | Writes the caption under caption-specific rules |
 | `artboard-builder` | Builds and checks the still |
 | `motion-director` | Defines the communication job of motion |
-| `motion-engineer` | Implements seekable motion and closes the loop |
+| `mascot-animator` | Inspects and animates the exact supplied mascot SVG under an identity contract |
+| `motion-engineer` | Integrates seekable motion and closes the loop |
 | `render-qa` | Produces deterministic render evidence |
-| `post-critic` | Red-teams copy, visual structure, and motion before shipment |
+| `post-critic` | Red-teams copy, UI fidelity, mascot identity, visual structure, and motion |
 | `story-verifier` | Independently verifies acceptance criteria against artifact evidence |
 
 ## Hooks
@@ -117,12 +153,14 @@ A `PostToolUse` lint runs on HTML files containing an `#artboard`. It catches no
 
 ```bash
 python3 -m unittest discover -s tests -v
-python3 -m compileall -q scripts tools
+python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
 python3 scripts/info_stories.py check
 python3 scripts/plugin_graph.py check
 python3 scripts/validate_marketplace.py
 claude plugin validate .
 ```
+
+The GitHub validation workflow also registers the marketplace from a clean checkout and installs `linkedin-animated-infographics@mamdouh-creative-tools` as an end-to-end marketplace smoke test.
 
 ## Credits
 

--- a/agents/artboard-builder.md
+++ b/agents/artboard-builder.md
@@ -6,6 +6,9 @@ description: >-
   passes check_render.py, plus the still PNG.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
+skills:
+  - artboard
+  - info-stories
 ---
 
 You build the static artboard. Motion is somebody else's job and you must not add any.
@@ -16,8 +19,8 @@ Approved caption and artboard copy, plus `build/story-brief.json` when the post 
 
 ## Method
 
-1. Load `linkedin-animated-infographics:artboard`.
-2. If a story brief exists, also load `linkedin-animated-infographics:info-stories`. Read its selected Visual Style, Story House, `execution.artboard_archetype`, `execution.house_tokens`, and design dials. These are resolved inputs, not suggestions to replace with a preferred house.
+1. Use the preloaded `artboard` skill.
+2. If a story brief exists, also use the preloaded `info-stories` skill. Read its selected Visual Style, Story House, `execution.artboard_archetype`, `execution.house_tokens`, and design dials. These are resolved inputs, not suggestions to replace with a preferred house.
 3. If no story brief exists, preserve the legacy behavior: use the explicitly approved visual archetype and House 0 unless the brief names another palette.
 4. Read `references/visual-archetypes.md` for the chosen execution archetype and `references/design-systems.md` for shared typography, spacing, and contrast rules.
 5. Start from the closest template in `${CLAUDE_PLUGIN_ROOT}/assets/`. A template is scaffolding; reshape it to the selected Visual Style rather than producing a palette-only reskin.
@@ -44,4 +47,4 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py build/post.html --out buil
 
 ## Before returning
 
-Measure the real element positions. Confirm the last content block clears the footer, the visual anchor lands at mobile scale, and no dead band is caused by a template that no longer fits the content. Return file path, still, execution archetype, Visual Style, and Story House used.
+Measure the real element positions. Confirm the last content block clears the footer, the visual anchor lands at mobile scale, and no dead band is caused by a template that no longer fits the content. Return file path, still, execution archetype, Visual Style, and Story House used to the parent workflow.

--- a/agents/artboard-builder.md
+++ b/agents/artboard-builder.md
@@ -15,36 +15,41 @@ You build the static artboard. Motion is somebody else's job and you must not ad
 
 ## Inputs
 
-Approved caption and artboard copy, plus `build/story-brief.json` when the post uses Info-stories.
+Approved caption and artboard copy, `build/layout-spec.json`, plus `build/story-brief.json` when the post uses Info-stories.
 
 ## Method
 
 1. Use the preloaded `artboard` skill.
-2. If a story brief exists, also use the preloaded `info-stories` skill. Read its selected Visual Style, Story House, `execution.artboard_archetype`, `execution.house_tokens`, and design dials. These are resolved inputs, not suggestions to replace with a preferred house.
-3. If no story brief exists, preserve the legacy behavior: use the explicitly approved visual archetype and House 0 unless the brief names another palette.
-4. Read `references/visual-archetypes.md` for the chosen execution archetype and `references/design-systems.md` for shared typography, spacing, and contrast rules.
-5. Start from the closest template in `${CLAUDE_PLUGIN_ROOT}/assets/`. A template is scaffolding; reshape it to the selected Visual Style rather than producing a palette-only reskin.
-6. Inline the exact Story House token block from the story brief. Never invent one-off colours halfway through the artboard. Legacy posts may use `${CLAUDE_PLUGIN_ROOT}/assets/house0-tokens.css`.
-7. Build in `build/`: macro zones first, then hierarchy, then cards/connectors, then attribution footer.
+2. If a story brief exists, also use the preloaded `info-stories` skill. Read its selected Visual Style, Story House, `execution.artboard_archetype`, `execution.house_tokens`, and design dials. These are resolved inputs.
+3. If no story brief exists, preserve legacy behavior with the explicitly approved visual archetype and House 0 unless another palette is named.
+4. Read `references/visual-archetypes.md` and `references/design-systems.md` for shared typography, spacing, and contrast rules.
+5. Start from the closest template in `${CLAUDE_PLUGIN_ROOT}/assets/`, then reshape it to the selected Visual Style rather than producing a palette-only reskin.
+6. Inline the exact Story House token block. Never invent one-off colours halfway through the artboard.
+7. Build macro zones first, then hierarchy, then cards/connectors/UI, then attribution footer.
 8. Check after every meaningful change:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py build/post.html --out build/still.png
 ```
 
-9. View the rendered PNG yourself. The checker catches geometry; it cannot judge visual anchor, structural repetition, or awkward density. For Info-stories, compare the result with `design-taste-gates.md` and the layout spec's structural fingerprint.
+9. View the rendered PNG yourself and compare it with the approved structural fingerprint.
+
+## UI Mockup Stories
+
+For `ui-storyboard` or `interface-cutaway`, read `skills/info-stories/references/ui-mockup-rules.md`. Build interface surfaces with semantic HTML/CSS/SVG, not a fake screenshot raster when editable structure is available. Keep only story-critical controls and labels, preserve evidence-qualified product names/states, and verify core UI text at feed width. Concept data must remain visibly identifiable as sample/concept when readers could mistake it for real evidence.
 
 ## Non-negotiables
 
 - Exactly one `#artboard` at `width:1080px; height:1350px`.
 - System-safe or base64-embedded fonts only. Never `@import` from a network.
 - Nothing moving belongs here.
-- The attribution footer is mandatory: avatar, name, one URL.
+- The attribution footer is mandatory.
 - Load-bearing text at or above 22px in artboard units.
 - Text contrast follows the artboard skill's 4.5:1 floor.
 - Use explicit classes for positioning, never `:nth-of-type`.
 - When a Story House is resolved, do not silently fall back to House 0.
+- If a mascot is planned, preserve the reserved mascot zone and do not redraw its exact SVG in the still.
 
 ## Before returning
 
-Measure the real element positions. Confirm the last content block clears the footer, the visual anchor lands at mobile scale, and no dead band is caused by a template that no longer fits the content. Return file path, still, execution archetype, Visual Style, and Story House used to the parent workflow.
+Measure real element positions. Confirm footer clearance, feed-scale visual anchor, structural fingerprint, and UI legibility when relevant. Return file path, still, execution archetype, Visual Style, and Story House used to the parent workflow.

--- a/agents/caption-writer.md
+++ b/agents/caption-writer.md
@@ -7,16 +7,15 @@ description: >-
   the first-comment text.
 tools: Read, Grep, Glob, Write, Edit
 model: opus
+skills:
+  - caption
 ---
 
-You write LinkedIn captions for the animated-infographic post format. You are not a general
-copywriter; you work inside one specific structure and your job is to make it land.
+You write LinkedIn captions for the animated-infographic post format. You are not a general copywriter; you work inside one specific structure and your job is to make it land.
 
 ## Before writing
 
-Load the `linkedin-animated-infographics:caption` skill and read `references/caption-patterns.md` in full.
-Pick exactly one of the seven archetypes and stay in it. Blending archetypes is the failure
-you are most likely to commit and the reader always feels it.
+Use the preloaded `caption` skill and read `references/caption-patterns.md` in full. Pick exactly one of the seven archetypes and stay in it. Blending archetypes is the failure you are most likely to commit and the reader always feels it.
 
 ## The four rules
 
@@ -27,21 +26,14 @@ you are most likely to commit and the reader always feels it.
 
 ## Hard bans, enforced before you return anything
 
-Read every line you wrote. If a line reduces to "not X, but Y" in any language, including
-`ده مش X، ده Y`, `مش مجرد X`, `هذا ليس X، بل Y`, delete it and write the positive statement.
-No em dashes. No buzzwords from the list in the reference.
+Read every line you wrote. If a line reduces to "not X, but Y" in any language, including `ده مش X، ده Y`, `مش مجرد X`, `هذا ليس X، بل Y`, delete it and write the positive statement. No em dashes. No buzzwords from the list in the reference.
 
-If you catch yourself reaching for a dramatic reversal to make a line land, the line is weak.
-Name the mechanism or the consequence instead.
+If you catch yourself reaching for a dramatic reversal to make a line land, the line is weak. Name the mechanism or the consequence instead.
 
 ## Verify the facts
 
-Every number, product name, star count, and price in the caption is checkable and commenters
-will check it. If you cannot verify a figure from something in context or from a fetched page,
-cut it rather than approximating. A wrong number is the one thing that costs the post its
-credibility.
+Every number, product name, star count, and price in the caption is checkable and commenters will check it. If you cannot verify a figure from something in context or from a fetched page, cut it rather than approximating.
 
 ## Return
 
-The caption in a fenced block, the first-comment text in a second block, and one line naming
-which archetype you used and why. Nothing else.
+Return the caption, first-comment text, and the selected archetype to the parent workflow.

--- a/agents/copy-compressor.md
+++ b/agents/copy-compressor.md
@@ -3,6 +3,9 @@ name: copy-compressor
 description: Compresses source material into infographic-sized copy when cards, labels, headlines, or a CTA are too dense.
 tools: Read, Grep
 model: sonnet
+skills:
+  - info-stories
+  - caption
 ---
 
 You reduce copy without reducing facts or voice.
@@ -17,8 +20,8 @@ First mark facts, names, numbers, mechanisms, and qualifications that must survi
 
 ## Outputs
 
-Return slot-keyed copy, a list of protected facts, anything cut for density, and any unclear claim that needs evidence. Do not make facts up to fill an empty card.
+Return slot-keyed copy, a list of protected facts, anything cut for density, and any unclear claim that needs evidence to the parent workflow. Do not make facts up to fill an empty card.
 
 ## Capability gates
 
-Before return, read `skills/info-stories/references/anti-slop-gates.md` and `skills/info-stories/references/design-taste-gates.md`. Run the anti-slop scan on visible prose, then preserve any intentional fragment that exists because the slot is a label or node.
+Use `skills/info-stories/references/anti-slop-gates.md` and `skills/info-stories/references/design-taste-gates.md`. Run the anti-slop scan on visible prose, then preserve any intentional fragment that exists because the slot is a label or node.

--- a/agents/design-study.md
+++ b/agents/design-study.md
@@ -3,6 +3,8 @@ name: design-study
 description: Studies reference images, GIFs, prior designs, or public visual references before an Info-stories direction is selected.
 tools: Read, Grep, Glob
 model: opus
+skills:
+  - info-stories
 ---
 
 You diagnose reference design DNA. You do not build or imitate the source.
@@ -13,10 +15,10 @@ One primary reference, optional secondary references scoped to named axes, the u
 
 ## Method
 
-Read `skills/info-stories/references/study-protocol.md`. Analyze surface, type roles, structure, rhythm, visible motion, visual anchor, and copy boundaries separately. For screenshots, do not claim exact font identification. For GIFs, inspect sequence and first-frame behavior. Map the diagnosis to ranked Info-stories candidates instead of reproducing the source.
+Use `skills/info-stories/references/study-protocol.md`. Analyze surface, type roles, structure, rhythm, visible motion, visual anchor, and copy boundaries separately. For screenshots, do not claim exact font identification. For GIFs, inspect sequence and first-frame behavior. Map the diagnosis to ranked Info-stories candidates instead of reproducing the source.
 
 ## Outputs
 
-Return the required study-report object, a short diagnosis, ranked Story House / Visual Style / Story Archetype / Motion Pattern candidates, confidence notes, and any reproduction boundary. Validate the structured report before handoff.
+Return the required study-report object, a short diagnosis, ranked Story House / Visual Style / Story Archetype / Motion Pattern candidates, confidence notes, and any reproduction boundary to the parent workflow. Validate the structured report before returning.
 
-Stop after diagnosis unless the user has already approved applying the studied DNA.
+Stop after diagnosis unless the parent workflow has an already-approved direction to apply.

--- a/agents/evidence-checker.md
+++ b/agents/evidence-checker.md
@@ -15,8 +15,10 @@ Source material, proposed copy blocks, any citations or URLs already provided, a
 
 ## Method
 
-Separate sourced fact, user-supplied claim, inference, and unsupported claim. Verify spelling and internal consistency. Preserve qualifiers. An unsupported metric, testimonial, logo claim, or benchmark is a failure, not a creative placeholder.
+Separate sourced fact, user-supplied claim, inference, and unsupported claim. Verify spelling and internal consistency. Preserve qualifiers. An unsupported metric, testimonial, logo claim, feature, integration, product state, or benchmark is a failure, not a creative placeholder.
+
+For UI Storyboard or Interface Cutaway work, read `skills/info-stories/references/ui-mockup-rules.md`. Distinguish documented real UI from conceptual UI. Fictional data is allowed only when it is clearly treated as sample/concept data and is not presented as evidence of a real product capability.
 
 ## Outputs
 
-Return a claim table with status and source, a list of blocked proof slots, and exact copy that needs qualification to the parent workflow. Do not invent replacement claims or sources.
+Return a claim table with status and source, a list of blocked proof slots, and exact copy/UI labels that need qualification to the parent workflow. Do not invent replacement claims or sources.

--- a/agents/evidence-checker.md
+++ b/agents/evidence-checker.md
@@ -3,6 +3,8 @@ name: evidence-checker
 description: Checks claims, numbers, product names, sources, and proof slots before an Info-stories artifact is built or shipped.
 tools: Read, Grep
 model: sonnet
+skills:
+  - info-stories
 ---
 
 You check truth claims. Do not invent missing evidence.
@@ -17,4 +19,4 @@ Separate sourced fact, user-supplied claim, inference, and unsupported claim. Ve
 
 ## Outputs
 
-Return a claim table with status and source, a list of blocked proof slots, and exact copy that needs qualification. Do not invent replacement claims or sources.
+Return a claim table with status and source, a list of blocked proof slots, and exact copy that needs qualification to the parent workflow. Do not invent replacement claims or sources.

--- a/agents/layout-composer.md
+++ b/agents/layout-composer.md
@@ -12,11 +12,13 @@ You define structure. You do not write the final artboard.
 
 ## Inputs
 
-Story brief, compressed content blocks, selected Visual Style, Story Archetype, Story House, and optional studied design DNA.
+Story brief, compressed content blocks, selected Visual Style, Story Archetype, Story House, optional studied design DNA, and mascot placement requirements when present.
 
 ## Method
 
 Map required story beats into zones, define the visual anchor, card grammar, divider/connector grammar, density, and reading order. Treat a palette-only reskin as unchanged structure. Preserve the existing safe margin and attribution contract. Use the selected style's preferred existing artboard archetype as the execution bridge.
+
+For `ui-storyboard` or `interface-cutaway`, read `skills/info-stories/references/ui-mockup-rules.md`. Reserve space for only the controls/states required by the story, enforce feed-width legibility, distinguish documented UI from concept UI, and keep annotations outside critical controls. If a mascot is present, reserve a non-blocking mascot zone before HTML is built.
 
 ## Outputs
 

--- a/agents/layout-composer.md
+++ b/agents/layout-composer.md
@@ -3,6 +3,9 @@ name: layout-composer
 description: Converts an approved Info-stories narrative and visual style into a static zone and hierarchy specification.
 tools: Read, Bash, Grep
 model: opus
+skills:
+  - info-stories
+  - artboard
 ---
 
 You define structure. You do not write the final artboard.
@@ -17,8 +20,8 @@ Map required story beats into zones, define the visual anchor, card grammar, div
 
 ## Outputs
 
-Return a static layout spec with zone order, approximate proportions, component counts, hierarchy, structural fingerprint, and asset requirements. Handoff that spec to `artboard-builder`; do not duplicate its HTML or render responsibilities.
+Return a static layout spec with zone order, approximate proportions, component counts, hierarchy, structural fingerprint, and asset requirements. Return the spec to the parent workflow; do not duplicate `artboard-builder` HTML or render responsibilities.
 
 ## Capability gates
 
-Read both `skills/info-stories/references/design-taste-gates.md` and `skills/info-stories/references/anti-slop-gates.md`. Record the six-axis structural fingerprint. If a previous brief is provided, reject a palette-only reskin and require real structural distance.
+Use `skills/info-stories/references/design-taste-gates.md` and `skills/info-stories/references/anti-slop-gates.md`. Record the six-axis structural fingerprint. If a previous brief is provided, reject a palette-only reskin and require real structural distance.

--- a/agents/mascot-animator.md
+++ b/agents/mascot-animator.md
@@ -1,0 +1,44 @@
+---
+name: mascot-animator
+description: Animates the exact user-supplied SVG mascot after identity, riggability, and motion purpose are approved.
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: opus
+skills:
+  - svg-mascot-animator
+  - mascots
+---
+
+You animate an exact user-supplied SVG. You never invent, redraw, substitute, or approximate a requested official mascot.
+
+## Inputs
+
+The parent workflow must provide:
+
+- exact SVG path and source classification (`user-supplied` or `task-attached`)
+- requested mascot name when one was named
+- approved still and layout specification
+- selected mascot role
+- approved creative direction or permission to choose one
+- motion budget and loop duration
+
+If the exact SVG is missing, return `HOLD: exact SVG required` to the parent workflow. Do not ask the user directly and do not continue with a substitute.
+
+## Method
+
+1. Validate the request with `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mascot_contract.py check <request.json>`.
+2. Preserve the supplied SVG untouched as the identity source. Work from a copy under `build/mascot/`.
+3. Inspect riggability with `${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/inspect_svg.py` and record viewBox, groups, IDs, transforms, clips, paths, and addressable parts.
+4. Read `references/creative-directions.md`, `references/rigging.md`, `references/physics.md`, and the mascot motion-budget rules.
+5. Select or adapt one creative direction that has a communication job. State which parts may move and which competing pointer primitive it replaces.
+6. Prefer transforms on existing groups or paths. Keep face details, marks, colours, proportions, and silhouette recognizable.
+7. Add only non-identity support elements that help the story, such as a small pointer, card, cursor, contact shadow, or route cue.
+8. Build seekable motion using the appropriate static/baked track for deterministic infographic rendering.
+9. Validate the result with the SVG asset checker and return the approved component plus motion contract to the parent workflow.
+
+## Quality bar
+
+Motion should feel intentional, light, and physically coherent. Use anticipation, follow-through, contact shadow, squash/stretch, or spring response only when the rig and story justify them. Avoid constant bouncing, random blinking, large rotations, repeated gimmicks, or movement that changes the mascot's identity.
+
+## Outputs
+
+Return `build/mascot/motion-contract.json`, the working animated SVG/component path, inspection findings, chosen creative direction, identity-preservation notes, and any rig limitation. The parent workflow passes the validated result to `motion-engineer`.

--- a/agents/motion-director.md
+++ b/agents/motion-director.md
@@ -3,6 +3,9 @@ name: motion-director
 description: Chooses Info-stories motion patterns when an approved static story needs animation direction.
 tools: Read, Bash, Grep
 model: sonnet
+skills:
+  - info-stories
+  - motion
 ---
 
 You choose why and where motion happens. You do not implement CSS keyframes.
@@ -17,4 +20,4 @@ Pick zero to two compatible Motion Patterns. For each, name its communication jo
 
 ## Outputs
 
-Return ordered motion patterns, target elements, reason, loop-order expectation, and anything deliberately static. Handoff to `motion-engineer`, which owns seekable implementation, timing, and seam closure.
+Return ordered motion patterns, target elements, reason, loop-order expectation, and anything deliberately static. Return that motion direction to the parent workflow; `motion-engineer` owns seekable implementation, timing, and seam closure after the parent passes it on.

--- a/agents/motion-director.md
+++ b/agents/motion-director.md
@@ -16,8 +16,12 @@ Approved static layout spec, Story Archetype, Visual Style, output mode, and opt
 
 ## Method
 
-Pick zero to two compatible Motion Patterns. For each, name its communication job: hierarchy, reading sequence, state change, or route direction. Reject motion whose only reason is decoration. Preserve frame 0, the safe margin, and the existing changed-pixel budget.
+Pick zero to two compatible Motion Patterns. For each, name its communication job: hierarchy, reading sequence, state change, or route direction. Reject motion whose only reason is decoration. Preserve frame 0, safe margin, and changed-pixel budget.
+
+For `ui-storyboard` or `interface-cutaway`, read `skills/info-stories/references/ui-mockup-rules.md`. Prefer `cursor-focus` for one control/region and `state-transition` for one meaningful state change. Do not animate constant scrolling, every control, or multiple competing cursors.
+
+When a mascot is planned, treat its role as part of the same motion budget. The mascot must replace a competing pointer/highlight when it carries reading order. Pass the communication job and reserved target region to the parent workflow so the exact-SVG mascot worker can build a compatible component.
 
 ## Outputs
 
-Return ordered motion patterns, target elements, reason, loop-order expectation, and anything deliberately static. Return that motion direction to the parent workflow; `motion-engineer` owns seekable implementation, timing, and seam closure after the parent passes it on.
+Return ordered motion patterns, target elements, reason, loop-order expectation, mascot communication job when present, and anything deliberately static. Return that motion direction to the parent workflow; `motion-engineer` owns seekable implementation after the parent passes it on.

--- a/agents/motion-engineer.md
+++ b/agents/motion-engineer.md
@@ -6,30 +6,33 @@ description: >-
   reverse-delay trap. Returns the animated artboard, not a rendered GIF.
 tools: Read, Edit, Write, Bash, Grep
 model: opus
+skills:
+  - motion
+  - info-stories
 ---
 
 You implement motion on an approved still. You do not restructure layout and you do not touch copy.
 
 ## Inputs
 
-Approved artboard and `build/story-brief.json` when Info-stories is active.
+Approved artboard, approved motion direction, and `build/story-brief.json` when Info-stories is active. When a mascot is active, also receive the validated mascot motion artifact from the parent workflow.
 
 ## Method
 
-1. Load `linkedin-animated-infographics:motion` and read `references/animation-recipes.md`.
-2. When a story brief exists, also load `linkedin-animated-infographics:info-stories` and read `references/motion-patterns.md`. Implement the selected Motion Patterns in their declared order. Do not replace them with different motion because another primitive is easier to write.
-3. Translate each Info-stories Motion Pattern to the closest existing seekable primitive. Keep the pattern's communication job intact. Examples: Sequential Highlight maps directly; Connector Draw uses Path Draw-On; Card Reveal uses Staggered Reveal; Type-On Terminal uses Typewriter; Node/Badge/Spotlight pulses use Glow Pulse; Float Micro-Motion uses Ambient Micro-Loops.
+1. Use the preloaded `motion` skill and `references/animation-recipes.md`.
+2. When a story brief exists, use the preloaded `info-stories` skill and `references/motion-patterns.md`. Implement the selected Motion Patterns in their declared order.
+3. Translate each Info-stories Motion Pattern to the closest existing seekable primitive while keeping the communication job intact.
 4. If no story brief exists, preserve the legacy rule: choose exactly two primitives from the existing composition table.
 5. Use at most two motion patterns. A mascot pointer replaces another pointer pattern rather than adding a third.
 6. Define one `--loop` and derive all sub-loops using legal integer divisions: 1, 2, 3, 4, 5, 6, 8, 10, 12.
-7. For a mascot, generate motion blocks with `bake_mascot.py`; do not hand-edit emitted timing math.
+7. When a validated mascot artifact is provided, preserve its approved rig and identity contract. Do not redraw or substitute the mascot.
 
 ## The two traps
 
-**Reverse delays.** A negative `animation-delay` pushes an animation forward. Verify the intended reading order by capturing frames across the loop rather than trusting intuitive delay order.
+**Reverse delays.** A negative `animation-delay` pushes an animation forward. Verify reading order by capturing frames across the loop.
 
 **Frame 0.** It is LinkedIn's poster frame. No required element may be hidden or half-revealed there.
 
 ## Verify before returning
 
-Capture a small contact sheet. Confirm selected Motion Patterns are actually represented, sequence order is correct, frame 0 is complete, the outer margin stays static, and the motion has a reading/state reason. Return implemented patterns, underlying primitives, loop, fps recommendation, and deliberate static areas.
+Capture a small contact sheet. Confirm selected Motion Patterns are represented, sequence order is correct, frame 0 is complete, the outer margin stays static, and motion has a reading/state reason. Return the animated artboard, implemented patterns, underlying primitives, loop, fps recommendation, and deliberate static areas to the parent workflow.

--- a/agents/palette-curator.md
+++ b/agents/palette-curator.md
@@ -3,6 +3,8 @@ name: palette-curator
 description: Selects or checks an Info-stories Story House when colour, brand fit, readability, or contrast is in question.
 tools: Read, Bash, Grep
 model: sonnet
+skills:
+  - info-stories
 ---
 
 You own colour-role decisions, not layout or copy.
@@ -17,4 +19,4 @@ Use `catalog.json` and `scripts/info_stories.py check`. Keep semantic roles stab
 
 ## Outputs
 
-Return the selected house, complete token block, contrast observations, any brand overrides that need a new named token, and a pass/fail verdict. Do not invent a freehand palette inside the artboard.
+Return the selected house, complete token block, contrast observations, any brand overrides that need a new named token, and a pass/fail verdict to the parent workflow. Do not invent a freehand palette inside the artboard.

--- a/agents/post-critic.md
+++ b/agents/post-critic.md
@@ -1,44 +1,34 @@
 ---
 name: post-critic
 description: >-
-  Red-teams a finished post before it ships: the caption's structure and claims, the still's
-  legibility in feed, and whether the motion actually points at the reading order. Use when a
-  post is built and about to go out, or when a post underperformed and you want a diagnosis.
+  Red-teams a finished post before it ships: caption structure and claims, still legibility in feed,
+  structural distinctness, and whether motion actually points at the reading order.
 tools: Read, Grep, Glob, WebSearch, WebFetch
 model: opus
+skills:
+  - info-stories
+  - caption
+  - render
 ---
 
-You are the last reader before the post goes public. Be specific and be direct. Vague praise
-is worse than useless here.
+You are the last adversarial reader before independent verification. Be specific and direct.
 
 ## Caption
 
-- Does line 1 survive the truncation cut and earn the click alone?
-- One archetype, or two blended into a pitch deck?
-- Is every number checkable? Verify anything you can with a search. A wrong figure is the one
-  thing commenters always find, and it costs the whole post.
-- Zero denial-then-reveal constructions in any language. Zero em dashes.
-- One CTA, at the end.
+Use the preloaded caption and Info-stories rules. Check the truncation cut, single archetype, factual support, one CTA, anti-slop findings, and banned constructions.
 
 ## Visual
 
-- At 350px feed width, what actually lands? Name the elements a scroller will read and the ones
-  that are texture.
-- Does frame 0 work as a still? Most impressions never see the motion.
-- Does the moving element point at the reading order, or does it compete with it?
-- Stripped of the caption on a repost, does the footer still identify the author?
+At 350px feed width, name what lands and what becomes texture. Check frame 0, attribution, the declared visual anchor, density, and whether the structural fingerprint represents a real layout choice rather than a palette-only reskin.
 
-## Fit
+## Motion
 
-- Does the visual carry what the caption promised, or is it decoration next to it?
-- Is the claim the post makes one this author can actually stand behind?
+Check whether motion serves reading order, state change, hierarchy, or route direction. Flag decorative competition, incomplete frame 0, or mascot motion that exceeds its communication role.
+
+## Fit and capability gates
+
+Use `skills/info-stories/references/anti-slop-gates.md` and `skills/info-stories/references/design-taste-gates.md`. Verify that the evidence-backed claims visible in the artifact match the approved claim table. Do not invent critique just to produce output.
 
 ## Return
 
-Three lists: **must fix before posting**, **would improve it**, and **leave alone**. Put the
-single highest-leverage change first and say what it buys. If the post is ready, say so
-plainly rather than inventing work.
-
-## Info-stories capability gates
-
-When the post used Info-stories, read `skills/info-stories/references/anti-slop-gates.md` and `skills/info-stories/references/design-taste-gates.md`. Name any copy-pattern finding and compare the rendered composition against its structural fingerprint. Do not call a colour-only variation a new visual style.
+Return three lists to the parent workflow: **must fix before posting**, **would improve it**, and **leave alone**. Put the single highest-leverage change first. If it is ready, say so plainly.

--- a/agents/post-critic.md
+++ b/agents/post-critic.md
@@ -2,7 +2,7 @@
 name: post-critic
 description: >-
   Red-teams a finished post before it ships: caption structure and claims, still legibility in feed,
-  structural distinctness, and whether motion actually points at the reading order.
+  structural distinctness, UI fidelity, mascot identity, and whether motion supports reading order.
 tools: Read, Grep, Glob, WebSearch, WebFetch
 model: opus
 skills:
@@ -21,13 +21,17 @@ Use the preloaded caption and Info-stories rules. Check the truncation cut, sing
 
 At 350px feed width, name what lands and what becomes texture. Check frame 0, attribution, the declared visual anchor, density, and whether the structural fingerprint represents a real layout choice rather than a palette-only reskin.
 
-## Motion
+For UI Storyboard or Interface Cutaway, read `skills/info-stories/references/ui-mockup-rules.md`. Flag unreadable core controls, invented real-product features, unlabeled fictional data that could be mistaken for proof, excessive chrome, or interactions that do not serve the narrative.
 
-Check whether motion serves reading order, state change, hierarchy, or route direction. Flag decorative competition, incomplete frame 0, or mascot motion that exceeds its communication role.
+## Motion and mascot
+
+Check whether motion serves reading order, state change, hierarchy, or route direction. Flag decorative competition, incomplete frame 0, or multiple competing pointers.
+
+When a named mascot is used, compare the animated component with the exact source SVG and identity notes. Any unexplained substitution, redrawing, altered marks/colours, or identity-changing deformation is a must-fix failure.
 
 ## Fit and capability gates
 
-Use `skills/info-stories/references/anti-slop-gates.md` and `skills/info-stories/references/design-taste-gates.md`. Verify that the evidence-backed claims visible in the artifact match the approved claim table. Do not invent critique just to produce output.
+Use `skills/info-stories/references/anti-slop-gates.md` and `skills/info-stories/references/design-taste-gates.md`. Verify that evidence-backed claims visible in the artifact match the approved claim table. Do not invent critique just to produce output.
 
 ## Return
 

--- a/agents/render-qa.md
+++ b/agents/render-qa.md
@@ -3,13 +3,14 @@ name: render-qa
 description: >-
   Renders a built artboard to GIF, runs every quality gate, and reports failures. Use
   proactively before delivering any post. Read-only with respect to the artboard: it diagnoses
-  and never edits, so the main thread keeps control of the fixes.
+  and never edits, so the parent workflow keeps control of fixes.
 tools: Read, Bash, Grep, Glob
 model: sonnet
+skills:
+  - render
 ---
 
-You render and you judge. You never edit the artboard. The render loop produces a lot of
-output and the point of running it here is that the noise stays out of the main conversation.
+You render and you judge. You never edit the artboard.
 
 ## Run
 
@@ -20,27 +21,20 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py <path> --mobile
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/render.sh <path> <out.gif> --duration <d> --fps <f>
 ```
 
-Then load `linkedin-animated-infographics:render` and walk `references/qa-gates.md` in full, including the
-mascot gates when a character is present.
+Use the preloaded `render` skill and walk `references/qa-gates.md` in full, including mascot gates when a character is present.
 
 ## Judge
 
-- **`motion:`** under 2% healthy, 2 to 5% acceptable only on a dark flat ground, over 5% means
-  something full-bleed is animating.
-- **Seam.** If the seam delta is no larger than the biggest normal frame-to-frame change, the
-  loop closes.
-- **Frame 0.** Open it. It must read as a complete infographic with no motion.
-- **Mobile.** Open the 350px downscale and say honestly what is unreadable.
-- **Size.** Under 5 MB, under 8 seconds.
+- `motion:` under 2% healthy, 2 to 5% acceptable only on a dark flat ground, over 5% means something full-bleed is animating.
+- Seam: if seam delta is no larger than the biggest normal frame-to-frame change, the loop closes.
+- Frame 0: open it. It must read as a complete infographic with no motion.
+- Mobile: open the 350px downscale and name what is unreadable.
+- Size: under 5 MB, under 8 seconds.
 
 ## Known false positive
 
-`check_render.py` flags animated groups inside `<defs>` as safe-zone violations, because a defs
-child reports a zero-size rect at the origin. Check whether the flagged element is a template
-before reporting it.
+`check_render.py` can flag animated groups inside `<defs>` as safe-zone violations because a defs child reports a zero-size rect at the origin. Check whether a flagged element is a template before reporting it.
 
 ## Return
 
-A gate-by-gate pass or fail list, each failure naming the specific element or line and the
-likely cause from the debugging table. End with one line: `SHIP` or
-`HOLD: <the one thing to fix first>`. Suggest fixes; do not apply them.
+Return a gate-by-gate pass or fail list to the parent workflow, each failure naming the specific element or line and likely cause. End with `SHIP` or `HOLD: <the one thing to fix first>`. Suggest fixes; do not apply them.

--- a/agents/story-architect.md
+++ b/agents/story-architect.md
@@ -3,6 +3,8 @@ name: story-architect
 description: Resolves an Info-stories brief before visual production begins.
 tools: Read, Bash, Grep
 model: opus
+skills:
+  - info-stories
 ---
 
 You choose the story contract. Do not build HTML.
@@ -13,7 +15,7 @@ Topic or source material, one takeaway, CTA, language, output mode, any explicit
 
 ## Method
 
-1. Load the `info-stories` skill and registry.
+1. Use the preloaded `info-stories` skill and registry.
 2. Resolve Story Archetype first, then Visual Style, Story House, then zero to two Motion Patterns.
 3. Preserve explicit choices unless the registry reports a hard incompatibility.
 4. Run `scripts/info_stories.py compose` and produce a deterministic scaffold.
@@ -23,4 +25,4 @@ Topic or source material, one takeaway, CTA, language, output mode, any explicit
 
 Return the story brief JSON path or JSON block, the four selected axes, the preferred existing artboard archetype, unresolved factual inputs, and any compatibility warnings.
 
-Handoff the approved brief to `layout-composer`, `palette-curator`, `copy-compressor`, and `motion-director` as needed. The final static spec goes to `artboard-builder`.
+Return the resolved brief to the parent workflow. The parent workflow decides which focused worker runs next and passes the brief as an explicit artifact.

--- a/agents/story-verifier.md
+++ b/agents/story-verifier.md
@@ -3,20 +3,23 @@ name: story-verifier
 description: Verifies a built Info-stories artifact against explicit acceptance criteria and direct evidence before delivery.
 tools: Read, Grep, Glob, Bash
 model: opus
+skills:
+  - info-stories
+  - render
 ---
 
-You are read-only. Do not edit the artifact and do not trust the worker's summary as evidence.
+You are read-only. Do not edit the artifact and do not trust a worker summary as evidence.
 
 ## Inputs
 
-Artifact paths, story brief, acceptance criteria, source claims, render outputs, and the current verification attempt number.
+Artifact paths, story brief, acceptance criteria, source claims, render outputs, post-critic findings, and the current verification attempt number.
 
 ## Method
 
-Read `skills/info-stories/references/verification-loop.md` plus the existing render QA gates. Inspect the artifact directly. For visual criteria, inspect rendered evidence rather than inferring from HTML. For motion criteria, use captured frames and render metrics. Record one evidence row per criterion.
+Use `skills/info-stories/references/verification-loop.md` plus the preloaded render QA gates. Inspect the artifact directly. For visual criteria, inspect rendered evidence rather than inferring from HTML. For motion criteria, use captured frames and render metrics. Record one evidence row per criterion. Confirm unresolved post-critic must-fix items are not being ignored.
 
 ## Outputs
 
-Return `PASS`, `FAIL:fixable`, or `FAIL:escalate`, the attempt number, criterion rows with artifact / observation / evidence, and only the targeted fix direction for failed criteria. Validate the report before returning it.
+Return `PASS`, `FAIL:fixable`, or `FAIL:escalate`, the attempt number, criterion rows with artifact / observation / evidence, and only the targeted fix direction for failed criteria to the parent workflow.
 
 After two targeted fix attempts, any remaining failure is `FAIL:escalate`. Never make the third fix yourself.

--- a/architecture/plugin-graph.json
+++ b/architecture/plugin-graph.json
@@ -49,6 +49,8 @@
     "design-taste": ["design-study", "layout-composer", "artboard-builder", "post-critic"],
     "structural-fingerprint": ["layout-composer", "artboard-builder", "post-critic"],
     "evidence": ["evidence-checker", "copy-compressor", "story-verifier"],
-    "verification-loop": ["render-qa", "post-critic", "story-verifier"]
+    "verification-loop": ["render-qa", "post-critic", "story-verifier"],
+    "mascot-identity": ["mascot-animator", "post-critic", "story-verifier"],
+    "ui-mockup-fidelity": ["evidence-checker", "layout-composer", "artboard-builder", "post-critic"]
   }
 }

--- a/architecture/plugin-graph.json
+++ b/architecture/plugin-graph.json
@@ -16,7 +16,16 @@
         "render-qa",
         "post-critic",
         "story-verifier"
-      ]
+      ],
+      "conditional": {
+        "mascot": {
+          "flag": "--mascot",
+          "asset_gate": "exact-svg",
+          "agent": "mascot-animator",
+          "after": "artboard-builder",
+          "before": "motion-engineer"
+        }
+      }
     }
   },
   "agents": {
@@ -26,6 +35,7 @@
     "design-study": {"required_skills": ["info-stories"]},
     "evidence-checker": {"required_skills": ["info-stories"]},
     "layout-composer": {"required_skills": ["info-stories", "artboard"]},
+    "mascot-animator": {"required_skills": ["svg-mascot-animator", "mascots"]},
     "motion-director": {"required_skills": ["info-stories", "motion"]},
     "motion-engineer": {"required_skills": ["motion", "info-stories"]},
     "palette-curator": {"required_skills": ["info-stories"]},

--- a/architecture/plugin-graph.json
+++ b/architecture/plugin-graph.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "workflows": {
+    "new-post": {
+      "sequence": [
+        "design-study",
+        "evidence-checker",
+        "story-architect",
+        "palette-curator",
+        "copy-compressor",
+        "layout-composer",
+        "caption-writer",
+        "artboard-builder",
+        "motion-director",
+        "motion-engineer",
+        "render-qa",
+        "post-critic",
+        "story-verifier"
+      ]
+    }
+  },
+  "agents": {
+    "artboard-builder": {"required_skills": ["artboard", "info-stories"]},
+    "caption-writer": {"required_skills": ["caption"]},
+    "copy-compressor": {"required_skills": ["info-stories", "caption"]},
+    "design-study": {"required_skills": ["info-stories"]},
+    "evidence-checker": {"required_skills": ["info-stories"]},
+    "layout-composer": {"required_skills": ["info-stories", "artboard"]},
+    "motion-director": {"required_skills": ["info-stories", "motion"]},
+    "motion-engineer": {"required_skills": ["motion", "info-stories"]},
+    "palette-curator": {"required_skills": ["info-stories"]},
+    "post-critic": {"required_skills": ["info-stories", "caption", "render"]},
+    "render-qa": {"required_skills": ["render"]},
+    "story-architect": {"required_skills": ["info-stories"]},
+    "story-verifier": {"required_skills": ["info-stories", "render"]}
+  },
+  "capabilities": {
+    "anti-slop": ["copy-compressor", "caption-writer", "post-critic"],
+    "design-taste": ["design-study", "layout-composer", "artboard-builder", "post-critic"],
+    "structural-fingerprint": ["layout-composer", "artboard-builder", "post-critic"],
+    "evidence": ["evidence-checker", "copy-compressor", "story-verifier"],
+    "verification-loop": ["render-qa", "post-critic", "story-verifier"]
+  }
+}

--- a/examples/info-stories/interface-cutaway-brief.json
+++ b/examples/info-stories/interface-cutaway-brief.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "topic": "Inside an agent review screen",
+  "takeaway": "The interface exposes the checks that produce the final decision",
+  "cta": "Use the structure",
+  "language": "en",
+  "output_mode": "gif",
+  "selection": {
+    "house": "ember-paper",
+    "style": "interface-cutaway",
+    "archetype": "inside-the-interface",
+    "motions": ["cursor-focus"]
+  },
+  "content_contract": {
+    "required_beats": ["hero-interface", "internal-zones", "why-it-matters"],
+    "density_range": [3, 7]
+  },
+  "execution": {
+    "artboard_archetype": "annotated-blueprint",
+    "structures": ["interface", "hero", "annotations", "cards", "states"],
+    "design_dials": {"design_variance": 8, "motion_intensity": 4, "visual_density": 7},
+    "house_tokens": {
+      "bg": "#FCF8F2",
+      "surface": "#FFFDFB",
+      "ink": "#1F2730",
+      "ink_2": "#46505B",
+      "muted": "#5C6570",
+      "line": "#D8CEC3",
+      "accent": "#C96E43",
+      "accent_deep": "#87401F",
+      "support_1": "#A7B8A8",
+      "support_2": "#DDB9C6"
+    },
+    "motion_limit": 2
+  }
+}

--- a/examples/info-stories/ui-storyboard-brief.json
+++ b/examples/info-stories/ui-storyboard-brief.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "topic": "From prompt to approved campaign screen",
+  "takeaway": "Each screen shows one decision in the workflow",
+  "cta": "Save the flow",
+  "language": "en",
+  "output_mode": "gif",
+  "selection": {
+    "house": "mist-board",
+    "style": "ui-storyboard",
+    "archetype": "screen-to-outcome",
+    "motions": ["cursor-focus", "state-transition"]
+  },
+  "content_contract": {
+    "required_beats": ["starting-screen", "interaction", "result"],
+    "density_range": [3, 7]
+  },
+  "execution": {
+    "artboard_archetype": "annotated-blueprint",
+    "structures": ["screens", "sequence", "cards", "annotations", "states"],
+    "design_dials": {"design_variance": 8, "motion_intensity": 5, "visual_density": 6},
+    "house_tokens": {
+      "bg": "#F4F7F8",
+      "surface": "#FFFFFF",
+      "ink": "#1E2933",
+      "ink_2": "#4A5965",
+      "muted": "#586772",
+      "line": "#D2DEE4",
+      "accent": "#638B9A",
+      "accent_deep": "#3E6676",
+      "support_1": "#C97D4F",
+      "support_2": "#AFCBC6"
+    },
+    "motion_limit": 2
+  }
+}

--- a/scripts/info_stories.py
+++ b/scripts/info_stories.py
@@ -8,13 +8,25 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CATALOG = ROOT / "skills" / "info-stories" / "catalog.json"
+DEFAULT_EXTENSIONS = ROOT / "skills" / "info-stories" / "extensions"
 AXIS_ALIASES = {"house": "houses", "style": "styles", "archetype": "archetypes", "motion": "motions"}
 HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
 SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 
-def load_catalog(path=DEFAULT_CATALOG):
-    return json.loads(Path(path).read_text())
+def load_catalog(path=DEFAULT_CATALOG, extensions_dir=None):
+    path = Path(path)
+    catalog = json.loads(path.read_text())
+    if extensions_dir is None and path.resolve() == DEFAULT_CATALOG.resolve():
+        extensions_dir = DEFAULT_EXTENSIONS
+    if extensions_dir:
+        extension_root = Path(extensions_dir)
+        if extension_root.exists():
+            for extension in sorted(extension_root.glob("*.json")):
+                payload = json.loads(extension.read_text())
+                for axis in ("houses", "styles", "archetypes", "motions"):
+                    catalog.setdefault(axis, []).extend(payload.get(axis, []))
+    return catalog
 
 
 def _linear(channel):
@@ -51,7 +63,8 @@ def validate_catalog(catalog):
                 errors.append(f"{axis}: duplicate slug {slug}")
             if name in names:
                 errors.append(f"{axis}: duplicate name {name}")
-            slugs.add(slug); names.add(name)
+            slugs.add(slug)
+            names.add(name)
     required_dials = {"design_variance", "motion_intensity", "visual_density"}
     for style in catalog.get("styles", []):
         dials = style.get("dials", {})
@@ -211,7 +224,7 @@ def validate_verification_report(report):
 
 def check_composition(catalog, style, archetype, motions):
     style_item = _find(catalog, "style", style)
-    archetype_item = _find(catalog, "archetype", archetype)
+    _find(catalog, "archetype", archetype)
     errors = []
     if archetype not in style_item.get("archetypes", []):
         errors.append(f"{style} is not compatible with {archetype}")

--- a/scripts/mascot_contract.py
+++ b/scripts/mascot_contract.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+
+_DIRECTIONS = [
+    {"slug":"guide-the-eye","purpose":"Use the mascot as the single reading pointer across ordered content.","communication_job":"reading sequence","allowed_parts":["whole body","eyes","one arm if addressable"],"loop_behavior":"return through an invisible or quiet reset","motion_budget":"one travelling mascot; replace any abstract pointer"},
+    {"slug":"curious-peek","purpose":"Let the mascot briefly inspect a card edge or panel before attention moves there.","communication_job":"focus cue","allowed_parts":["whole body","eyes","head if addressable"],"loop_behavior":"peek, settle, reset during a quiet beat","motion_budget":"small local motion around one panel"},
+    {"slug":"inspect-and-react","purpose":"Inspect one result, then give a restrained reaction tied to that state.","communication_job":"state confirmation","allowed_parts":["eyes","head","whole body scale"],"loop_behavior":"inspect, react once, return to neutral","motion_budget":"one reaction beat"},
+    {"slug":"carry-and-place","purpose":"Carry a small support object from input to destination to explain movement of information.","communication_job":"transfer","allowed_parts":["whole body","arms if addressable","support object"],"loop_behavior":"pickup, travel, place, quiet reset","motion_budget":"one support object plus mascot"},
+    {"slug":"reveal-assistant","purpose":"Use the mascot to uncover or point to one hidden annotation without hiding required frame-zero content.","communication_job":"hierarchy","allowed_parts":["whole body","one arm if addressable","support curtain/card"],"loop_behavior":"gesture, reveal emphasis, return","motion_budget":"local reveal only"},
+    {"slug":"status-confirmation","purpose":"Give a compact nod, bounce, or check reaction when a process reaches a valid state.","communication_job":"status change","allowed_parts":["whole body","head if addressable"],"loop_behavior":"single confirmation beat with long rest","motion_budget":"one small reaction"},
+    {"slug":"route-follow","purpose":"Follow an existing connector path so the character explains direction rather than decorating it.","communication_job":"route direction","allowed_parts":["whole body","contact shadow"],"loop_behavior":"travel route, reset off emphasis beat","motion_budget":"one route traveller"},
+    {"slug":"card-to-card-handoff","purpose":"Move attention from one card to the next using a brief handoff gesture or body shift.","communication_job":"reading handoff","allowed_parts":["whole body","arms if addressable","eyes"],"loop_behavior":"handoff across two or three stops, then reset","motion_budget":"one active handoff at a time"},
+    {"slug":"calm-idle-breathing","purpose":"Keep a mascot alive in a footer or quiet panel without competing with the story.","communication_job":"ambient presence","allowed_parts":["whole body scale","eyes"],"loop_behavior":"slow low-amplitude idle","motion_budget":"3px target, 4px hard cap"},
+    {"slug":"contextual-micro-reaction","purpose":"React to a nearby highlighted state with one context-specific micro motion.","communication_job":"local confirmation","allowed_parts":["eyes","head if addressable","whole body"],"loop_behavior":"short reaction followed by long neutral hold","motion_budget":"secondary motion only"}
+]
+
+
+def creative_directions():
+    return [dict(item) for item in _DIRECTIONS]
+
+
+def validate_mascot_request(request: dict) -> list[str]:
+    errors = []
+    requested_name = str(request.get("requested_name") or "").strip()
+    source = request.get("source")
+    svg_path = request.get("svg_path")
+    if request.get("allow_substitute"):
+        errors.append("Mascot substitution is not allowed for a requested official or named mascot.")
+    if requested_name and source not in {"user-supplied", "task-attached"}:
+        errors.append("The exact user-supplied SVG is required for a requested official or named mascot.")
+    if requested_name and not svg_path:
+        errors.append("The exact mascot SVG path is required before animation can begin.")
+    if svg_path:
+        path = Path(svg_path)
+        if path.suffix.lower() != ".svg":
+            errors.append("Mascot source must be an SVG file.")
+        elif source in {"user-supplied", "task-attached"} and not path.exists():
+            errors.append("The supplied mascot SVG path does not exist.")
+    return errors
+
+
+def main(argv=None):
+    import argparse
+    parser = argparse.ArgumentParser(description="Validate exact-SVG mascot requests or list creative directions")
+    sub = parser.add_subparsers(dest="command", required=True)
+    check = sub.add_parser("check")
+    check.add_argument("request", type=Path)
+    sub.add_parser("directions")
+    args = parser.parse_args(argv)
+    if args.command == "directions":
+        print(json.dumps(creative_directions(), indent=2))
+        return 0
+    request = json.loads(args.request.read_text())
+    errors = validate_mascot_request(request)
+    print(json.dumps({"ok": not errors, "errors": errors}, indent=2))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plugin_graph.py
+++ b/scripts/plugin_graph.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def parse_frontmatter(path: Path) -> dict:
+    text = path.read_text()
+    if not text.startswith("---\n"):
+        return {}
+    _, frontmatter, _ = text.split("---", 2)
+    data = {}
+    current_list = None
+    for raw in frontmatter.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if line.startswith("  - ") and current_list:
+            data[current_list].append(line[4:].strip())
+            continue
+        current_list = None
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key, value = key.strip(), value.strip()
+        if value:
+            data[key] = value.strip('"\'')
+        else:
+            data[key] = []
+            current_list = key
+    return data
+
+
+def load_component_graph(root: Path = ROOT) -> dict:
+    return json.loads((root / "architecture" / "plugin-graph.json").read_text())
+
+
+def validate_component_graph(root: Path = ROOT) -> list[str]:
+    errors = []
+    graph_path = root / "architecture" / "plugin-graph.json"
+    if not graph_path.exists():
+        return ["missing architecture/plugin-graph.json"]
+    graph = load_component_graph(root)
+    agent_dir = root / "agents"
+    skill_dir = root / "skills"
+    actual_agents = {p.stem for p in agent_dir.glob("*.md")}
+    graph_agents = set(graph.get("agents", {}))
+    if actual_agents != graph_agents:
+        missing = sorted(actual_agents - graph_agents)
+        extra = sorted(graph_agents - actual_agents)
+        if missing:
+            errors.append(f"agents missing from graph: {', '.join(missing)}")
+        if extra:
+            errors.append(f"graph references missing agents: {', '.join(extra)}")
+    actual_skills = {p.parent.name for p in skill_dir.glob("*/SKILL.md")}
+    for agent, contract in graph.get("agents", {}).items():
+        path = agent_dir / f"{agent}.md"
+        if not path.exists():
+            continue
+        frontmatter = parse_frontmatter(path)
+        declared = set(frontmatter.get("skills", []))
+        for skill in contract.get("required_skills", []):
+            if skill not in actual_skills:
+                errors.append(f"{agent} requires missing skill {skill}")
+            if skill not in declared:
+                errors.append(f"{agent} does not preload required skill {skill}")
+    sequence = graph.get("workflows", {}).get("new-post", {}).get("sequence", [])
+    for agent in sequence:
+        if agent not in graph_agents:
+            errors.append(f"new-post references unknown agent {agent}")
+    shipping = set(sequence)
+    for capability, owners in graph.get("capabilities", {}).items():
+        unknown = sorted(set(owners) - graph_agents)
+        if unknown:
+            errors.append(f"{capability} has unknown owners: {', '.join(unknown)}")
+        if not shipping.intersection(owners):
+            errors.append(f"{capability} has no owner on the shipping path")
+    return errors
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Validate plugin agent/skill/capability graph")
+    parser.add_argument("command", nargs="?", default="check", choices=("check",))
+    args = parser.parse_args(argv)
+    errors = validate_component_graph(ROOT)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Plugin graph: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plugin_graph.py
+++ b/scripts/plugin_graph.py
@@ -54,6 +54,7 @@ def validate_component_graph(root: Path = ROOT) -> list[str]:
             errors.append(f"agents missing from graph: {', '.join(missing)}")
         if extra:
             errors.append(f"graph references missing agents: {', '.join(extra)}")
+
     actual_skills = {p.parent.name for p in skill_dir.glob("*/SKILL.md")}
     for agent, contract in graph.get("agents", {}).items():
         path = agent_dir / f"{agent}.md"
@@ -66,11 +67,29 @@ def validate_component_graph(root: Path = ROOT) -> list[str]:
                 errors.append(f"{agent} requires missing skill {skill}")
             if skill not in declared:
                 errors.append(f"{agent} does not preload required skill {skill}")
-    sequence = graph.get("workflows", {}).get("new-post", {}).get("sequence", [])
+
+    workflow = graph.get("workflows", {}).get("new-post", {})
+    sequence = workflow.get("sequence", [])
     for agent in sequence:
         if agent not in graph_agents:
             errors.append(f"new-post references unknown agent {agent}")
-    shipping = set(sequence)
+
+    conditional_agents = set()
+    for name, edge in workflow.get("conditional", {}).items():
+        agent = edge.get("agent")
+        if not agent or agent not in graph_agents:
+            errors.append(f"conditional edge {name} references unknown agent {agent!r}")
+            continue
+        conditional_agents.add(agent)
+        after, before = edge.get("after"), edge.get("before")
+        if after not in sequence or before not in sequence:
+            errors.append(f"conditional edge {name} has invalid anchors {after!r}/{before!r}")
+        elif sequence.index(after) >= sequence.index(before):
+            errors.append(f"conditional edge {name} anchors are out of order")
+        if not edge.get("asset_gate"):
+            errors.append(f"conditional edge {name} is missing asset_gate")
+
+    shipping = set(sequence) | conditional_agents
     for capability, owners in graph.get("capabilities", {}).items():
         unknown = sorted(set(owners) - graph_agents)
         if unknown:
@@ -83,7 +102,7 @@ def validate_component_graph(root: Path = ROOT) -> list[str]:
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Validate plugin agent/skill/capability graph")
     parser.add_argument("command", nargs="?", default="check", choices=("check",))
-    args = parser.parse_args(argv)
+    parser.parse_args(argv)
     errors = validate_component_graph(ROOT)
     if errors:
         for error in errors:

--- a/scripts/validate_marketplace.py
+++ b/scripts/validate_marketplace.py
@@ -9,10 +9,16 @@ def _load_json(path: Path, errors: list[str]):
     try:
         return json.loads(path.read_text())
     except FileNotFoundError:
-        errors.append(f"missing {path.relative_to(path.parents[1]) if len(path.parents) > 1 else path}")
+        errors.append(f"missing {path}")
     except json.JSONDecodeError as exc:
         errors.append(f"invalid JSON in {path}: {exc}")
     return None
+
+
+def _require_frontmatter(paths, root: Path, errors: list[str]):
+    for path in paths:
+        if not path.read_text().startswith("---\n"):
+            errors.append(f"missing YAML frontmatter: {path.relative_to(root)}")
 
 
 def validate_marketplace(root: Path = ROOT) -> list[str]:
@@ -51,10 +57,10 @@ def validate_marketplace(root: Path = ROOT) -> list[str]:
     hooks = _load_json(root / "hooks" / "hooks.json", errors)
     if hooks is not None and "hooks" not in hooks:
         errors.append("hooks/hooks.json is missing top-level hooks")
-    for directory in (root / "skills", root / "agents"):
-        for path in directory.rglob("*.md"):
-            if not path.read_text().startswith("---\n"):
-                errors.append(f"missing YAML frontmatter: {path.relative_to(root)}")
+
+    # Claude component entrypoints require frontmatter. Supporting references do not.
+    _require_frontmatter((root / "skills").glob("*/SKILL.md"), root, errors)
+    _require_frontmatter((root / "agents").glob("*.md"), root, errors)
     return errors
 
 

--- a/scripts/validate_marketplace.py
+++ b/scripts/validate_marketplace.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_json(path: Path, errors: list[str]):
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        errors.append(f"missing {path.relative_to(path.parents[1]) if len(path.parents) > 1 else path}")
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid JSON in {path}: {exc}")
+    return None
+
+
+def validate_marketplace(root: Path = ROOT) -> list[str]:
+    errors = []
+    market_path = root / ".claude-plugin" / "marketplace.json"
+    plugin_path = root / ".claude-plugin" / "plugin.json"
+    market = _load_json(market_path, errors)
+    plugin = _load_json(plugin_path, errors)
+    if not market or not plugin:
+        return errors
+
+    if market.get("name") != "mamdouh-creative-tools":
+        errors.append("unexpected marketplace name")
+    owner = market.get("owner") or {}
+    if not owner.get("name"):
+        errors.append("marketplace owner.name is required")
+    entries = market.get("plugins")
+    if not isinstance(entries, list) or len(entries) != 1:
+        errors.append("marketplace must expose exactly one root plugin")
+        return errors
+    entry = entries[0]
+    if entry.get("name") != plugin.get("name"):
+        errors.append("marketplace plugin name does not match plugin.json")
+    if entry.get("source") != "./":
+        errors.append("root plugin source must be ./")
+    if entry.get("strict") is not True:
+        errors.append("root plugin must use strict mode")
+    if entry.get("version") != plugin.get("version"):
+        errors.append("marketplace plugin version does not match plugin.json")
+    if plugin.get("version") != "2.2.0":
+        errors.append("plugin release version must be 2.2.0")
+
+    for relative in ("skills", "agents", "hooks/hooks.json"):
+        if not (root / relative).exists():
+            errors.append(f"missing standard plugin component {relative}")
+    hooks = _load_json(root / "hooks" / "hooks.json", errors)
+    if hooks is not None and "hooks" not in hooks:
+        errors.append("hooks/hooks.json is missing top-level hooks")
+    for directory in (root / "skills", root / "agents"):
+        for path in directory.rglob("*.md"):
+            if not path.read_text().startswith("---\n"):
+                errors.append(f"missing YAML frontmatter: {path.relative_to(root)}")
+    return errors
+
+
+def main():
+    errors = validate_marketplace(ROOT)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Claude marketplace: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/info-stories/SKILL.md
+++ b/skills/info-stories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: info-stories
-description: Use when turning source material, a topic, a screenshot, or an approved caption into a structured LinkedIn infographic story and choosing its palette, visual grammar, narrative shape, or motion direction.
+description: Use when turning source material, a topic, a screenshot, an interface, or an approved caption into a structured LinkedIn infographic story and choosing its palette, visual grammar, narrative shape, or motion direction.
 ---
 
 # Info-stories
@@ -9,7 +9,9 @@ Info-stories resolves four independent choices before HTML is built: **Story Hou
 
 ## Use the registry
 
-`catalog.json` is the machine-readable source of truth. Validate it before a build:
+`catalog.json` contains the stable base registry. Optional first-party families live in `extensions/*.json`. `scripts/info_stories.py` merges them deterministically by extension filename and exposes one catalog to every agent and tool.
+
+Validate the merged registry before a build:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/info_stories.py check
@@ -23,9 +25,15 @@ Inspect options with `list` and `show`. Use `scaffold` to emit a deterministic s
 2. Visual Style from information topology and density. Read `references/visual-styles.md`.
 3. Story House from tone, brand constraints, and contrast. Read `references/palette-houses.md`.
 4. Motion Patterns from what motion must communicate. Read `references/motion-patterns.md`.
-5. Check the combination against `references/composition-matrix.md` and the registry.
+5. Check the combination against `references/composition-matrix.md` and the merged registry.
 
-Explicit user choices win unless they violate a hard contrast, compatibility, or render constraint. Unknown choices fail with valid alternatives instead of silently substituting a default.
+Explicit user choices win unless they violate a hard contrast, compatibility, evidence, or render constraint. Unknown choices fail with valid alternatives instead of silently substituting a default.
+
+## UI Mockup Stories
+
+UI mockups are first-class story surfaces. Use `UI Storyboard` for a sequence of two to four screens/states and `Interface Cutaway` for one dominant interface with annotated internal regions. The dedicated archetypes are `Screen to Outcome`, `Inside the Interface`, and `State Change Story`.
+
+Read `references/ui-mockup-rules.md`. A UI mockup may simplify a documented product flow or use clearly fictional concept data, but it must not invent real product claims, features, metrics, integrations, or customer proof. Core controls and labels must remain readable at feed width. `Cursor Focus` and `State Transition` are the dedicated restrained motion patterns.
 
 ## Reference study
 
@@ -43,7 +51,8 @@ The parent workflow coordinates focused workers and passes artifacts between the
 - `caption-writer` owns caption archetype and caption-specific copy rules.
 - `artboard-builder` owns static execution of the approved layout.
 - `motion-director` owns motion intent and pattern selection.
-- `motion-engineer` owns seekable animation implementation.
+- `mascot-animator` owns exact-SVG mascot inspection, identity preservation, and the approved mascot motion component when the mascot path is active.
+- `motion-engineer` owns final seekable animation integration.
 - `render-qa` owns deterministic render evidence.
 - `post-critic` owns adversarial copy, visual, motion, and fingerprint review.
 - `story-verifier` owns evidence-backed final acceptance and the bounded repair loop.
@@ -58,6 +67,7 @@ The executable graph is tracked in `architecture/plugin-graph.json` and checked 
 - Frame 0 remains a complete still.
 - Never invent metrics, testimonials, proof, product facts, or source claims.
 - A palette swap is not a new visual style. Structural choices must change when the story needs a different visual grammar.
+- A named official mascot uses the exact user-supplied SVG. Missing SVG means hold the mascot path, not substitute an asset.
 
 ## Independent verification
 

--- a/skills/info-stories/SKILL.md
+++ b/skills/info-stories/SKILL.md
@@ -5,7 +5,7 @@ description: Use when turning source material, a topic, a screenshot, or an appr
 
 # Info-stories
 
-Info-stories resolves four independent choices before any HTML is built: **Story House**, **Visual Style**, **Story Archetype**, and **Motion Pattern**. It is an orchestration layer over the existing artboard, motion, render, mascot, Arabic, and QA skills.
+Info-stories resolves four independent choices before HTML is built: **Story House**, **Visual Style**, **Story Archetype**, and **Motion Pattern**. It is a composition layer over the existing artboard, motion, render, mascot, Arabic, and QA skills.
 
 ## Use the registry
 
@@ -19,21 +19,36 @@ Inspect options with `list` and `show`. Use `scaffold` to emit a deterministic s
 
 ## Resolution order
 
-1. **Story Archetype** from the content's narrative job. Read `references/story-archetypes.md`.
-2. **Visual Style** from information topology and density. Read `references/visual-styles.md`.
-3. **Story House** from tone, brand constraints, and contrast. Read `references/palette-houses.md`.
-4. **Motion Patterns** from what motion must communicate. Read `references/motion-patterns.md`.
+1. Story Archetype from the content's narrative job. Read `references/story-archetypes.md`.
+2. Visual Style from information topology and density. Read `references/visual-styles.md`.
+3. Story House from tone, brand constraints, and contrast. Read `references/palette-houses.md`.
+4. Motion Patterns from what motion must communicate. Read `references/motion-patterns.md`.
 5. Check the combination against `references/composition-matrix.md` and the registry.
 
 Explicit user choices win unless they violate a hard contrast, compatibility, or render constraint. Unknown choices fail with valid alternatives instead of silently substituting a default.
 
 ## Reference study
 
-When the direction comes from screenshots, GIFs, previous designs, or a public reference, use `design-study` and read `references/study-protocol.md` before selecting the four axes. A study diagnoses design DNA; it does not grant permission to copy source wording or distinctive assets.
+When the direction comes from screenshots, GIFs, previous designs, or a public reference, `design-study` owns design-DNA diagnosis using `references/study-protocol.md`. The diagnosis maps reusable principles into local choices and never grants permission to copy source wording or distinctive assets.
 
-## Agent handoff
+## Capability ownership
 
-Use `story-architect` for the four-axis brief. It may delegate palette, layout, motion, copy compression, and evidence checks to their focused agents. Once the brief is approved, hand the static composition to `artboard-builder`, then hand approved motion direction to `motion-engineer`. Existing render and QA skills stay authoritative for capture, GIF assembly, mobile checks, seam checks, and file budgets.
+The parent workflow coordinates focused workers and passes artifacts between them. Workers do not assume hidden peer delegation.
+
+- `evidence-checker` owns claim provenance and blocked proof slots.
+- `story-architect` owns the four-axis story contract.
+- `palette-curator` owns Story House tokens and contrast verdicts.
+- `copy-compressor` owns slot-sized visible copy and anti-slop compression.
+- `layout-composer` owns information topology, design-taste gates, and structural fingerprints.
+- `caption-writer` owns caption archetype and caption-specific copy rules.
+- `artboard-builder` owns static execution of the approved layout.
+- `motion-director` owns motion intent and pattern selection.
+- `motion-engineer` owns seekable animation implementation.
+- `render-qa` owns deterministic render evidence.
+- `post-critic` owns adversarial copy, visual, motion, and fingerprint review.
+- `story-verifier` owns evidence-backed final acceptance and the bounded repair loop.
+
+The executable graph is tracked in `architecture/plugin-graph.json` and checked by `scripts/plugin_graph.py`.
 
 ## Hard constraints
 
@@ -46,4 +61,4 @@ Use `story-architect` for the four-axis brief. It may delegate palette, layout, 
 
 ## Independent verification
 
-Before delivery of a built Info-story, use `story-verifier` and `references/verification-loop.md`. The verifier reads artifacts directly, records evidence against stable criteria, and permits at most two targeted fix attempts before escalation.
+Before delivery, `story-verifier` uses `references/verification-loop.md`, reads artifacts directly, records evidence against stable criteria, and permits at most two targeted fix attempts before escalation.

--- a/skills/info-stories/extensions/ui-mockups.json
+++ b/skills/info-stories/extensions/ui-mockups.json
@@ -1,0 +1,54 @@
+{
+  "styles": [
+    {
+      "slug": "ui-storyboard",
+      "name": "UI Storyboard",
+      "archetypes": ["screen-to-outcome", "state-change-story", "before-after-workflow"],
+      "preferred_artboard": "annotated-blueprint",
+      "structures": ["screens", "sequence", "cards", "annotations", "states"],
+      "dials": {"design_variance": 8, "motion_intensity": 5, "visual_density": 6}
+    },
+    {
+      "slug": "interface-cutaway",
+      "name": "Interface Cutaway",
+      "archetypes": ["inside-the-interface", "state-change-story", "working-screen"],
+      "preferred_artboard": "annotated-blueprint",
+      "structures": ["interface", "hero", "annotations", "cards", "states"],
+      "dials": {"design_variance": 8, "motion_intensity": 4, "visual_density": 7}
+    }
+  ],
+  "archetypes": [
+    {
+      "slug": "screen-to-outcome",
+      "name": "Screen to Outcome",
+      "required_beats": ["starting-screen", "interaction", "result"],
+      "density_range": [3, 7]
+    },
+    {
+      "slug": "inside-the-interface",
+      "name": "Inside the Interface",
+      "required_beats": ["hero-interface", "internal-zones", "why-it-matters"],
+      "density_range": [3, 7]
+    },
+    {
+      "slug": "state-change-story",
+      "name": "State Change Story",
+      "required_beats": ["before-state", "trigger", "after-state"],
+      "density_range": [3, 6]
+    }
+  ],
+  "motions": [
+    {
+      "slug": "cursor-focus",
+      "name": "Cursor Focus",
+      "structures": ["screens", "interface", "cards", "annotations"],
+      "roles": ["secondary"]
+    },
+    {
+      "slug": "state-transition",
+      "name": "State Transition",
+      "structures": ["screens", "interface", "states", "sequence"],
+      "roles": ["primary"]
+    }
+  ]
+}

--- a/skills/info-stories/references/composition-matrix.md
+++ b/skills/info-stories/references/composition-matrix.md
@@ -1,6 +1,6 @@
 # Composition Matrix
 
-The registry is authoritative. This page is the human scan layer.
+The merged base registry plus `extensions/*.json` is authoritative. This page is the human scan layer.
 
 | Visual Style | Allowed Story Archetypes | Preferred artboard |
 |---|---|---|
@@ -14,9 +14,17 @@ The registry is authoritative. This page is the human scan layer.
 | Tool Catalog | Inside the Stack; Ecosystem Snapshot; Framework in One Page | logo-grid |
 | Story Strip | One Prompt, Full Workflow; From Raw Input to Final Output; Before / After Workflow | pipeline-stages |
 | Field Guide | Framework in One Page; Decision Cards; What Each Piece Actually Does | cheat-sheet-poster |
+| UI Storyboard | Screen to Outcome; State Change Story; Before / After Workflow | annotated-blueprint |
+| Interface Cutaway | Inside the Interface; State Change Story; The Working Screen | annotated-blueprint |
+
+## UI mockup rules
+
+For UI Storyboard and Interface Cutaway, read `ui-mockup-rules.md`. Product fidelity and evidence rules remain active even when the interface is illustrative.
 
 ## Motion compatibility
 
 A motion is compatible when at least one of its structural signals intersects the selected Visual Style. Use no more than two. A primary-only motion must not compete with another primary-only motion.
+
+`Cursor Focus` is secondary and points to one UI region or control. `State Transition` is primary and shows one meaningful interface state change.
 
 Run `python3 scripts/info_stories.py compose --style <slug> --archetype <slug> --motion <slug>` before handoff.

--- a/skills/info-stories/references/motion-patterns.md
+++ b/skills/info-stories/references/motion-patterns.md
@@ -81,3 +81,23 @@ Slug: `float-micro-motion`
 Works with structural signals: hero, gallery, tiles.
 
 Allowed role: secondary.
+
+## Cursor Focus
+
+Slug: `cursor-focus`
+
+Works with structural signals: screens, interface, cards, annotations.
+
+Allowed role: secondary.
+
+Use a short cursor move, focus ring, or selection cue to identify the control or region that matters. The cursor does not wander continuously.
+
+## State Transition
+
+Slug: `state-transition`
+
+Works with structural signals: screens, interface, states, sequence.
+
+Allowed role: primary.
+
+Show one meaningful UI state change such as empty to populated, idle to active, validation failure to correction, or action to result. Frame 0 remains a complete state.

--- a/skills/info-stories/references/story-archetypes.md
+++ b/skills/info-stories/references/story-archetypes.md
@@ -97,3 +97,33 @@ Slug: `framework-in-one-page`
 Required beats: principle -> parts -> action.
 
 Recommended density: 5-10 content units.
+
+## Screen to Outcome
+
+Slug: `screen-to-outcome`
+
+Required beats: starting-screen -> interaction -> result.
+
+Recommended density: 3-7 content units.
+
+Use when the interface itself explains how an action becomes a visible outcome.
+
+## Inside the Interface
+
+Slug: `inside-the-interface`
+
+Required beats: hero-interface -> internal-zones -> why-it-matters.
+
+Recommended density: 3-7 content units.
+
+Use when one screen contains the important architecture and the story is about how its regions work together.
+
+## State Change Story
+
+Slug: `state-change-story`
+
+Required beats: before-state -> trigger -> after-state.
+
+Recommended density: 3-6 content units.
+
+Use when the key insight is the transition between two product or workflow states rather than a long process.

--- a/skills/info-stories/references/ui-mockup-rules.md
+++ b/skills/info-stories/references/ui-mockup-rules.md
@@ -1,0 +1,49 @@
+# UI Mockup Story Rules
+
+UI mockups are story surfaces inside the infographic. They are not filler screenshots and they are not evidence by themselves.
+
+## What a mockup may represent
+
+- a user-supplied real product screen
+- a faithful simplified diagram of a documented flow
+- a clearly fictional concept interface used to explain an interaction pattern
+- a state comparison such as empty, active, success, error, or completed
+
+## Evidence boundary
+
+Never invent an unsupported product claim, metric, customer result, feature, integration, logo, or workflow and present it as real UI. If a mockup uses fictional data that a reader could mistake for real evidence, label it as sample, concept, demo, or illustrative data in the visible composition or supporting caption.
+
+User-supplied screenshots remain reference inputs. Rebuild only the parts needed for the story unless the user explicitly asks for a faithful product mockup and provides the necessary source material.
+
+## Feed-width legibility
+
+Judge the mockup at LinkedIn feed width, not only at 1080px. Core labels, values, controls, state names, and annotations must still read around a 350px downscale. Remove nonessential chrome before shrinking important content.
+
+A UI panel should have one visual anchor. Avoid complete application dashboards when only one state or interaction matters.
+
+## Structural grammar
+
+**UI Storyboard** uses two to four screens or screen states in a reading sequence. Each screen has one job. Connectors or labels explain what changed between them.
+
+**Interface Cutaway** uses one dominant interface with a small number of annotated internal zones. It explains what happens inside the screen rather than showing many separate screens.
+
+## Motion
+
+Frame 0 is a complete infographic. Motion may add:
+
+- cursor focus or a short pointer move
+- focused/selected state
+- one row or card activation
+- restrained state transition
+- route indication between UI regions
+- small success/error confirmation
+
+Do not animate constant scrolling, large fake typing sessions, every control, or multiple competing cursors. Motion communicates one reading or state change at a time.
+
+## Real and fictional UI
+
+When the visual depicts an existing product, keep documented names, states, controls, and claims faithful to available evidence. When it is a fictional interface, do not use a real brand identity in a way that implies the product actually has that UI or feature.
+
+## Accessibility and composition
+
+Use semantic HTML/CSS/SVG where possible. Keep text contrast at the selected Story House floor. Do not rely on colour alone for state meaning. The normal Info-stories attribution/footer contract remains mandatory.

--- a/skills/info-stories/references/visual-styles.md
+++ b/skills/info-stories/references/visual-styles.md
@@ -121,3 +121,31 @@ Structural vocabulary: reference, rules, cards.
 Design dials: variance 4/10, motion 2/10, density 9/10.
 
 Best with: framework-in-one-page, decision-cards, what-each-piece-does.
+
+## UI Storyboard
+
+Slug: `ui-storyboard`
+
+Preferred artboard: **annotated-blueprint**
+
+Structural vocabulary: screens, sequence, cards, annotations, states.
+
+Design dials: variance 8/10, motion 5/10, density 6/10.
+
+Best with: screen-to-outcome, state-change-story, before-after-workflow.
+
+Use two to four interface states where each state has one narrative job. Read `ui-mockup-rules.md` before building.
+
+## Interface Cutaway
+
+Slug: `interface-cutaway`
+
+Preferred artboard: **annotated-blueprint**
+
+Structural vocabulary: interface, hero, annotations, cards, states.
+
+Design dials: variance 8/10, motion 4/10, density 7/10.
+
+Best with: inside-the-interface, state-change-story, working-screen.
+
+Use one dominant interface as the visual anchor and annotate only the internal zones required to understand the story.

--- a/skills/mascots/SKILL.md
+++ b/skills/mascots/SKILL.md
@@ -1,75 +1,84 @@
 ---
 name: mascots
 description: >-
-  Put an animated character on an infographic without breaking the reading order. Use when
-  adding a mascot, character, or logo animation to a LinkedIn visual, when a mascot should walk
-  a route or react to an outcome, when idle characters should breathe or blink in a panel, or
-  when a mascot renders static, blank, or out of sync with the highlight. Covers the three
-  mascot roles, the seek-safe rig, the bake_mascot.py generator, the loop seam, motion
-  budgeting, and which archetypes accept a character at all.
+  Use when an infographic contains a mascot or character, especially when the user names an
+  official mascot, supplies an SVG, wants a mascot to guide reading order, or needs character
+  motion that stays inside the infographic motion budget.
 ---
 
-# Mascots
+# Mascots for Infographics
 
-A mascot is the loudest moving object anyone can put on a page. Dropped in casually it stops
-being decoration and starts competing with the reading pointer.
+A mascot is a communication element, not filler. It must have one clear job in the story and it must preserve the identity of the user's asset.
 
-So the mascot is not added *next to* the pointer. **Where a mascot exists, the mascot becomes
-the reading pointer**, and the abstract particle is deleted.
+## Hard gate: exact official mascot
 
-## Three roles, and the counts are not stylistic
+When the user names a specific official mascot or says to use a mascot exactly:
 
-| Role | Count | Amplitude | Job |
-|---|---|---|---|
-| **Pointer** | exactly 1 | travels the route | cards light as it lands |
-| **Payoff** | 0 or 1 | one spring, ~20px | reacts at the last stop |
-| **Idle** | 0 to 6 | 3px, hard cap 4px | ambient life in a panel or footer |
+1. Require the exact SVG from the user unless it is already attached to the current task.
+2. Treat that SVG as the identity source.
+3. Never redraw, approximate, substitute, generate a lookalike, or silently use a different mascot.
+4. Preserve recognizable silhouette, colours, marks, face details, and proportions.
+5. If the SVG structure cannot support the requested articulation, explain the rig limitation and propose safe motion that still uses the original asset.
 
-Two pointers means two reading orders, which means no reading order at all.
+The parent workflow owns this intake gate because the focused mascot worker should receive a validated asset, not ask the user for one itself.
 
-## Generate the motion, do not write it
+Validate the request before planning motion:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mascot_contract.py check build/mascot-request.json
+```
+
+## Roles
+
+| Role | Count | Motion budget | Job |
+|---|---:|---:|---|
+| Pointer | exactly 1 | route travel | carries reading order |
+| Payoff | 0 or 1 | one short reaction | confirms the final state |
+| Idle | 0 to 6 | 3px target, 4px cap | quiet presence in a panel/footer |
+
+A mascot pointer replaces an abstract pointer. Do not create two simultaneous reading orders.
+
+## Creative direction
+
+Read `skills/svg-mascot-animator/references/creative-directions.md`. Good starting directions include Guide the Eye, Curious Peek, Inspect and React, Carry and Place, Reveal Assistant, Status Confirmation, Route Follow, Card-to-Card Handoff, Calm Idle Breathing, and Contextual Micro-Reaction.
+
+A direction is valid only when it states:
+
+- what the motion communicates
+- which existing mascot parts may move
+- which support elements may be added outside the mascot
+- how the loop resets
+- what competing primitive it replaces
+
+## Seek-safe infographic motion
+
+Use one artboard clock. Frame 0 stays complete. Motion in the outer 48px margin is prohibited. Use baked CSS/SMIL/seekable motion for deterministic frame capture. Do not use runtime `requestAnimationFrame` animation in a rendered LinkedIn GIF.
+
+Generate physics/timing rather than nudging arbitrary keyframes:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py budget --mascot 64 --travel 1 --idles 4
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py hop    --loop 6000 --id mf  --stops 5 --apex 40 --dwell .11
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py idle   --loop 6000 --id amb --n 2 --amp 3 --blink
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py hop --loop 6000 --id mf --stops 5 --apex 40 --dwell .11
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py idle --loop 6000 --id amb --n 2 --amp 3 --blink
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py payoff --loop 6000 --id win --at .89 --rise 18 --zeta .30
 ```
 
-Run `budget` first. It costs nothing and it is the difference between finding out the mascot is
-too big now or after a five-minute render.
+Never hand-edit baked timing output. Change the parameters and regenerate.
 
-`hop` prints the `keyTimes`/`keyPoints` pair, the landing squash, the phased contact shadow, the
-seam fade, **the arrival instants already converted to the reversed negative delays the cards
-need**, and the implied gravity. Read the gravity line: below 500 the mascot floats, above 2000
-it snaps. Fix it by changing `--apex` or `--dwell`, never by nudging keyframes.
+## Structural fit
 
-Never hand-edit the baked output. Change the arguments and re-run.
+Mascots work best in route, process, annotated, and state-change stories. Dense catalogs and reference sheets usually need no moving character. UI Mockup Stories may use a mascot as a guide, assistant, or state reaction only if it does not cover core controls or imitate a product assistant that does not actually exist.
 
-## What breaks it
+## Verification
 
-- **Anime.js runtime motion.** `requestAnimationFrame` is not seekable. The render comes back
-  static or blank. Use the baked static track only.
-- **A mascot clock that is not the artboard clock.** Everything inherits `var(--loop)` or an
-  integer division of it.
-- **The seam on frame 0.** Frame 0 is LinkedIn's poster frame and must be a complete
-  infographic. Shift every mascot track by `calc(var(--loop) * -0.5)` and the
-  `<animateMotion>` by `begin="-3s"` so the fade that hides the loop teleport happens mid-cycle.
-- **A missing `rotate="0"`.** `animateMotion` banks to the path tangent by default, so the
-  mascot arrives at each stop tilted.
+Before shipment confirm:
 
-## Not every archetype takes one
+- the exact supplied SVG remains recognizably unchanged
+- the role is singular and clear
+- the selected creative direction has a story purpose
+- frame 0 is complete
+- the motion budget is respected
+- the mascot does not compete with UI, copy, or route highlights
+- reduced-motion and accessibility requirements from the SVG animator contract are satisfied
 
-Native: Character Flowchart, Pipeline Stages, Annotated Blueprint.
-Idles only: Trading Card Grid, Node Tree, Directory Map.
-None: Specimen Grid, Cheat Sheet Poster, Terminal Card, Logo Grid, Spec Sheet.
-
-Full doctrine, the rig, the budget table, and the failure modes:
-`references/mascots.md`. Reference build: `${CLAUDE_PLUGIN_ROOT}/assets/template-mascot-flow.html`.
-
-## Physics comes from the sibling plugin
-
-The timing equations live in `${CLAUDE_PLUGIN_ROOT}/scripts/physics.py`, vendored from the
-`svg-mascot-animator` plugin. Plugins are copied to a cache directory on install, so a
-cross-plugin relative path would not resolve. Install that plugin too when you need the full
-runtime track, Anime.js, or the README asset contract.
+Full infographic mascot doctrine and failure modes remain in `references/mascots.md`.

--- a/skills/new-post/SKILL.md
+++ b/skills/new-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-post
-description: Run the full post pipeline end to end, from topic to a delivered GIF plus caption plus first comment.
+description: Run the full post pipeline end to end, from topic to a delivered GIF or static infographic plus caption and first comment.
 disable-model-invocation: true
 argument-hint: "[topic or URL] [optional: --arabic] [optional: --mascot]"
 ---
@@ -9,58 +9,75 @@ argument-hint: "[topic or URL] [optional: --arabic] [optional: --mascot]"
 
 Topic: **$ARGUMENTS**
 
-Run the pipeline. Do not skip approval gates.
+The parent workflow owns orchestration. Workers return artifacts to this workflow; do not ask one worker to coordinate its peers.
 
-## 1. Intake
+## 1. Reference diagnosis
 
-Ask only two things in one message: **what is the one takeaway**, and **what is the CTA**. Infer everything else from the topic or supplied source. If the source contains facts or numbers, mark them for `evidence-checker` before compression.
+If the user supplied screenshots, GIFs, previous designs, or visual references, delegate to `design-study` and save the structured result as `build/design-study.json`. If there is no visual reference, record that this stage is not applicable and continue.
 
-## 2. Resolve the Info-stories brief
+## 2. Evidence inventory
 
-Delegate to `story-architect`. It loads `linkedin-animated-infographics:info-stories` and resolves:
+Delegate to `evidence-checker` with the source material and all claims, numbers, product names, proof slots, and logos likely to appear. Save `build/evidence.json`. Unsupported proof is blocked before copy or layout work begins. A source with no external factual claims still gets a short evidence record saying so.
 
-- Story Archetype
-- Visual Style
-- Story House
-- zero to two Motion Patterns
-- the Visual Style design dials
+## 3. Story contract
 
-If references or previous designs were supplied, run `design-study` first and pass the accepted design DNA into `story-architect`.
+Delegate to `story-architect` with the topic, one takeaway, CTA, language, output mode, `build/design-study.json` when present, and `build/evidence.json`. Save the deterministic result as `build/story-brief.json`.
 
-Save the resolved scaffold as `build/story-brief.json`. State the four choices and the caption archetype with one short reason each. If `--mascot` was passed, state the mascot role too. Wait for a yes or redirect before writing the caption.
+State the four Info-stories choices and one reason per choice. If the user explicitly chose an axis, preserve it unless a hard compatibility or contrast rule fails.
 
-## 3. Caption and compressed artboard copy
+## 4. Palette contract
 
-Delegate caption writing to `caption-writer`. Use `copy-compressor` for artboard slots when the source is too dense, and `evidence-checker` for any claim that will appear visually. Load `linkedin-animated-infographics:caption` only if writing inline.
+Delegate to `palette-curator` with `build/story-brief.json` and any brand colours. Save the complete verified token block and contrast result as `build/palette-check.json`. A failing text or state pair holds the build.
 
-Show the caption. Get a yes before building anything.
+## 5. Artboard copy
 
-## 4. Still
+Delegate to `copy-compressor` with the source, evidence record, Story Archetype, and target story beats. Save slot-keyed copy and protected facts as `build/artboard-copy.json`. Keep intentional short labels; remove generic filler and unsupported claims.
 
-Delegate to `artboard-builder` with the approved caption, compressed artboard copy, and `build/story-brief.json`. The story brief owns the Story House tokens, Visual Style, and preferred existing artboard archetype. The builder returns `build/post.html` and `build/still.png` already passing `check_render.py`.
+## 6. Static layout specification
 
-Show the still. **This is the approval gate.** Get a yes before motion.
+Delegate to `layout-composer` with the story brief, palette check, artboard copy, and optional design study. Save `build/layout-spec.json`, including zone order, visual anchor, hierarchy, structural fingerprint, and asset requirements.
 
-## 5. Motion
+## 7. Caption
 
-Delegate to `motion-engineer` with `build/story-brief.json`. It implements the resolved Motion Patterns using the existing seekable primitives. If output mode is static, skip this step. If a mascot is in play, the mascot pointer replaces any competing pointer primitive rather than becoming a third motion.
+Delegate to `caption-writer` with the approved facts, one takeaway, CTA, and narrative context. Save the caption as `build/caption.md` and first-comment text as `build/first-comment.md`.
 
-## 6. Render and independent QA
+Show the caption and the resolved story direction. Get approval before building the still.
 
-Delegate render mechanics to `render-qa`. Fix render failures and re-run until the existing QA gates pass.
+## 8. Still construction
 
-Then delegate final acceptance to `story-verifier`. It reads the artifact directly and uses `skills/info-stories/references/verification-loop.md`. A `FAIL:fixable` may trigger a targeted fix and re-check. Maximum two targeted fix attempts. A third unresolved failure escalates instead of looping.
+Delegate to `artboard-builder` with `build/story-brief.json`, `build/palette-check.json`, `build/artboard-copy.json`, `build/layout-spec.json`, and the approved caption. It returns `build/post.html` and `build/still.png` after static checks.
 
-## 7. Deliver
+Show the still. This is the visual approval gate. Get approval before motion.
 
-Present, in this order:
+## 9. Motion direction
 
-1. the GIF or static artifact
-2. the caption in a copyable block
-3. the first-comment text
-4. the resolved Info-stories four-axis selection
-5. render numbers: motion, seam, and file size when applicable
+For animated output, delegate to `motion-director` with the approved still, layout spec, story brief, and mascot role when applicable. Save `build/motion-direction.json`. Static output records this stage as skipped.
 
-Then stop. No postamble.
+## 10. Motion implementation
 
-If `--arabic` was passed, load `linkedin-animated-infographics:arabic` before step 3. Arabic changes layout and type behavior; it is not a translation pass.
+For animated output, delegate to `motion-engineer` with the approved still, story brief, and motion-direction artifact. It returns the animated `build/post.html`. Static output skips this stage.
+
+## 11. Render mechanics and gates
+
+Delegate to `render-qa`. Save its gate-by-gate evidence as `build/render-report.json`. A `HOLD` returns control to this parent workflow for a targeted fix and re-run.
+
+## 12. Adversarial review
+
+Delegate to `post-critic` with the rendered artifact, caption, evidence record, structural fingerprint, and render report. Save `build/critic-report.json`. Resolve every must-fix item or record why it is not applicable before independent verification.
+
+## 13. Independent acceptance
+
+Delegate to `story-verifier` with the artifact paths, story brief, evidence record, render report, critic report, and explicit acceptance criteria. Save `build/verification-report.json`. `FAIL:fixable` may trigger a targeted fix and re-check. Maximum two targeted fix attempts; a third unresolved failure escalates.
+
+## 14. Deliver
+
+Deliver, in this order:
+
+1. GIF or static artifact
+2. caption
+3. first-comment text
+4. resolved Story House, Visual Style, Story Archetype, and Motion Patterns
+5. render numbers when applicable
+6. final verification verdict
+
+If `--arabic` is present, apply `linkedin-animated-infographics:arabic` before copy/layout production. If `--mascot` is present, the exact-SVG mascot gate defined by the mascot skills must pass before any mascot animation is attempted.

--- a/skills/new-post/SKILL.md
+++ b/skills/new-post/SKILL.md
@@ -11,6 +11,12 @@ Topic: **$ARGUMENTS**
 
 The parent workflow owns orchestration. Workers return artifacts to this workflow; do not ask one worker to coordinate its peers.
 
+## 0. Mascot asset gate
+
+If `--mascot` is present or the user names a specific mascot, identify whether the request refers to an official or exact character. For a named or official mascot, require the **exact SVG** from the user unless that SVG is already task-attached. Do not redraw, approximate, substitute, or generate a lookalike. If the exact SVG is missing, ask the user to attach it and stop the mascot path until it is available.
+
+Record `build/mascot-request.json` with requested name, SVG path, source classification (`user-supplied` or `task-attached`), and `allow_substitute: false`. Validate it with `scripts/mascot_contract.py check` before continuing any mascot planning.
+
 ## 1. Reference diagnosis
 
 If the user supplied screenshots, GIFs, previous designs, or visual references, delegate to `design-study` and save the structured result as `build/design-study.json`. If there is no visual reference, record that this stage is not applicable and continue.
@@ -35,7 +41,7 @@ Delegate to `copy-compressor` with the source, evidence record, Story Archetype,
 
 ## 6. Static layout specification
 
-Delegate to `layout-composer` with the story brief, palette check, artboard copy, and optional design study. Save `build/layout-spec.json`, including zone order, visual anchor, hierarchy, structural fingerprint, and asset requirements.
+Delegate to `layout-composer` with the story brief, palette check, artboard copy, optional design study, and mascot placement requirement when present. Save `build/layout-spec.json`, including zone order, visual anchor, hierarchy, structural fingerprint, and asset requirements.
 
 ## 7. Caption
 
@@ -53,23 +59,27 @@ Show the still. This is the visual approval gate. Get approval before motion.
 
 For animated output, delegate to `motion-director` with the approved still, layout spec, story brief, and mascot role when applicable. Save `build/motion-direction.json`. Static output records this stage as skipped.
 
-## 10. Motion implementation
+## 10. Mascot animation component
 
-For animated output, delegate to `motion-engineer` with the approved still, story brief, and motion-direction artifact. It returns the animated `build/post.html`. Static output skips this stage.
+When the mascot path is active, delegate to `mascot-animator` with the validated exact SVG request, approved still, layout spec, selected mascot role, and motion direction. Save its inspection and identity-preservation evidence under `build/mascot/` and pass the resulting motion contract forward. The supplied SVG remains the identity source and must not be replaced.
 
-## 11. Render mechanics and gates
+## 11. Motion implementation
+
+For animated output, delegate to `motion-engineer` with the approved still, story brief, motion-direction artifact, and validated mascot component when present. It returns the animated `build/post.html`. Static output skips this stage.
+
+## 12. Render mechanics and gates
 
 Delegate to `render-qa`. Save its gate-by-gate evidence as `build/render-report.json`. A `HOLD` returns control to this parent workflow for a targeted fix and re-run.
 
-## 12. Adversarial review
+## 13. Adversarial review
 
-Delegate to `post-critic` with the rendered artifact, caption, evidence record, structural fingerprint, and render report. Save `build/critic-report.json`. Resolve every must-fix item or record why it is not applicable before independent verification.
+Delegate to `post-critic` with the rendered artifact, caption, evidence record, structural fingerprint, mascot identity notes when present, and render report. Save `build/critic-report.json`. Resolve every must-fix item or record why it is not applicable before independent verification.
 
-## 13. Independent acceptance
+## 14. Independent acceptance
 
 Delegate to `story-verifier` with the artifact paths, story brief, evidence record, render report, critic report, and explicit acceptance criteria. Save `build/verification-report.json`. `FAIL:fixable` may trigger a targeted fix and re-check. Maximum two targeted fix attempts; a third unresolved failure escalates.
 
-## 14. Deliver
+## 15. Deliver
 
 Deliver, in this order:
 
@@ -80,4 +90,4 @@ Deliver, in this order:
 5. render numbers when applicable
 6. final verification verdict
 
-If `--arabic` is present, apply `linkedin-animated-infographics:arabic` before copy/layout production. If `--mascot` is present, the exact-SVG mascot gate defined by the mascot skills must pass before any mascot animation is attempted.
+If `--arabic` is present, apply `linkedin-animated-infographics:arabic` before copy/layout production.

--- a/skills/qa-post/SKILL.md
+++ b/skills/qa-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-post
-description: Run every quality gate against a built post before it ships, and red-team the caption.
+description: Run every quality gate against a built post before it ships, red-team the post, and independently verify acceptance evidence.
 disable-model-invocation: true
 argument-hint: "[path/to/artboard.html] [optional: path/to/caption.md]"
 ---
@@ -9,10 +9,9 @@ argument-hint: "[path/to/artboard.html] [optional: path/to/caption.md]"
 
 Arguments: **$ARGUMENTS**
 
-Run the gates in this order and report pass or fail per gate with the specific line or element
-that failed. Do not fix anything unless asked; this skill reports.
+This workflow reports evidence. It does not silently edit the artifact.
 
-## Artboard
+## 1. Deterministic render gates
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py <path> --out /tmp/qa-still.png
@@ -20,25 +19,20 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py <path> --mobile
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/lint_artboard.sh <path>
 ```
 
-Then walk `linkedin-animated-infographics:render` → `references/qa-gates.md` in full, including the mascot
-gates if a character is present.
+Walk `linkedin-animated-infographics:render` and `references/qa-gates.md` in full. Open frame 0 and the 350px preview. For GIFs, include seam, motion, duration, and file-size evidence.
 
-## Frame 0
+## 2. Caption checks
 
-Open the first captured frame on its own. It is LinkedIn's poster frame. If it does not read as
-a complete infographic without motion, that is a fail regardless of how the loop looks.
+Use `linkedin-animated-infographics:caption` when a caption is supplied. Check the truncation cut, one archetype, factual support, exactly one CTA, anti-slop rules, and banned constructions.
 
-## Caption
+## 3. Adversarial review
 
-Load `linkedin-animated-infographics:caption` and check:
+Delegate to `post-critic` with the artifact, caption, render evidence, story brief if present, and evidence record if present. Report must-fix, improvement, and leave-alone findings. Any must-fix item produces `HOLD` until resolved or explicitly shown not applicable.
 
-- line 1 at or under 60 characters
-- one archetype, not two blended
-- every generic noun replaced by a specific name or number
-- exactly one CTA, at the end
-- **zero** denial-then-reveal constructions in any language
-- zero em dashes, zero buzzwords from the ban list
+## 4. Independent verification
+
+When an Info-stories brief or acceptance criteria exist, delegate to `story-verifier` with direct artifact paths, render evidence, post-critic findings, and criteria. Do not substitute a worker summary for artifact evidence. Respect the maximum-two-fix-attempt rule.
 
 ## Verdict
 
-End with a single line: `SHIP` or `HOLD: <the one thing to fix first>`.
+End with one line: `SHIP` or `HOLD: <the one thing to fix first>`.

--- a/skills/svg-mascot-animator/SKILL.md
+++ b/skills/svg-mascot-animator/SKILL.md
@@ -1,186 +1,112 @@
 ---
 name: svg-mascot-animator
 description: >-
-  Turn any static SVG mascot, logo, icon, or character into physics-driven animation, using Anime.js v4 as the default engine for interactive contexts and baked CSS keyframes for README and docs assets. Use this skill EVERY TIME the user wants to animate an SVG, add motion to a mascot or logo, build animated README or docs assets, create an animated badge or banner, mentions Anime.js or animejs, asks for "SVG animation", "حرك الـ mascot دي", "اعملي أنيميشن للـ SVG", "animate this logo", "motion for my icon", "README animation", or shares an SVG file and asks for movement, life, or a collection of poses. Also use when the user asks for believable motion physics on the web such as bounce, jump, swing, fall, squash and stretch, spring, motion path, line drawing, morph, stagger, walk cycle, floating, or inertia. Even for a single small request like "خليها تنط" or "make it bounce", use this skill.
+  Animate an exact SVG mascot, logo, icon, or character with professional physics-driven motion.
+  Use whenever the user supplies an SVG for animation, names an official mascot that must be used
+  exactly, requests believable mascot motion, or wants static/baked or runtime SVG animation.
 license: MIT
 ---
 
 # SVG Mascot Animator
 
-Static SVG in, animation out, with the timing coming from equations and solvers rather than
-from nudged keyframes. Anime.js v4 is the default engine. Where JavaScript cannot run, the
-same Anime.js solvers are sampled ahead of time and baked into CSS keyframes, so both
-versions of an asset share one motion identity.
+The input SVG is the identity source. Animation adds behavior around that source; it does not redesign the character.
 
-What separates convincing motion from generic motion is not more keyframes. It is that the
-timing comes from somewhere real: a parabola carried by a motion path, a pendulum whose
-period follows from its length, a spring whose settling duration is computed by a solver
-rather than picked by feel.
+## Identity and asset gate
 
-## Setup
+For a named or official mascot:
 
-Install the engine first, before writing any animation code:
+- require the exact user-supplied or task-attached SVG before animation begins
+- never substitute a generated mascot or a visually similar asset
+- keep an untouched copy of the source SVG
+- preserve recognizable silhouette, proportions, brand colours, face details, marks, and distinctive geometry
+- if the user has not supplied the exact SVG, the parent workflow must ask for it and hold the mascot path
 
-```bash
-bash scripts/setup.sh          # npm install animejs, verifies the version and exports
-```
-
-In a browser without a build step, import pinned so a future release cannot change the
-motion under the user:
-
-```js
-import { animate, createTimeline, spring, svg, utils } from 'https://esm.sh/animejs@4.5.0';
-```
-
-The API moved substantially at v4 and keeps growing, so confirm the installed surface rather
-than trusting a remembered snippet. `setup.sh` prints it, and `node scripts/bake.mjs list`
-prints the easing names.
-
-## Pick the track first
-
-**Runtime track — Anime.js drives the page.** Docs sites, landing pages, product UI,
-artifacts, demos, anything reacting to scroll, hover, pointer, or state. Timelines, springs,
-motion paths, drawables, morphs, stagger, draggables. Start from
-`assets/runtime-scene.html`.
-
-**Static track — baked CSS inside a self-contained SVG.** README images, badges, anything
-loaded through `<img>`, where scripting never executes. Anime.js still designs the motion;
-`scripts/bake.mjs` samples its easings and spring solver in Node and emits the keyframes.
-
-Ask which one the asset is for. When the answer is both, design the timeline once on the
-runtime track, then bake it, since going the other direction loses the interactivity that
-made the runtime version worth building.
-
-## Workflow
-
-### 1. Read the source and find the rig
+Run the request contract before inspection:
 
 ```bash
-python3 scripts/inspect_svg.py <path-to-svg>
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mascot_contract.py check build/mascot-request.json
 ```
 
-Reports the viewBox, the bounding box, how many separately addressable shapes exist, and the
-pivot translations to use when normalizing.
-
-**A single path cannot articulate.** If the mascot is one path, limbs and eyes cannot move
-independently and every idea has to live at body level: squash, stretch, arcs, rotation, and
-secondary elements drawn outside the path. Say this early rather than promising a walk cycle
-you cannot deliver, and offer the split as an option, since separating the parts unlocks gait
-and reactions.
-
-### 2. Pick stories, one physical domain each
-
-A collection reads as a collection when the pieces do not repeat the same trick.
-
-| Domain | Feels like | Story hooks | Anime.js |
-|---|---|---|---|
-| Projectile + restitution | committed, weighty | shipping, deploying, jumping a gap | `svg.createMotionPath` then `spring()` on landing |
-| Pendulum | rhythmic, hypnotic | swinging between branches, hanging | `ease:'inOutSine'`, `alternate:true` |
-| Damped spring | comic, reactive | load, pressure, overflow | `spring({stiffness, damping, mass})` |
-| Free fall + stacking | escalating | queue building, backlog, tokens piling | `ease:'inQuad'` + `stagger()` |
-| Hop cycle + treadmill | patient, looping | long build, endless progress | looping timeline, ground offset matched to stride |
-| Orbit + drift | calm, ambient | idle, thinking, waiting | `createTimer` or a sine-eased loop |
-| Inertia drag | mechanical | being pushed, dragging weight | `createDraggable` with `releaseEase: spring()` |
-| Reveal / construction | deliberate | building, compiling, assembling | `svg.createDrawable` with `draw:['0 0','0 1']` |
-| Transformation | surprising | switching modes, evolving | `svg.morphTo` |
-
-Propose three with one-line stories and let the user pick or redirect. Serious brands may
-want the calm end of that table rather than the comic end.
-
-Read `references/animejs.md` for the API and `references/physics.md` for the equations,
-easing map, and timing values before writing anything.
-
-### 3. Rig the transform stack
-
-Normalize the artwork once in `<defs>` so the origin sits at the natural pivot, then nest one
-transform per concern, outermost first: horizontal position, vertical position, rotation,
-scale. Mixing two concerns in one group forces hand-tuning, because CSS `transform` and
-Anime.js both replace the whole value rather than composing it.
-
-The rig is identical on both tracks. That is deliberate: it is what lets one motion design
-ship twice.
-
-`references/rigging.md` covers `transform-box`, the origin traps that silently break scaling,
-splitting a path for articulation, and reduced-motion poses.
-
-### 4. Build the timeline
-
-On the runtime track, `createTimeline` with explicit positions. The positions carry the
-performance: `'<'` to start with the previous beat, `'<+=120'` for a lag, `stagger()` as a
-position for a cascade. Let springs set their own durations.
-
-On the static track, generate the SVG from a script that imports `scripts/bake.mjs` for
-spring and easing samples, or `scripts/physics.py` when the scene is pure ballistics and
-Node is unavailable. Print the computed constants and check them before writing the file.
-Reporting "apex 95 units over 0.85s implies g = 1052 units/s²" is how you catch a floaty arc
-before rendering it.
-
-Two rules carry most of the quality:
-
-- **Sample curves, interpolate linearly.** A parabola becomes eight or nine samples with
-  `linear` between them. An `ease-in-out` between two points always reads as floating. On the
-  runtime track a motion path does this for you, which is why `createMotionPath` plus
-  `ease:'linear'` beats easing a straight translate.
-- **Use easing only where the real motion is genuinely eased.** A pendulum is the clean case:
-  `inOutSine` is sinusoidal velocity, which is exactly correct, so two keyframes suffice.
-
-### 5. Layer the secondary motion
-
-The primary motion is the least interesting half of the work:
-
-- **Contact shadow driven by the subject's own height**, read from the same samples or, at
-  runtime, from the live transform in `onUpdate`. A shadow on its own curve drifts out of
-  phase and quietly destroys the sense of depth.
-- **Squash and stretch tied to velocity**: stretch at launch and before impact, neutral at
-  the apex where vertical velocity is zero, squash on contact.
-- **Short contact frames.** A landing squash beyond roughly 0.08s reads as soft.
-- **Follow-through and lag**: trailing parts on the same period, offset 6 to 10 percent, at
-  roughly 20 percent of the amplitude.
-- **Anticipation** before any committed move, slow in and fast out.
-- **Overshoot on arrival**, which is what `spring()` gives for free.
-
-### 6. Apply the asset contract
-
-Both tracks satisfy all of this. `references/contract.md` explains why each item matters:
-
-- `role="img"` with `<title>` and `<desc>` wired through `aria-labelledby`
-- every `id` and every keyframe name prefixed with the filename stem, so several assets can
-  be inlined on one page without collisions
-- a reduced-motion path: `@media (prefers-reduced-motion:reduce)` on the static track, a
-  `matchMedia` guard that seeks the timeline to its payoff on the runtime track
-- a dark variant for neutral colours, with brand colours left alone
-- static track only: zero JavaScript, zero external references, zero web fonts
-
-### 7. Verify before delivering
+## Inspect before promising motion
 
 ```bash
-python3 scripts/check_asset.py <output.svg>              # static track
-python3 scripts/check_asset.py --runtime <scene.html>    # runtime track
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/inspect_svg.py <path-to-svg>
 ```
 
-Fix everything it reports, then deliver and explain the physics behind each piece: the
-constants, why that easing, what the secondary motion is doing. The explanation is part of
-the deliverable, since it is what lets the user judge and adjust the result.
+Record viewBox, bounds, IDs, groups, transforms, clips, paths, and addressable parts. A single-path mascot cannot articulate limbs or eyes independently. Use body-level transforms, external support elements, or ask the user whether an articulated derivative is acceptable. Never split identity-critical geometry silently.
 
-## Output conventions
+## Choose the delivery track
 
-Name files `<subject>-<verb>`, lowercase and hyphenated: `claudecode-ship-it.svg`. Loops run
-3 to 6 seconds; shorter becomes irritating on a page someone is reading, longer means most
-viewers never see the payoff. When a scene cannot loop positionally, fade the actor across
-the last few percent and reset its position while it is invisible.
+**Deterministic static/baked track** is the default for LinkedIn GIFs, README assets, and anything captured frame by frame. Use self-contained SVG/CSS/SMIL with no runtime JavaScript.
 
-Keep each scene in a viewBox sized to its content, typically 320 to 480 units wide.
+**Runtime track** uses Anime.js when the final environment genuinely supports interaction. Use it for interactive web contexts, then bake an equivalent deterministic version if the same motion must appear in a rendered infographic.
 
-## Reference files
+Install and inspect the local Anime.js surface when runtime work is required:
 
-- `references/animejs.md` — v4 API surface, install, physics-to-feature mapping, springs,
-  SVG helpers, baking, and the version traps. Read this before writing engine code.
-- `references/physics.md` — equations, easing map, timing tables, secondary motion.
-- `references/rigging.md` — transform stack, `transform-box`, origin traps, articulation.
-- `references/contract.md` — accessibility, namespacing, `<img>` limits, QA checklist.
-- `scripts/setup.sh` — installs Anime.js and prints the installed export surface.
-- `scripts/bake.mjs` — samples Anime.js easings and springs into CSS keyframes.
-- `scripts/physics.py` — closed-form generators for ballistics and oscillation without Node.
-- `scripts/inspect_svg.py` — geometry and riggability report for a source file.
-- `scripts/check_asset.py` — contract validator for both tracks.
-- `assets/runtime-scene.html` — working starting point for the runtime track.
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/setup.sh
+node ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/bake.mjs list
+```
+
+## Creative direction before keyframes
+
+Read `references/creative-directions.md`. Start from a communication job, then adapt the motion to the supplied rig. The starter set includes Guide the Eye, Curious Peek, Inspect and React, Carry and Place, Reveal Assistant, Status Confirmation, Route Follow, Card-to-Card Handoff, Calm Idle Breathing, and Contextual Micro-Reaction.
+
+Creative work is encouraged, but each new direction must define:
+
+1. communication purpose
+2. exact existing SVG parts allowed to move
+3. optional non-identity support elements
+4. loop/reset behavior
+5. motion budget
+
+Do not reuse the same bounce or float treatment for every mascot.
+
+## Rig rules
+
+Normalize pivots once, then separate transform concerns into nested groups: position, vertical motion, rotation, scale. Prefer transforms on existing groups and paths. Read `references/rigging.md` before changing transform structure.
+
+If articulation exists, secondary parts may lag the primary motion by a small amount. If it does not exist, do not fake limb movement by deforming identity-critical geometry.
+
+## Physical motion rules
+
+Read `references/physics.md` and `references/animejs.md` before implementation. Use real motion relationships rather than decorative easing:
+
+- projectile paths for hops and transfers
+- damped springs for short landing/payoff reactions
+- pendulum timing for genuine swings
+- linear sampling for physical paths
+- contact shadow derived from subject height
+- squash/stretch tied to velocity and contact
+- anticipation before committed movement
+- follow-through only on addressable secondary parts
+
+Keep contact frames short. Keep ambient motion small. Long constant bouncing, random blinking, large rotations, and unmotivated floating are failures.
+
+## Story-aware support elements
+
+You may add a small contact shadow, pointer dot, cursor, route line, card, badge, or lightweight prop when it helps the story and the user did not forbid it. These elements must remain visually separate from the mascot identity and should be removable without changing the official asset.
+
+## Accessibility and asset contract
+
+Read `references/contract.md`. Both delivery tracks require accessible labeling, ID/keyframe namespacing, reduced-motion behavior, collision-safe IDs, and no accidental external dependencies. Brand colours remain brand colours.
+
+For static assets:
+
+- zero JavaScript
+- zero web fonts or network dependencies
+- self-contained styles/animation
+- deterministic seekable timing
+
+## Verification
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/check_asset.py <output.svg>
+python3 ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/check_asset.py --runtime <scene.html>
+```
+
+Also compare the animated output with the untouched source. Confirm identity preservation, motion purpose, loop closure, frame-zero readability when used in an infographic, and reduced-motion behavior.
+
+## Output
+
+Return the animated asset/component, inspection report, chosen creative direction, physics/timing rationale, identity-preservation notes, and any rig limitation. For Info-stories, return these to the parent workflow so `motion-engineer`, `render-qa`, `post-critic`, and `story-verifier` can consume the same evidence.

--- a/skills/svg-mascot-animator/SKILL.md
+++ b/skills/svg-mascot-animator/SKILL.md
@@ -19,7 +19,8 @@ For a named or official mascot:
 - never substitute a generated mascot or a visually similar asset
 - keep an untouched copy of the source SVG
 - preserve recognizable silhouette, proportions, brand colours, face details, marks, and distinctive geometry
-- if the user has not supplied the exact SVG, the parent workflow must ask for it and hold the mascot path
+
+If the exact SVG is missing and this skill is running in the main conversational context, ask the user to upload the exact SVG and do not start mascot production. If this skill is running inside a focused subagent, return `HOLD: exact SVG required` to the parent workflow instead of contacting the user or inventing an asset.
 
 Run the request contract before inspection:
 

--- a/skills/svg-mascot-animator/references/creative-directions.md
+++ b/skills/svg-mascot-animator/references/creative-directions.md
@@ -1,0 +1,34 @@
+# Mascot Creative Directions
+
+These directions are starting points for story-aware motion. They are not a menu that must be used literally. Choose or adapt one only after inspecting the exact SVG and understanding what the motion must communicate.
+
+## Identity rule
+
+When the user names a specific official mascot, the exact user-supplied or task-attached SVG is the identity source. Never redraw it, replace it, approximate it, or generate a lookalike. Preserve its recognizable silhouette, colours, marks, face details, and proportions. New support elements may sit around the mascot, but they do not become part of its identity.
+
+## Directions
+
+| Direction | Communication job | Starting idea |
+|---|---|---|
+| Guide the Eye | reading sequence | mascot travels a real reading route and replaces any abstract pointer |
+| Curious Peek | focus cue | mascot peeks around one panel edge before attention moves there |
+| Inspect and React | state confirmation | eyes/head inspect a result, followed by one restrained reaction |
+| Carry and Place | transfer | mascot moves one small support object from input to destination |
+| Reveal Assistant | hierarchy | gesture toward or uncover one annotation without hiding frame-zero content |
+| Status Confirmation | status change | compact nod, bounce, or settling reaction on a verified state |
+| Route Follow | route direction | whole mascot follows an existing connector path with a contact shadow |
+| Card-to-Card Handoff | reading handoff | body/arm/eye cue passes attention between two or three cards |
+| Calm Idle Breathing | ambient presence | low-amplitude breathing/blink in a quiet footer or panel |
+| Contextual Micro-Reaction | local confirmation | one brief reaction tied to a nearby highlighted state |
+
+## Creative expansion
+
+A new direction is valid when it states five things before implementation:
+
+1. what the motion communicates
+2. which existing SVG groups or paths may move
+3. which support elements, if any, may be added outside the mascot
+4. how the loop resets without harming frame 0
+5. the motion budget and what competing primitive it replaces
+
+Prefer transformations of existing addressable groups. If the SVG is a single path, stay at body-level motion unless the user explicitly approves creating an articulated derivative. Do not promise limb animation that the supplied structure cannot support.

--- a/tests/test_info_stories.py
+++ b/tests/test_info_stories.py
@@ -16,7 +16,7 @@ class InfoStoriesRegistryTests(unittest.TestCase):
         cls.catalog = info_stories.load_catalog(CATALOG)
 
     def test_registry_counts_and_unique_slugs(self):
-        expected = {"houses": 10, "styles": 10, "archetypes": 12, "motions": 10}
+        expected = {"houses": 10, "styles": 12, "archetypes": 15, "motions": 12}
         for axis, count in expected.items():
             items = self.catalog[axis]
             self.assertEqual(count, len(items), axis)
@@ -121,7 +121,7 @@ class InfoStoriesRegistryTests(unittest.TestCase):
         artboard=(ROOT/"agents/artboard-builder.md").read_text().lower(); motion=(ROOT/"agents/motion-engineer.md").read_text().lower(); self.assertIn("story brief",artboard); self.assertIn("story house",artboard); self.assertIn("motion pattern",motion); self.assertIn("story brief",motion)
 
     def test_plugin_version_and_readme_publish_info_stories(self):
-        plugin=json.loads((ROOT/".claude-plugin/plugin.json").read_text()); self.assertEqual("2.1.0",plugin["version"]); self.assertIn("info-stories",plugin["keywords"])
+        plugin=json.loads((ROOT/".claude-plugin/plugin.json").read_text()); self.assertEqual("2.2.0",plugin["version"]); self.assertIn("info-stories",plugin["keywords"])
         readme=(ROOT/"README.md").read_text().lower()
         for needle in ["info-stories","story house","scripts/info_stories.py","tools/palette_preview.py","tools/story_scaffold.py","tools/composition_check.py","tools/copy_slop_check.py"]: self.assertIn(needle,readme)
 

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -1,0 +1,57 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN = ROOT / ".claude-plugin" / "plugin.json"
+VALIDATOR = ROOT / "scripts" / "validate_marketplace.py"
+README = ROOT / "README.md"
+
+
+def load_validator():
+    if not VALIDATOR.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("validate_marketplace", VALIDATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class MarketplaceTests(unittest.TestCase):
+    def test_same_repo_marketplace_manifest(self):
+        self.assertTrue(MARKETPLACE.exists(), "missing .claude-plugin/marketplace.json")
+        data = json.loads(MARKETPLACE.read_text())
+        self.assertEqual("mamdouh-creative-tools", data["name"])
+        self.assertEqual("1.0.0", data["version"])
+        self.assertEqual("Mamdouh Aboammar", data["owner"]["name"])
+        self.assertEqual(1, len(data["plugins"]))
+        entry = data["plugins"][0]
+        self.assertEqual("linkedin-animated-infographics", entry["name"])
+        self.assertEqual("./", entry["source"])
+        self.assertIs(True, entry["strict"])
+
+    def test_marketplace_and_plugin_versions_match(self):
+        market = json.loads(MARKETPLACE.read_text())["plugins"][0]
+        plugin = json.loads(PLUGIN.read_text())
+        self.assertEqual("2.2.0", plugin["version"])
+        self.assertEqual(plugin["version"], market["version"])
+
+    def test_standard_component_directories_exist(self):
+        for relative in ("skills", "agents", "hooks/hooks.json"):
+            self.assertTrue((ROOT / relative).exists(), relative)
+
+    def test_readme_documents_marketplace_install(self):
+        text = README.read_text()
+        self.assertIn("/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics", text)
+        self.assertIn("/plugin install linkedin-animated-infographics@mamdouh-creative-tools", text)
+
+    def test_local_marketplace_validator_is_clean(self):
+        module = load_validator()
+        self.assertIsNotNone(module, "missing scripts/validate_marketplace.py")
+        self.assertEqual([], module.validate_marketplace(ROOT))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mascot_contract.py
+++ b/tests/test_mascot_contract.py
@@ -56,6 +56,11 @@ class MascotContractTests(unittest.TestCase):
         self.assertLess(text.index("artboard-builder"), text.index("mascot-animator"))
         self.assertLess(text.index("mascot-animator"), text.index("motion-engineer"))
 
+    def test_direct_skill_tells_main_model_to_request_svg(self):
+        text = (ROOT / "skills" / "svg-mascot-animator" / "SKILL.md").read_text().lower()
+        self.assertIn("ask the user to upload the exact svg", text)
+        self.assertIn("hold: exact svg required", text)
+
     def test_mascot_agent_preloads_both_mascot_skills(self):
         path = ROOT / "agents" / "mascot-animator.md"
         self.assertTrue(path.exists())

--- a/tests/test_mascot_contract.py
+++ b/tests/test_mascot_contract.py
@@ -1,0 +1,69 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "mascot_contract.py"
+
+
+def load_module():
+    if not SCRIPT.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("mascot_contract", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class MascotContractTests(unittest.TestCase):
+    def test_named_mascot_requires_exact_user_svg(self):
+        module = load_module()
+        self.assertIsNotNone(module, "missing scripts/mascot_contract.py")
+        request = {"requested_name": "Official Brand Mascot", "source": "missing", "svg_path": None}
+        errors = module.validate_mascot_request(request)
+        self.assertTrue(any("exact" in error.lower() and "svg" in error.lower() for error in errors))
+
+    def test_user_supplied_svg_passes_identity_gate(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            svg = Path(tmp) / "official.svg"
+            svg.write_text('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M0 0h10v10H0z"/></svg>')
+            request = {"requested_name": "Official Brand Mascot", "source": "user-supplied", "svg_path": str(svg), "allow_substitute": False}
+            self.assertEqual([], module.validate_mascot_request(request))
+
+    def test_substitution_is_rejected(self):
+        module = load_module()
+        request = {"requested_name": "Official Brand Mascot", "source": "generated", "svg_path": "fake.svg", "allow_substitute": True}
+        errors = module.validate_mascot_request(request)
+        self.assertTrue(any("substitut" in error.lower() for error in errors))
+
+    def test_creative_direction_catalog_is_actionable(self):
+        module = load_module()
+        directions = module.creative_directions()
+        self.assertGreaterEqual(len(directions), 10)
+        slugs = {item["slug"] for item in directions}
+        self.assertEqual(len(directions), len(slugs))
+        for item in directions:
+            for key in ("purpose", "communication_job", "allowed_parts", "loop_behavior", "motion_budget"):
+                self.assertTrue(item.get(key), f"{item['slug']} missing {key}")
+
+    def test_workflow_routes_exact_svg_through_mascot_animator(self):
+        text = (ROOT / "skills" / "new-post" / "SKILL.md").read_text()
+        self.assertIn("exact SVG", text)
+        self.assertIn("mascot-animator", text)
+        self.assertLess(text.index("artboard-builder"), text.index("mascot-animator"))
+        self.assertLess(text.index("mascot-animator"), text.index("motion-engineer"))
+
+    def test_mascot_agent_preloads_both_mascot_skills(self):
+        path = ROOT / "agents" / "mascot-animator.md"
+        self.assertTrue(path.exists())
+        text = path.read_text()
+        self.assertIn("  - svg-mascot-animator", text)
+        self.assertIn("  - mascots", text)
+        self.assertIn("exact user-supplied SVG", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_graph.py
+++ b/tests/test_plugin_graph.py
@@ -36,6 +36,13 @@ class PluginGraphTests(unittest.TestCase):
         }
         self.assertTrue(required.issubset(sequence))
 
+    def test_conditional_mascot_edge_is_explicit(self):
+        edge = json.loads(GRAPH.read_text())["workflows"]["new-post"]["conditional"]["mascot"]
+        self.assertEqual("mascot-animator", edge["agent"])
+        self.assertEqual("exact-svg", edge["asset_gate"])
+        self.assertEqual("artboard-builder", edge["after"])
+        self.assertEqual("motion-engineer", edge["before"])
+
     def test_knowledge_workers_preload_required_skills(self):
         graph = json.loads(GRAPH.read_text())
         for agent, contract in graph["agents"].items():
@@ -48,9 +55,13 @@ class PluginGraphTests(unittest.TestCase):
 
     def test_capability_families_have_shipping_owners(self):
         graph = json.loads(GRAPH.read_text())
-        expected = {"anti-slop", "design-taste", "structural-fingerprint", "evidence", "verification-loop"}
+        expected = {
+            "anti-slop", "design-taste", "structural-fingerprint", "evidence",
+            "verification-loop", "mascot-identity", "ui-mockup-fidelity",
+        }
         self.assertEqual(expected, set(graph["capabilities"]))
-        shipping = set(graph["workflows"]["new-post"]["sequence"])
+        workflow = graph["workflows"]["new-post"]
+        shipping = set(workflow["sequence"]) | {edge["agent"] for edge in workflow.get("conditional", {}).values()}
         for capability, owners in graph["capabilities"].items():
             self.assertTrue(shipping.intersection(owners), f"{capability} has no shipping owner")
 

--- a/tests/test_plugin_graph.py
+++ b/tests/test_plugin_graph.py
@@ -1,0 +1,67 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "plugin_graph.py"
+GRAPH = ROOT / "architecture" / "plugin-graph.json"
+
+
+def load_module():
+    if not SCRIPT.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("plugin_graph", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PluginGraphTests(unittest.TestCase):
+    def test_graph_contract_files_exist(self):
+        self.assertTrue(SCRIPT.exists(), "missing scripts/plugin_graph.py")
+        self.assertTrue(GRAPH.exists(), "missing architecture/plugin-graph.json")
+
+    def test_graph_validator_reports_no_errors(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        self.assertEqual([], module.validate_component_graph(ROOT))
+
+    def test_shipping_agents_are_reachable(self):
+        graph = json.loads(GRAPH.read_text())
+        sequence = graph["workflows"]["new-post"]["sequence"]
+        required = {
+            "story-architect", "palette-curator", "copy-compressor", "layout-composer",
+            "caption-writer", "artboard-builder", "render-qa", "post-critic", "story-verifier",
+        }
+        self.assertTrue(required.issubset(sequence))
+
+    def test_knowledge_workers_preload_required_skills(self):
+        graph = json.loads(GRAPH.read_text())
+        for agent, contract in graph["agents"].items():
+            required = set(contract.get("required_skills", []))
+            if not required:
+                continue
+            text = (ROOT / "agents" / f"{agent}.md").read_text()
+            for skill in required:
+                self.assertIn(f"  - {skill}", text, f"{agent} does not preload {skill}")
+
+    def test_capability_families_have_shipping_owners(self):
+        graph = json.loads(GRAPH.read_text())
+        expected = {"anti-slop", "design-taste", "structural-fingerprint", "evidence", "verification-loop"}
+        self.assertEqual(expected, set(graph["capabilities"]))
+        shipping = set(graph["workflows"]["new-post"]["sequence"])
+        for capability, owners in graph["capabilities"].items():
+            self.assertTrue(shipping.intersection(owners), f"{capability} has no shipping owner")
+
+
+class WorkerCoordinationTests(unittest.TestCase):
+    def test_planning_workers_return_to_parent_orchestrator(self):
+        for name in ("story-architect", "layout-composer", "motion-director"):
+            text = (ROOT / "agents" / f"{name}.md").read_text()
+            self.assertIn("parent workflow", text.lower(), name)
+            self.assertNotIn("Handoff the approved brief to", text, name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_graph.py
+++ b/tests/test_plugin_graph.py
@@ -54,6 +54,20 @@ class PluginGraphTests(unittest.TestCase):
         for capability, owners in graph["capabilities"].items():
             self.assertTrue(shipping.intersection(owners), f"{capability} has no shipping owner")
 
+    def test_new_post_executes_graph_order(self):
+        text = (ROOT / "skills" / "new-post" / "SKILL.md").read_text()
+        sequence = json.loads(GRAPH.read_text())["workflows"]["new-post"]["sequence"]
+        positions = []
+        for agent in sequence:
+            self.assertIn(agent, text, f"new-post never invokes {agent}")
+            positions.append(text.index(agent))
+        self.assertEqual(sorted(positions), positions)
+
+    def test_qa_post_runs_adversarial_and_independent_review(self):
+        text = (ROOT / "skills" / "qa-post" / "SKILL.md").read_text()
+        self.assertIn("post-critic", text)
+        self.assertIn("story-verifier", text)
+
 
 class WorkerCoordinationTests(unittest.TestCase):
     def test_planning_workers_return_to_parent_orchestrator(self):

--- a/tests/test_ui_mockup_stories.py
+++ b/tests/test_ui_mockup_stories.py
@@ -1,5 +1,4 @@
 import json
-import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -42,18 +41,20 @@ class UIMockupStoryTests(unittest.TestCase):
         for needle in ("fictional data", "unsupported product claim", "feed width", "frame 0"):
             self.assertIn(needle, rules.lower())
 
+    def test_ui_rules_are_wired_into_shipping_workers(self):
+        for name in ("evidence-checker", "layout-composer", "artboard-builder", "motion-director", "post-critic"):
+            text = (ROOT / "agents" / f"{name}.md").read_text().lower()
+            self.assertIn("ui-mockup-rules", text, name)
+
     def test_tracked_ui_examples_match_scaffold(self):
         examples = [
-            ("ui-storyboard-brief.json", "ui-storyboard", "screen-to-outcome", ["cursor-focus", "state-transition"]),
-            ("interface-cutaway-brief.json", "interface-cutaway", "inside-the-interface", ["cursor-focus"]),
+            ("ui-storyboard-brief.json", dict(topic="From prompt to approved campaign screen", takeaway="Each screen shows one decision in the workflow", cta="Save the flow", house="mist-board", style="ui-storyboard", archetype="screen-to-outcome", motions=["cursor-focus", "state-transition"], language="en", output_mode="gif")),
+            ("interface-cutaway-brief.json", dict(topic="Inside an agent review screen", takeaway="The interface exposes the checks that produce the final decision", cta="Use the structure", house="ember-paper", style="interface-cutaway", archetype="inside-the-interface", motions=["cursor-focus"], language="en", output_mode="gif")),
         ]
-        for filename, style, archetype, motions in examples:
+        for filename, case in examples:
             path = ROOT / "examples/info-stories" / filename
             self.assertTrue(path.exists(), filename)
-            payload = json.loads(path.read_text())
-            self.assertEqual(style, payload["selection"]["style"])
-            self.assertEqual(archetype, payload["selection"]["archetype"])
-            self.assertEqual(motions, payload["selection"]["motions"])
+            self.assertEqual(info_stories.build_brief(self.catalog, **case), json.loads(path.read_text()))
 
 
 if __name__ == "__main__":

--- a/tests/test_ui_mockup_stories.py
+++ b/tests/test_ui_mockup_stories.py
@@ -46,6 +46,16 @@ class UIMockupStoryTests(unittest.TestCase):
             text = (ROOT / "agents" / f"{name}.md").read_text().lower()
             self.assertIn("ui-mockup-rules", text, name)
 
+    def test_repo_conventions_define_merged_registry_as_authority(self):
+        for path in (
+            ROOT / ".agents/skills/linkedin-animated-infographics/SKILL.md",
+            ROOT / ".claude/skills/linkedin-animated-infographics/SKILL.md",
+        ):
+            text = path.read_text()
+            self.assertIn("merged registry returned by `scripts/info_stories.py::load_catalog()`", text)
+            self.assertIn("skills/info-stories/extensions/*.json", text)
+            self.assertNotIn("`skills/info-stories/catalog.json` is the machine-readable source of truth", text)
+
     def test_tracked_ui_examples_match_scaffold(self):
         examples = [
             ("ui-storyboard-brief.json", dict(topic="From prompt to approved campaign screen", takeaway="Each screen shows one decision in the workflow", cta="Save the flow", house="mist-board", style="ui-storyboard", archetype="screen-to-outcome", motions=["cursor-focus", "state-transition"], language="en", output_mode="gif")),

--- a/tests/test_ui_mockup_stories.py
+++ b/tests/test_ui_mockup_stories.py
@@ -1,0 +1,60 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from scripts import info_stories
+
+
+class UIMockupStoryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.catalog = info_stories.load_catalog()
+
+    def test_ui_styles_are_first_class_catalog_entries(self):
+        styles = {item["slug"]: item for item in self.catalog["styles"]}
+        self.assertIn("ui-storyboard", styles)
+        self.assertIn("interface-cutaway", styles)
+        for slug in ("ui-storyboard", "interface-cutaway"):
+            self.assertEqual({"design_variance", "motion_intensity", "visual_density"}, set(styles[slug]["dials"]))
+
+    def test_ui_archetypes_are_available(self):
+        archetypes = {item["slug"] for item in self.catalog["archetypes"]}
+        self.assertTrue({"screen-to-outcome", "inside-the-interface", "state-change-story"}.issubset(archetypes))
+
+    def test_ui_motion_patterns_are_available(self):
+        motions = {item["slug"] for item in self.catalog["motions"]}
+        self.assertTrue({"cursor-focus", "state-transition"}.issubset(motions))
+
+    def test_ui_storyboard_composes_screen_to_outcome(self):
+        errors = info_stories.check_composition(self.catalog, "ui-storyboard", "screen-to-outcome", ["cursor-focus", "state-transition"])
+        self.assertEqual([], errors)
+
+    def test_interface_cutaway_composes_inside_interface(self):
+        errors = info_stories.check_composition(self.catalog, "interface-cutaway", "inside-the-interface", ["cursor-focus"])
+        self.assertEqual([], errors)
+
+    def test_ui_mockup_rules_block_fake_product_evidence(self):
+        rules = (ROOT / "skills/info-stories/references/ui-mockup-rules.md").read_text()
+        for needle in ("fictional data", "unsupported product claim", "feed width", "frame 0"):
+            self.assertIn(needle, rules.lower())
+
+    def test_tracked_ui_examples_match_scaffold(self):
+        examples = [
+            ("ui-storyboard-brief.json", "ui-storyboard", "screen-to-outcome", ["cursor-focus", "state-transition"]),
+            ("interface-cutaway-brief.json", "interface-cutaway", "inside-the-interface", ["cursor-focus"]),
+        ]
+        for filename, style, archetype, motions in examples:
+            path = ROOT / "examples/info-stories" / filename
+            self.assertTrue(path.exists(), filename)
+            payload = json.loads(path.read_text())
+            self.assertEqual(style, payload["selection"]["style"])
+            self.assertEqual(archetype, payload["selection"]["archetype"])
+            self.assertEqual(motions, payload["selection"]["motions"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Turn the repository into one executable Claude Code plugin graph, package the same repository as a Claude marketplace, harden official mascot animation around exact user-supplied SVGs, and add UI Mockup Stories to Info-stories.

## Agent and capability integration

- adds a machine-readable executable graph at `architecture/plugin-graph.json`
- adds `scripts/plugin_graph.py` to validate agent reachability, required skill preloads, and capability ownership
- preloads focused knowledge through agent `skills:` frontmatter
- makes `new-post` the parent orchestrator instead of relying on worker-to-worker delegation
- routes design study, evidence, story architecture, palette, copy compression, layout, caption, artboard, motion direction, render QA, adversarial critique, and independent verification in a single artifact-driven path
- keeps anti-slop, design-taste, structural fingerprint, evidence, and bounded verification capabilities on the shipping path

## Same-repository Claude marketplace

- adds `.claude-plugin/marketplace.json`
- marketplace name: `mamdouh-creative-tools`
- root plugin source: `./`
- strict manifest mode
- plugin version bumped to `2.2.0`
- adds deterministic marketplace validation and user install commands to README
- adds GitHub Actions that install the current Claude Code package and run `claude plugin validate .`

## Mascot Animator 2

- named or official mascots require the exact user-supplied or task-attached SVG
- no automatic redrawing, substitution, or lookalike mascot generation
- adds `mascot-animator` as a focused worker between still approval and final motion integration
- adds SVG request validation and a creative direction library with ten professional starting directions
- preserves identity, rig constraints, motion budget, frame zero, accessibility, and deterministic rendering

## UI Mockup Stories

Adds a modular Info-stories extension with:

- `UI Storyboard`
- `Interface Cutaway`
- `Screen to Outcome`
- `Inside the Interface`
- `State Change Story`
- `Cursor Focus`
- `State Transition`

UI mockup rules enforce product/evidence fidelity, fictional-data labeling, feed-width legibility, restrained motion, and semantic editable construction.

## Validation strategy

The PR includes focused regression suites for:

- executable plugin graph
- Claude marketplace contract
- exact-SVG mascot contract
- UI Mockup Story registry/composition
- existing Info-stories regression suite

The new CI runs the complete unit suite, Python compilation, Info-stories validation, plugin graph validation, marketplace validation, hook/shell syntax checks, and the official Claude plugin validator. This PR should not merge until those checks are green and review findings are resolved.