### PR TITLE
feat: ship ecosystem routing kernel v3

### DIFF
--- a/.agents/skills/linkedin-animated-infographics/SKILL.md
+++ b/.agents/skills/linkedin-animated-infographics/SKILL.md
@@ -1,67 +1,65 @@
 ---
 name: linkedin-animated-infographics-conventions
-description: Development conventions for a Python, Markdown, HTML, CSS, SVG, and shell based LinkedIn infographic plugin with Info-stories composition.
+description: Repository conventions for the Python, Markdown, HTML/CSS/SVG, shell, agent, research-gate, and Claude Marketplace ecosystem.
 ---
 
-# Linkedin Animated Infographics Conventions
+# LinkedIn Animated Infographics Repository Conventions
 
-Use this skill when changing this repository, adding a skill or agent, modifying the render pipeline, or writing regression tests.
+Use this skill when modifying this repository. Start with `helper/GUIDE.md`; do not create a parallel routing or capability model.
 
-## Tech Stack
+## Machine-readable authority
 
-- **Python 3**: registries, validators, frame capture, GIF assembly, and utility tools
-- **Markdown**: skills, agents, references, plans, and research notes
-- **HTML / CSS / SVG**: 1080x1350 artboards and deterministic animation
-- **Shell**: setup, lint, and render wrappers
-- **JSON**: plugin metadata, hooks, Story House / style registry data, extensions, and structured briefs
-- **unittest**: regression and acceptance tests
+- `helper/router.json`: routes
+- `helper/capabilities.json`: owners and plugin-local defaults
+- `helper/quality-gates.json`: local creative/product gates
+- `helper/artifacts.json`: handoff artifacts
+- `helper/modules.json`: active skills, agents, and public tools
+- `research/capability-notes/gates.json`: adopted research-derived runtime gates
+- `architecture/plugin-graph.json`: shipping sequence and required skill preloads
+- `scripts/info_stories.py::load_catalog()`: merged Info-stories registry
 
-There is no TypeScript application layer in the current repository. Do not introduce frontend framework conventions unless a task explicitly adds one.
+The merged registry combines `skills/info-stories/catalog.json` with `skills/info-stories/extensions/*.json`. `catalog.json` alone is not the complete authority.
 
-## Architecture
+## Actual stack
 
-- `skills/`: user-facing capabilities and their references
-- `agents/`: focused worker contracts with narrow inputs and outputs
-- `scripts/`: implementation and validation logic shared by skills and tools
-- `tools/`: thin public CLIs over shared Python logic
-- `assets/`: templates and generated-but-tracked visual reference assets
-- `tests/`: unit, contract, portability, and acceptance tests
-- `research/`: tracked provenance and design/capability studies; ignored upstream clones never ship
+- Python 3 for validators, registries, render tooling, and public CLIs
+- Markdown for skills, agents, docs, research, and plans
+- HTML / CSS / SVG for fixed 1080x1350 artboards and deterministic motion
+- shell for setup/lint/render wrappers
+- JSON for plugin, routing, capability, gate, artifact, module, and Info-stories contracts
+- unittest for regression and architecture tests
 
-## Info-stories
+There is no TypeScript application layer in the current repository.
 
-Info-stories is the composition layer. Keep its four axes independent:
+## Production architecture
 
-1. Story House
-2. Visual Style
-3. Story Archetype
-4. Motion Pattern
+`new-post` is the parent workflow. Workers return artifacts to the parent workflow; they do not coordinate peer agents directly.
 
-The machine-readable source of truth is the **merged registry returned by `scripts/info_stories.py::load_catalog()`**. It combines the stable base `skills/info-stories/catalog.json` with first-party registry families in `skills/info-stories/extensions/*.json`, merged deterministically by filename. Human references explain the merged registry and must not contradict the merged result. Existing artboard, motion, render, Arabic, and mascot skills remain the execution layer.
+Shipping order:
 
-When adding a base item or extension item, add or update tests before implementation. Preserve 4.5:1 text contrast, 3:1 state-pair contrast, deterministic briefs, unique slugs/names across the merged registry, and explicit compatibility failures.
+`design-study -> evidence-checker -> creative-director -> story-architect -> palette-curator -> copy-compressor -> layout-composer -> caption-writer -> artboard-builder -> motion-director -> optional mascot-animator -> motion-engineer -> render-qa -> post-critic -> story-verifier`
 
-## Development Method
+`creative-director` owns early concept generation. Apply `hooked-design-copy`, `creative-payoff`, `creative-attractive-restrained`, and `center-first` as declared in helper contracts. Named official mascots require the exact SVG.
 
-- Follow existing architecture before adding a parallel implementation
-- Prefer one shared implementation with thin CLIs rather than duplicated logic
-- Write a failing regression test for behavior changes, then implement the minimum fix
-- Run the focused test first, then the complete test suite
-- Run `python3 -m compileall -q scripts tools`
-- Run `python3 scripts/info_stories.py check` when the base registry or extensions change
-- Run `python3 scripts/plugin_graph.py check` when agent routing or preloads change
-- Run `python3 scripts/validate_marketplace.py` when plugin packaging changes
-- Run `git diff --check` before committing
-- Treat browser render verification separately from non-browser tests and report environment blockers precisely
+## Research
 
-## Commit Conventions
+Research is activated through `research/capability-notes/gates.json`. Keep upstream source URL, inspected SHA, license, local Adopt/Adapt/Reject notes, owners, and implementation references. Ignored `research/upstreams/` working copies never ship.
 
-Use conventional commits such as `feat:`, `fix:`, `test:`, `docs:`, and `chore:`. Keep one coherent concern per commit when practical.
+## Development method
 
-## Safety and Provenance
+Write a failing test first for behavior changes, implement the minimum coherent fix, then run focused and full validation.
 
-- Never commit credentials, private MCP configuration, or user secrets
-- Never ship `research/upstreams/`
-- Track source URL, inspected SHA, license, adopted ideas, and rejected ideas for capability research
-- Prefer independently worded local rules over wholesale copying
-- Do not fabricate visual proof or factual content to satisfy a template or UI slot
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
+python3 scripts/info_stories.py check
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/validate_marketplace.py
+```
+
+Use `scripts/ecosystem_doctor.py` as the strict reality gate. A declared module must exist, be reachable, have tests, and remain linked to the live architecture.
+
+Never fabricate factual content or product/UI proof to satisfy a template. Never commit credentials or private MCP configuration.

--- a/.agents/skills/linkedin-animated-infographics/SKILL.md
+++ b/.agents/skills/linkedin-animated-infographics/SKILL.md
@@ -16,9 +16,9 @@ Use this skill when modifying this repository. Start with `helper/GUIDE.md`; do 
 - `helper/modules.json`: active skills, agents, and public tools
 - `research/capability-notes/gates.json`: adopted research-derived runtime gates
 - `architecture/plugin-graph.json`: shipping sequence and required skill preloads
-- `scripts/info_stories.py::load_catalog()`: merged Info-stories registry
+- the merged registry returned by `scripts/info_stories.py::load_catalog()`: complete Info-stories authority
 
-The merged registry combines `skills/info-stories/catalog.json` with `skills/info-stories/extensions/*.json`. `catalog.json` alone is not the complete authority.
+The merged registry returned by `scripts/info_stories.py::load_catalog()` combines `skills/info-stories/catalog.json` with `skills/info-stories/extensions/*.json`. `catalog.json` alone is not the complete authority.
 
 ## Actual stack
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,8 @@
       "name": "linkedin-animated-infographics",
       "source": "./",
       "strict": true,
-      "version": "2.2.0",
-      "description": "Design, validate, render, and animate LinkedIn Info-stories with agent orchestration, exact-SVG mascots, and deterministic QA.",
+      "version": "3.0.0",
+      "description": "Create evidence-safe LinkedIn Info-stories with LLM routing, creative concepting, research gates, exact-SVG mascots, UI mockup stories, and deterministic QA.",
       "author": {
         "name": "Mamdouh Aboammar",
         "url": "https://github.com/imMamdouhaboammar"
@@ -22,7 +22,7 @@
       "repository": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
       "license": "MIT",
       "category": "design",
-      "tags": ["linkedin", "infographic", "animation", "info-stories", "svg", "mascot", "ui-mockup"]
+      "tags": ["linkedin", "infographic", "animation", "creative-direction", "info-stories", "research-gates", "svg", "mascot", "ui-mockup"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-animated-infographics",
-  "description": "Claude Code plugin for designing, rendering, and animating deterministic 1080x1350 GIF infographics, UI mockup stories, and exact-SVG mascots for LinkedIn (Arabic & RTL supported).",
-  "version": "2.2.0",
+  "description": "Claude Code plugin for creative, evidence-safe LinkedIn infographics with LLM routing, Info-stories, research gates, UI mockup stories, exact-SVG mascots, deterministic rendering, and strict QA.",
+  "version": "3.0.0",
   "author": {
     "name": "Mamdouh Aboammar",
     "url": "https://github.com/imMamdouhaboammar"
@@ -15,6 +15,9 @@
     "gif",
     "animation",
     "marketing",
+    "creative-direction",
+    "llm-router",
+    "research-gates",
     "arabic",
     "rtl",
     "svg",

--- a/.claude/skills/linkedin-animated-infographics/SKILL.md
+++ b/.claude/skills/linkedin-animated-infographics/SKILL.md
@@ -1,67 +1,65 @@
 ---
 name: linkedin-animated-infographics-conventions
-description: Development conventions for a Python, Markdown, HTML, CSS, SVG, and shell based LinkedIn infographic plugin with Info-stories composition.
+description: Repository conventions for the Python, Markdown, HTML/CSS/SVG, shell, agent, research-gate, and Claude Marketplace ecosystem.
 ---
 
-# Linkedin Animated Infographics Conventions
+# LinkedIn Animated Infographics Repository Conventions
 
-Use this skill when changing this repository, adding a skill or agent, modifying the render pipeline, or writing regression tests.
+Use this skill when modifying this repository. Start with `helper/GUIDE.md`; do not create a parallel routing or capability model.
 
-## Tech Stack
+## Machine-readable authority
 
-- **Python 3**: registries, validators, frame capture, GIF assembly, and utility tools
-- **Markdown**: skills, agents, references, plans, and research notes
-- **HTML / CSS / SVG**: 1080x1350 artboards and deterministic animation
-- **Shell**: setup, lint, and render wrappers
-- **JSON**: plugin metadata, hooks, Story House / style registry data, extensions, and structured briefs
-- **unittest**: regression and acceptance tests
+- `helper/router.json`: routes
+- `helper/capabilities.json`: owners and plugin-local defaults
+- `helper/quality-gates.json`: local creative/product gates
+- `helper/artifacts.json`: handoff artifacts
+- `helper/modules.json`: active skills, agents, and public tools
+- `research/capability-notes/gates.json`: adopted research-derived runtime gates
+- `architecture/plugin-graph.json`: shipping sequence and required skill preloads
+- `scripts/info_stories.py::load_catalog()`: merged Info-stories registry
 
-There is no TypeScript application layer in the current repository. Do not introduce frontend framework conventions unless a task explicitly adds one.
+The merged registry combines `skills/info-stories/catalog.json` with `skills/info-stories/extensions/*.json`. `catalog.json` alone is not the complete authority.
 
-## Architecture
+## Actual stack
 
-- `skills/`: user-facing capabilities and their references
-- `agents/`: focused worker contracts with narrow inputs and outputs
-- `scripts/`: implementation and validation logic shared by skills and tools
-- `tools/`: thin public CLIs over shared Python logic
-- `assets/`: templates and generated-but-tracked visual reference assets
-- `tests/`: unit, contract, portability, and acceptance tests
-- `research/`: tracked provenance and design/capability studies; ignored upstream clones never ship
+- Python 3 for validators, registries, render tooling, and public CLIs
+- Markdown for skills, agents, docs, research, and plans
+- HTML / CSS / SVG for fixed 1080x1350 artboards and deterministic motion
+- shell for setup/lint/render wrappers
+- JSON for plugin, routing, capability, gate, artifact, module, and Info-stories contracts
+- unittest for regression and architecture tests
 
-## Info-stories
+There is no TypeScript application layer in the current repository.
 
-Info-stories is the composition layer. Keep its four axes independent:
+## Production architecture
 
-1. Story House
-2. Visual Style
-3. Story Archetype
-4. Motion Pattern
+`new-post` is the parent workflow. Workers return artifacts to the parent workflow; they do not coordinate peer agents directly.
 
-The machine-readable source of truth is the **merged registry returned by `scripts/info_stories.py::load_catalog()`**. It combines the stable base `skills/info-stories/catalog.json` with first-party registry families in `skills/info-stories/extensions/*.json`, merged deterministically by filename. Human references explain the merged registry and must not contradict the merged result. Existing artboard, motion, render, Arabic, and mascot skills remain the execution layer.
+Shipping order:
 
-When adding a base item or extension item, add or update tests before implementation. Preserve 4.5:1 text contrast, 3:1 state-pair contrast, deterministic briefs, unique slugs/names across the merged registry, and explicit compatibility failures.
+`design-study -> evidence-checker -> creative-director -> story-architect -> palette-curator -> copy-compressor -> layout-composer -> caption-writer -> artboard-builder -> motion-director -> optional mascot-animator -> motion-engineer -> render-qa -> post-critic -> story-verifier`
 
-## Development Method
+`creative-director` owns early concept generation. Apply `hooked-design-copy`, `creative-payoff`, `creative-attractive-restrained`, and `center-first` as declared in helper contracts. Named official mascots require the exact SVG.
 
-- Follow existing architecture before adding a parallel implementation
-- Prefer one shared implementation with thin CLIs rather than duplicated logic
-- Write a failing regression test for behavior changes, then implement the minimum fix
-- Run the focused test first, then the complete test suite
-- Run `python3 -m compileall -q scripts tools`
-- Run `python3 scripts/info_stories.py check` when the base registry or extensions change
-- Run `python3 scripts/plugin_graph.py check` when agent routing or preloads change
-- Run `python3 scripts/validate_marketplace.py` when plugin packaging changes
-- Run `git diff --check` before committing
-- Treat browser render verification separately from non-browser tests and report environment blockers precisely
+## Research
 
-## Commit Conventions
+Research is activated through `research/capability-notes/gates.json`. Keep upstream source URL, inspected SHA, license, local Adopt/Adapt/Reject notes, owners, and implementation references. Ignored `research/upstreams/` working copies never ship.
 
-Use conventional commits such as `feat:`, `fix:`, `test:`, `docs:`, and `chore:`. Keep one coherent concern per commit when practical.
+## Development method
 
-## Safety and Provenance
+Write a failing test first for behavior changes, implement the minimum coherent fix, then run focused and full validation.
 
-- Never commit credentials, private MCP configuration, or user secrets
-- Never ship `research/upstreams/`
-- Track source URL, inspected SHA, license, adopted ideas, and rejected ideas for capability research
-- Prefer independently worded local rules over wholesale copying
-- Do not fabricate visual proof or factual content to satisfy a template or UI slot
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
+python3 scripts/info_stories.py check
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/validate_marketplace.py
+```
+
+Use `scripts/ecosystem_doctor.py` as the strict reality gate. A declared module must exist, be reachable, have tests, and remain linked to the live architecture.
+
+Never fabricate factual content or product/UI proof to satisfy a template. Never commit credentials or private MCP configuration.

--- a/.claude/skills/linkedin-animated-infographics/SKILL.md
+++ b/.claude/skills/linkedin-animated-infographics/SKILL.md
@@ -16,9 +16,9 @@ Use this skill when modifying this repository. Start with `helper/GUIDE.md`; do 
 - `helper/modules.json`: active skills, agents, and public tools
 - `research/capability-notes/gates.json`: adopted research-derived runtime gates
 - `architecture/plugin-graph.json`: shipping sequence and required skill preloads
-- `scripts/info_stories.py::load_catalog()`: merged Info-stories registry
+- the merged registry returned by `scripts/info_stories.py::load_catalog()`: complete Info-stories authority
 
-The merged registry combines `skills/info-stories/catalog.json` with `skills/info-stories/extensions/*.json`. `catalog.json` alone is not the complete authority.
+The merged registry returned by `scripts/info_stories.py::load_catalog()` combines `skills/info-stories/catalog.json` with `skills/info-stories/extensions/*.json`. `catalog.json` alone is not the complete authority.
 
 ## Actual stack
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,26 +1,56 @@
-# ECC for Codex CLI
+# Codex Repository Guide
 
-This supplements the root `AGENTS.md` with a repo-local ECC baseline.
+This supplements the root `AGENTS.md`. The repository-specific operating authority is `helper/GUIDE.md`.
 
-## Repo Skill
+## Required authority
 
-- Repo-generated Codex skill: `.agents/skills/linkedin-animated-infographics/SKILL.md`
-- Claude-facing companion skill: `.claude/skills/linkedin-animated-infographics/SKILL.md`
-- Keep user-specific credentials and private MCPs in `~/.codex/config.toml`, not in this repo.
+Before changing routing, skills, agents, tools, research, or marketplace packaging, read:
 
-## MCP Baseline
+- `helper/GUIDE.md`
+- `helper/router.json`
+- `helper/capabilities.json`
+- `helper/quality-gates.json`
+- `helper/artifacts.json`
+- `helper/modules.json`
+- `research/capability-notes/gates.json`
+- `architecture/plugin-graph.json`
 
-Treat `.codex/config.toml` as the default ECC-safe baseline for work in this repository.
-The generated baseline enables GitHub, Context7, Exa, Memory, Playwright, and Sequential Thinking.
+Use the merged Info-stories registry from `scripts/info_stories.py::load_catalog()` rather than treating `catalog.json` alone as the source of truth.
 
-## Multi-Agent Support
+## Execution model
 
-- Explorer: read-only evidence gathering
-- Reviewer: correctness, security, and regression review
-- Docs researcher: API and release-note verification
+`new-post` is the parent workflow. Subtasks return bounded artifacts to it; no worker coordinates peer workers through hidden delegation.
 
-## Workflow Files
+The complete path includes `creative-director` after evidence gathering and before story architecture. The creative worker supplies evidence-safe concepts, copy/visual hooks, and a useful aha mechanic before downstream story/layout/motion decisions.
 
-- No dedicated workflow command files were generated for this repo.
+Plugin-local defaults:
 
-Use these workflow files as reusable task scaffolds when the detected repository workflows recur.
+- `hooked-design-copy`
+- `creative-payoff`
+- `creative-attractive-restrained`
+- `center-first`
+- exact SVG required for a named/official mascot
+
+Research-derived gates remain active through `research/capability-notes/gates.json`.
+
+## Strict validation
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/validate_marketplace.py
+```
+
+`scripts/ecosystem_doctor.py` is the strict reality gate for module existence, reachability, ownership, artifacts, tests, and cross-registry drift.
+
+## Repo skills
+
+- Generic/coding-agent conventions: `.agents/skills/linkedin-animated-infographics/SKILL.md`
+- Claude-facing companion: `.claude/skills/linkedin-animated-infographics/SKILL.md`
+
+Keep user credentials and private MCP configuration outside the repository. Do not fabricate claims, UI behavior, proof, or mascot assets to satisfy a build.

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -36,15 +36,30 @@ jobs:
       - name: Validate Info-stories registry
         run: python3 scripts/info_stories.py check
 
+      - name: Validate ecosystem router
+        run: python3 scripts/ecosystem_router.py check
+
+      - name: Validate research gates
+        run: python3 scripts/research_gates.py check
+
       - name: Validate executable plugin graph
         run: python3 scripts/plugin_graph.py check
+
+      - name: Run strict ecosystem doctor
+        run: python3 scripts/ecosystem_doctor.py check
 
       - name: Validate marketplace contract
         run: python3 scripts/validate_marketplace.py
 
-      - name: Validate hook and shell syntax
+      - name: Validate hook, JSON, and shell syntax
         run: |
           python3 -m json.tool hooks/hooks.json >/dev/null
+          python3 -m json.tool helper/router.json >/dev/null
+          python3 -m json.tool helper/capabilities.json >/dev/null
+          python3 -m json.tool helper/artifacts.json >/dev/null
+          python3 -m json.tool helper/quality-gates.json >/dev/null
+          python3 -m json.tool helper/modules.json >/dev/null
+          python3 -m json.tool research/capability-notes/gates.json >/dev/null
           bash -n scripts/lint_artboard.sh
           bash -n scripts/setup.sh
 

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -11,19 +11,20 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Set up Node for Claude Code validator
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# Repository Agent Guide
+
+This repository is an executable Claude/plugin ecosystem for evidence-safe LinkedIn infographics. Do not treat `skills/`, `agents/`, `research/`, or `tools/` as independent islands.
+
+## Start here
+
+Read `helper/GUIDE.md` before changing or running production behavior.
+
+Machine-readable authority:
+
+- `helper/router.json`: request to workflow/skills/agents/capabilities
+- `helper/capabilities.json`: capability owners and plugin-local defaults
+- `helper/quality-gates.json`: local creative/product gates
+- `helper/artifacts.json`: worker handoff artifacts
+- `helper/modules.json`: active public module manifest
+- `research/capability-notes/gates.json`: adopted research-derived runtime gates
+- `architecture/plugin-graph.json`: executable worker order and skill preloads
+- `scripts/info_stories.py::load_catalog()`: merged Info-stories registry
+
+Run the strict cross-repository validator after structural changes:
+
+```bash
+python3 scripts/ecosystem_doctor.py check
+```
+
+## Complete production path
+
+`new-post` is the parent workflow. Workers return artifacts to it; workers do not orchestrate peers directly.
+
+The complete path is:
+
+`design-study -> evidence-checker -> creative-director -> story-architect -> palette-curator -> copy-compressor -> layout-composer -> caption-writer -> artboard-builder -> motion-director -> optional mascot-animator -> motion-engineer -> render-qa -> post-critic -> story-verifier`
+
+`creative-director` must generate evidence-safe concept directions before story architecture. Attention-bearing design copy follows `hooked-design-copy`, and a complete concept should produce a useful `creative-payoff` rather than decorative spectacle.
+
+## Product defaults
+
+- Palette default: `creative-attractive-restrained`
+- Composition default: `center-first`
+- Alignment exceptions are valid for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or documented reference DNA when they improve comprehension/fidelity
+- Named or official mascots require the **exact SVG** supplied by the user/task. No automatic redraw, substitute, or lookalike
+- UI mockups that look real must be evidence-backed; conceptual UI must be identifiable when readers could mistake it for product proof
+
+## Research gates
+
+Research under `research/` is active production guidance. Adopted runtime gates live in `research/capability-notes/gates.json` and are validated by:
+
+```bash
+python3 scripts/research_gates.py check
+```
+
+Do not package ignored `research/upstreams/` clones. Keep source URL, inspected SHA, license, Adopt/Adapt/Reject decisions, local implementation references, shipping owners, and tests.
+
+## Change method
+
+1. Add or update a failing regression/contract test
+2. Implement the minimum coherent change
+3. Run focused tests
+4. Run the full suite and validators
+5. Update docs/manifest/version when public behavior changes
+6. Merge only after official Claude validation, same-repo marketplace install smoke, repository checks, and review findings are clean
+
+Minimum deterministic gate:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
+python3 scripts/info_stories.py check
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/validate_marketplace.py
+```
+
+## Safety
+
+Never commit credentials, private MCP data, or user secrets. Do not fabricate claims, metrics, logos, UI states, testimonials, product behavior, or evidence to satisfy a visual slot. Report browser/render environment blockers separately from non-browser validation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# Claude Code Guide
+
+This repository is a same-repository Claude Marketplace plugin. Treat its helper registries, agents, skills, research gates, and validators as one executable contract.
+
+## First read
+
+Read `helper/GUIDE.md` before selecting a skill or subagent.
+
+The authoritative machine-readable files are:
+
+- `helper/router.json`
+- `helper/capabilities.json`
+- `helper/quality-gates.json`
+- `helper/artifacts.json`
+- `helper/modules.json`
+- `research/capability-notes/gates.json`
+- `architecture/plugin-graph.json`
+- merged Info-stories registry from `scripts/info_stories.py::load_catalog()`
+
+Run:
+
+```bash
+python3 scripts/ecosystem_doctor.py check
+```
+
+after changing skills, agents, tools, routes, capabilities, artifacts, gates, or module inventory.
+
+## Claude orchestration rule
+
+Subagents do not orchestrate peer subagents. The main/parent workflow owns sequencing and HOLD resolution.
+
+For complete post creation, use `new-post` and follow the graph:
+
+`design-study -> evidence-checker -> creative-director -> story-architect -> palette-curator -> copy-compressor -> layout-composer -> caption-writer -> artboard-builder -> motion-director -> optional mascot-animator -> motion-engineer -> render-qa -> post-critic -> story-verifier`
+
+Required skill knowledge is preloaded through each agent's `skills:` frontmatter.
+
+## Creative behavior
+
+- `creative-director` runs before story architecture and produces multiple evidence-safe concept directions
+- hero/design copy must satisfy `hooked-design-copy`, not merely report the topic
+- complete concepts should create a useful `creative-payoff` or documented reason to remain intentionally simple
+- palette default is `creative-attractive-restrained`
+- composition default is `center-first` with evidence/comprehension-driven exceptions only
+- named/official mascot requests require the **exact SVG**; ask for it when missing and do not substitute a lookalike
+
+## Research behavior
+
+`research/capability-notes/gates.json` is active production guidance, not optional background reading. Apply the route's gate IDs and keep provenance in `research/capability-notes/sources.json`. Never package ignored upstream clones.
+
+## Validation
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
+python3 scripts/info_stories.py check
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/validate_marketplace.py
+claude plugin validate .
+```
+
+The CI also registers this repository as marketplace `mamdouh-creative-tools` and installs `linkedin-animated-infographics@mamdouh-creative-tools` from a clean checkout.

--- a/README.md
+++ b/README.md
@@ -1,120 +1,112 @@
 # linkedin-animated-infographics
 
-A Claude Code plugin for designing, rendering, and animating deterministic 1080x1350 GIF infographics, Info-stories, UI mockup stories, and exact-SVG mascots for LinkedIn (Arabic & RTL supported).
+A Claude Code plugin for designing, validating, rendering, and animating evidence-safe LinkedIn infographics with structured Info-stories, creative concept development, UI mockup stories, exact-SVG mascots, Arabic/RTL support, deterministic GIF rendering, and strict repository validation.
 
-## Install from the Claude Marketplace
+Current plugin release: **3.0.0**
 
-Add the marketplace hosted by this repository, then install the plugin:
+## Install from Claude Marketplace
 
 ```text
 /plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics
 /plugin install linkedin-animated-infographics@mamdouh-creative-tools
 ```
 
-The marketplace catalog is `.claude-plugin/marketplace.json`. It exposes the plugin at the repository root with strict manifest mode.
-
-For local development, Claude Code can validate the same repository with:
+The marketplace and plugin live in this same repository. Validate a local checkout with:
 
 ```bash
 claude plugin validate .
 ```
 
-Then, once per machine for browser rendering:
+## What v3 adds
 
-```bash
-bash scripts/setup.sh
+The repository is now one connected production ecosystem instead of a loose collection of prompts and workers.
+
+- `helper/` is the LLM routing and guidance authority
+- `creative-director` develops multiple evidence-safe concepts before story architecture
+- attention-bearing design copy uses `hooked-design-copy`
+- complete concepts require a useful `creative-payoff`, not decorative spectacle
+- palette default is `creative-attractive-restrained`
+- composition default is `center-first`, with documented comprehension/fidelity exceptions
+- `research/` ships as active runtime capability gates with provenance and real owners
+- named or official mascots require the exact user-supplied/task-attached SVG
+- UI Mockup Stories are first-class Info-stories with evidence and feed-width fidelity rules
+- `scripts/ecosystem_doctor.py` rejects dead, undeclared, unreachable, untested, or disconnected public modules
+
+## Quick architecture
+
+Read [`helper/GUIDE.md`](helper/GUIDE.md) before choosing a workflow or worker.
+
+The complete production path is:
+
+```text
+design-study
+  -> evidence-checker
+  -> creative-director
+  -> story-architect
+  -> palette-curator
+  -> copy-compressor
+  -> layout-composer
+  -> caption-writer
+  -> artboard-builder
+  -> motion-director
+  -> optional mascot-animator
+  -> motion-engineer
+  -> render-qa
+  -> post-critic
+  -> story-verifier
 ```
 
-That installs Playwright and a Chrome binary and checks for `ffmpeg`. Registry, graph, and marketplace validation run on plain Python 3.
+`new-post` is the parent workflow. Agents return bounded artifacts to it; they do not secretly orchestrate peer agents.
 
-## Features & Skills
+## Creative runtime
 
-| Skill | Covers |
-|---|---|
-| `post` | The main router. Pipeline, non-negotiables, working method |
-| `caption` | Caption archetypes, truncation cut, hook and CTA libraries, ban list |
-| `info-stories` | Story Houses, Visual Styles, Story Archetypes, Motion Patterns, study, and verification |
-| `artboard` | Execution archetypes, type scale, offline fonts, and still construction |
-| `motion` | Seekable primitives, one-loop-clock rule, reverse-delay trap |
-| `mascots` | Exact mascot identity, roles, motion budget, and infographic fit |
-| `render` | Frame capture, GIF assembly with size budgeting, QA gates, publishing |
-| `arabic` | RTL mirroring, Arabic type scale, bidi isolation, caption rhythm |
-| `svg-mascot-animator` | Exact-SVG inspection, rigging, physics, creative directions, and deterministic animation |
+Before layout starts, `creative-director` produces at least three genuinely different directions in `build/creative-concepts.json`. Every direction includes a visual hook, copy hook, aha mechanic, story shape, recommended visual style/archetype/motion, evidence dependencies, risks, and a reason it earns attention.
+
+A useful wow/aha moment can be a reveal, relationship, comparison, transformation, state change, or interaction that makes the idea easier to understand or remember. It is not a license for random 3D, glow, extreme saturation, arbitrary asymmetry, or excessive motion.
+
+Design copy follows one strong-hook principle: hero/opening copy should earn attention through specificity, supported tension, concrete outcome, recognizable problem, useful surprise, or strong framing. Literal labels, commands, table headers, and UI controls stay literal when clarity is the job.
+
+## Visual defaults
+
+- Palette character: `creative-attractive-restrained`
+- Composition: `center-first`
+- Text contrast: 4.5:1 floor for meaningful text
+- State-defining contrast: 3:1 floor
+- One clear visual anchor at feed scale
+
+Alignment can move away from center-first when the content genuinely benefits, including tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or documented reference-DNA decisions.
 
 ## Info-stories
 
-Info-stories separates a visual direction into four choices:
+Info-stories resolves four independent choices:
 
-1. **Story House**: semantic colour palette and contrast roles
-2. **Visual Style**: structural grammar such as Signal Sheet, Command Canvas, UI Storyboard, or Interface Cutaway
-3. **Story Archetype**: narrative job such as Framework in One Page, Screen to Outcome, or State Change Story
-4. **Motion Pattern**: zero to two meaning-driven motions
+1. Story House
+2. Visual Style
+3. Story Archetype
+4. Motion Pattern
 
-Each Visual Style also carries three 1-10 design dials: design variance, motion intensity, and visual density. Reference images or GIFs can be diagnosed first by `design-study`; the diagnosis maps design DNA into ranked local choices rather than copying the source.
+The source of truth is the merged registry returned by `scripts/info_stories.py::load_catalog()`, combining the stable base with first-party extensions.
 
-The stable base lives in `skills/info-stories/catalog.json`. First-party story families can extend it through `skills/info-stories/extensions/*.json`. `scripts/info_stories.py::load_catalog()` merges the registry deterministically and is the machine-readable source used by agents and tools.
+UI Mockup Stories include UI Storyboard, Interface Cutaway, Screen to Outcome, Inside the Interface, State Change Story, Cursor Focus, and State Transition. Real-looking product behavior must be evidence-backed; conceptual UI must be identifiable when readers could mistake it for product proof.
 
-### UI Mockup Stories
+## Exact-SVG mascots
 
-UI Mockup Stories make interface states part of the infographic narrative rather than decorative screenshots.
+If the user names a specific or official mascot, the plugin requires the **exact SVG** supplied by the user or attached to the task. It does not redraw, approximate, substitute, or generate a lookalike automatically.
 
-- **UI Storyboard**: two to four screens or interface states in a clear sequence
-- **Interface Cutaway**: one dominant interface with annotated internal zones
-- **Screen to Outcome**: starting screen, interaction, visible result
-- **Inside the Interface**: hero interface, internal zones, why they matter
-- **State Change Story**: before state, trigger, after state
-- **Cursor Focus**: restrained secondary cue for one control or region
-- **State Transition**: one primary interface state change
-
-The UI rules preserve feed-width legibility, distinguish documented product UI from concept UI, label fictional data when it could be mistaken for real evidence, and block unsupported features, metrics, integrations, or customer proof.
-
-### Mascot Animator 2
-
-When the user names a specific official mascot, the plugin requires the exact user-supplied or task-attached SVG before mascot animation starts. It never redraws, approximates, substitutes, or generates a lookalike automatically.
-
-The mascot path is:
-
-`exact SVG -> identity contract -> SVG inspection -> rig plan -> creative direction -> mascot-animator -> motion integration -> render QA -> adversarial review -> independent verification`
-
-Creative starting directions include Guide the Eye, Curious Peek, Inspect and React, Carry and Place, Reveal Assistant, Status Confirmation, Route Follow, Card-to-Card Handoff, Calm Idle Breathing, and Contextual Micro-Reaction. Each direction must state its communication job, movable SVG parts, reset behavior, and motion budget.
-
-Inspect the available directions or validate a request:
+The mascot path inspects the real SVG, identifies addressable geometry, selects a communication-led creative direction, preserves identity, integrates motion, and verifies the result against the untouched source.
 
 ```bash
 python3 scripts/mascot_contract.py directions
 python3 scripts/mascot_contract.py check build/mascot-request.json
 ```
 
-## Validation and tools
+## Research gates
 
-Inspect and validate the registry, executable graph, and marketplace:
+Tracked research is active production guidance. The current runtime gates are:
 
-```bash
-python3 scripts/info_stories.py check
-python3 scripts/plugin_graph.py check
-python3 scripts/validate_marketplace.py
-python3 scripts/info_stories.py list house
-python3 scripts/info_stories.py list style
-```
+`prose-specificity`, `voice-preservation`, `design-dials`, `structural-originality`, `reference-dna`, `contrast-discipline`, `evidence-traceability`, and `bounded-verification`.
 
-External capability research lives under `research/capability-notes/`; cloned upstream working copies are ignored and are not shipped with the plugin.
-
-### Info-stories tools
-
-```bash
-python3 tools/palette_preview.py --out assets/info-stories-palettes.html
-python3 tools/story_scaffold.py --topic "..." --takeaway "..." --cta "..." \
-  --house ember-paper --style signal-sheet --archetype framework-in-one-page \
-  --motion sequential-highlight --out build/story-brief.json
-python3 tools/composition_check.py --style signal-sheet \
-  --archetype framework-in-one-page --motion sequential-highlight
-python3 tools/copy_slop_check.py "copy to inspect"
-python3 tools/contrast_check.py --house ember-paper --fg accent_deep --bg bg --minimum 4.5
-python3 tools/fingerprint_check.py --current build/fingerprint.json \
-  --previous build/previous-fingerprint.json --min-changes 2
-```
-
-Tracked palette chooser: `assets/info-stories-palettes.html`. Acceptance examples: `examples/info-stories/`.
+Each gate has source provenance, a local independently-worded behavior, stage, severity, real shipping owners, implementation references, and tests. Ignored upstream working copies are never packaged with the plugin.
 
 ## Workflows
 
@@ -124,48 +116,54 @@ Tracked palette chooser: `assets/info-stories-palettes.html`. Acceptance example
 /linkedin-animated-infographics:qa-post     [path.html] [caption.md]
 ```
 
-`new-post` is the parent orchestrator. Worker agents return explicit artifacts to it instead of coordinating hidden peer calls. The executable route, conditional mascot path, skill preloads, and capability ownership are tracked in `architecture/plugin-graph.json`.
+For programmatic routing:
 
-## Agents
+```bash
+python3 tools/route_request.py --request "Create an animated LinkedIn infographic"
+```
 
-| Agent | Does |
-|---|---|
-| `design-study` | Extracts reusable design DNA from references without pixel cloning |
-| `evidence-checker` | Blocks unsupported claims and fabricated proof |
-| `story-architect` | Resolves the four-axis Info-stories brief |
-| `palette-curator` | Verifies Story House tokens and contrast |
-| `copy-compressor` | Compresses artboard copy while preserving facts and voice |
-| `layout-composer` | Produces the structural fingerprint and layout specification |
-| `caption-writer` | Writes the caption under caption-specific rules |
-| `artboard-builder` | Builds and checks the still |
-| `motion-director` | Defines the communication job of motion |
-| `mascot-animator` | Inspects and animates the exact supplied mascot SVG under an identity contract |
-| `motion-engineer` | Integrates seekable motion and closes the loop |
-| `render-qa` | Produces deterministic render evidence |
-| `post-critic` | Red-teams copy, UI fidelity, mascot identity, visual structure, and motion |
-| `story-verifier` | Independently verifies acceptance criteria against artifact evidence |
-
-## Hooks
-
-A `PostToolUse` lint runs on HTML files containing an `#artboard`. It catches non-seekable `requestAnimationFrame` motion, network fonts, and missing or wrongly sized artboards before a full render.
-
-## Development & Validation
+## Strict validation
 
 ```bash
 python3 -m unittest discover -s tests -v
 python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
 python3 scripts/info_stories.py check
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
 python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
 python3 scripts/validate_marketplace.py
 claude plugin validate .
 ```
 
-The GitHub validation workflow also registers the marketplace from a clean checkout and installs `linkedin-animated-infographics@mamdouh-creative-tools` as an end-to-end marketplace smoke test.
+The CI also registers the checked-out repository as marketplace `mamdouh-creative-tools` and installs `linkedin-animated-infographics@mamdouh-creative-tools` in a clean Claude home.
 
-## Credits
+Useful public tools include:
 
-Built by **Mamdouh Aboammar**, Managing Partner at Momint, founder of PrePilot.cloud and OpenOps Studio.
+```text
+tools/story_scaffold.py
+tools/composition_check.py
+tools/palette_preview.py
+tools/copy_slop_check.py
+tools/contrast_check.py
+tools/fingerprint_check.py
+tools/route_request.py
+```
 
-The mascot layer takes its physics and rig from [vibe-svgs](https://github.com/imMamdouhaboammar/vibe-svgs).
+## Documentation
 
-MIT licensed.
+- [Ecosystem architecture](docs/ecosystem.md)
+- [Routing protocol](docs/routing.md)
+- [Agents](docs/agents.md)
+- [Skills](docs/skills.md)
+- [Research gates and provenance](docs/research.md)
+- [Claude Marketplace](docs/marketplace.md)
+- [Development and validation](docs/development.md)
+
+## Development entrypoints
+
+Coding agents should also read [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md). Both point back to the same helper, research, module, and validation authority.
+
+## License
+
+MIT

--- a/agents/artboard-builder.md
+++ b/agents/artboard-builder.md
@@ -25,14 +25,16 @@ Approved caption and artboard copy, `build/layout-spec.json`, plus `build/story-
 4. Read `references/visual-archetypes.md` and `references/design-systems.md` for shared typography, spacing, and contrast rules.
 5. Start from the closest template in `${CLAUDE_PLUGIN_ROOT}/assets/`, then reshape it to the selected Visual Style rather than producing a palette-only reskin.
 6. Inline the exact Story House token block. Never invent one-off colours halfway through the artboard.
-7. Build macro zones first, then hierarchy, then cards/connectors/UI, then attribution footer.
-8. Check after every meaningful change:
+7. Apply the plugin-local palette default `creative-attractive-restrained`: keep the resolved palette expressive and memorable without exaggerated saturation, unnecessary neon, or competing accent overload unless the brief explicitly requires it.
+8. Execute the approved `center-first` layout by default. Keep the main visual anchor and major content zones centered as a coherent fixed-page composition. Respect a documented alignment exception from `build/layout-spec.json` for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity. Do not create arbitrary asymmetry after layout approval.
+9. Build macro zones first, then hierarchy, then cards/connectors/UI, then attribution footer.
+10. Check after every meaningful change:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py build/post.html --out build/still.png
 ```
 
-9. View the rendered PNG yourself and compare it with the approved structural fingerprint.
+11. View the rendered PNG yourself and compare it with the approved structural fingerprint.
 
 ## UI Mockup Stories
 
@@ -52,4 +54,4 @@ For `ui-storyboard` or `interface-cutaway`, read `skills/info-stories/references
 
 ## Before returning
 
-Measure real element positions. Confirm footer clearance, feed-scale visual anchor, structural fingerprint, and UI legibility when relevant. Return file path, still, execution archetype, Visual Style, and Story House used to the parent workflow.
+Measure real element positions. Confirm footer clearance, feed-scale visual anchor, center-first execution or documented alignment exception, restrained palette character, structural fingerprint, and UI legibility when relevant. Return file path, still, execution archetype, Visual Style, and Story House used to the parent workflow.

--- a/agents/artboard-builder.md
+++ b/agents/artboard-builder.md
@@ -1,9 +1,6 @@
 ---
 name: artboard-builder
-description: >-
-  Builds the 1080x1350 HTML still for an animated infographic, before any motion is added. Use
-  after a caption and visual direction are approved. Returns a static artboard that already
-  passes check_render.py, plus the still PNG.
+description: Builds the approved 1080x1350 static HTML artboard and still PNG while preserving Story House tokens, center-first composition, UI fidelity, contrast, and the selected creative payoff.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 skills:
@@ -11,47 +8,58 @@ skills:
   - info-stories
 ---
 
-You build the static artboard. Motion is somebody else's job and you must not add any.
+## Role
+
+Execute the approved static composition for the parent workflow. Build the still faithfully from the selected concept, story brief, palette, copy, and layout. Do not add motion and do not redesign the concept independently.
+
+Read `helper/GUIDE.md` before static execution.
 
 ## Inputs
 
-Approved caption and artboard copy, `build/layout-spec.json`, plus `build/story-brief.json` when the post uses Info-stories.
+- `build/creative-concepts.json` selected direction
+- `build/story-brief.json`
+- `build/palette-check.json`
+- `build/artboard-copy.json`
+- `build/layout-spec.json`
+- approved caption/brand/UI assets when relevant
+- reserved mascot zone when the mascot path is active
 
 ## Method
 
-1. Use the preloaded `artboard` skill.
-2. If a story brief exists, also use the preloaded `info-stories` skill. Read its selected Visual Style, Story House, `execution.artboard_archetype`, `execution.house_tokens`, and design dials. These are resolved inputs.
-3. If no story brief exists, preserve legacy behavior with the explicitly approved visual archetype and House 0 unless another palette is named.
-4. Read `references/visual-archetypes.md` and `references/design-systems.md` for shared typography, spacing, and contrast rules.
-5. Start from the closest template in `${CLAUDE_PLUGIN_ROOT}/assets/`, then reshape it to the selected Visual Style rather than producing a palette-only reskin.
-6. Inline the exact Story House token block. Never invent one-off colours halfway through the artboard.
-7. Apply the plugin-local palette default `creative-attractive-restrained`: keep the resolved palette expressive and memorable without exaggerated saturation, unnecessary neon, or competing accent overload unless the brief explicitly requires it.
-8. Execute the approved `center-first` layout by default. Keep the main visual anchor and major content zones centered as a coherent fixed-page composition. Respect a documented alignment exception from `build/layout-spec.json` for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity. Do not create arbitrary asymmetry after layout approval.
-9. Build macro zones first, then hierarchy, then cards/connectors/UI, then attribution footer.
-10. Check after every meaningful change:
+1. Use the preloaded `artboard` and `info-stories` skills.
+2. Read the selected Visual Style, Story House, execution archetype, semantic tokens, design dials, and selected concept payoff.
+3. Start from the closest reusable asset/template, then reshape it to the approved layout rather than producing a palette-only reskin.
+4. Apply `structural-originality`: preserve the approved structural fingerprint and do not collapse it into a generic repeated-card layout.
+5. Apply `restrained-palette`: use the resolved `creative-attractive-restrained` Story House/token block, with no one-off decorative colors or exaggerated saturation unless explicitly approved.
+6. Apply `center-first-composition`: execute the centered visual anchor/major zones unless `build/layout-spec.json` records a valid alignment exception. Do not introduce arbitrary off-center drift after approval.
+7. Apply `contrast-discipline`: verify meaningful foreground/background and state pairs at the repository floors.
+8. For UI stories, read `skills/info-stories/references/ui-mockup-rules.md`. Use editable semantic HTML/CSS/SVG where appropriate, preserve evidence-qualified product states, and keep critical controls readable at feed width. Concept/sample data must not masquerade as real proof.
+9. Preserve mascot reservation without redrawing the exact SVG in the still.
+10. Build macro zones first, then hierarchy, cards/connectors/UI, then attribution footer.
+11. Check the still:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py build/post.html --out build/still.png
 ```
 
-11. View the rendered PNG yourself and compare it with the approved structural fingerprint.
+12. Inspect the PNG directly. Confirm the selected creative payoff is visible without animation, frame-zero content is complete, and the layout/palette defaults are satisfied.
 
-## UI Mockup Stories
+## HOLD conditions
 
-For `ui-storyboard` or `interface-cutaway`, read `skills/info-stories/references/ui-mockup-rules.md`. Build interface surfaces with semantic HTML/CSS/SVG, not a fake screenshot raster when editable structure is available. Keep only story-critical controls and labels, preserve evidence-qualified product names/states, and verify core UI text at feed width. Concept data must remain visibly identifiable as sample/concept when readers could mistake it for real evidence.
+Return a HOLD when contrast fails, the approved layout cannot be executed at feed-readable scale, UI/product evidence is insufficient, the selected payoff disappears in static execution, a non-centered treatment lacks a documented exception, or a required asset is missing.
 
-## Non-negotiables
+## Quality gates
 
-- Exactly one `#artboard` at `width:1080px; height:1350px`.
-- System-safe or base64-embedded fonts only. Never `@import` from a network.
-- Nothing moving belongs here.
-- The attribution footer is mandatory.
-- Load-bearing text at or above 22px in artboard units.
-- Text contrast follows the artboard skill's 4.5:1 floor.
-- Use explicit classes for positioning, never `:nth-of-type`.
-- When a Story House is resolved, do not silently fall back to House 0.
-- If a mascot is planned, preserve the reserved mascot zone and do not redraw its exact SVG in the still.
+- `restrained-palette`
+- `center-first-composition`
+- static readability at feed scale
+- selected creative payoff remains legible
+- mandatory attribution and safe margins
 
-## Before returning
+## Research gates
 
-Measure real element positions. Confirm footer clearance, feed-scale visual anchor, center-first execution or documented alignment exception, restrained palette character, structural fingerprint, and UI legibility when relevant. Return file path, still, execution archetype, Visual Style, and Story House used to the parent workflow.
+Own and execute `structural-originality` and `contrast-discipline`. Respect active `reference-dna` without copying distinctive source work and preserve evidence constraints from `evidence-traceability` for UI/proof surfaces.
+
+## Outputs
+
+Return `build/post.html` and `build/still.png` to the parent workflow plus execution archetype, Story House/Visual Style used, structural fingerprint confirmation, UI fidelity notes, contrast verdict, and any remaining static limitation.

--- a/agents/caption-writer.md
+++ b/agents/caption-writer.md
@@ -1,39 +1,53 @@
 ---
 name: caption-writer
-description: >-
-  Writes and rewrites LinkedIn captions for animated infographic posts. Use proactively
-  whenever a caption, hook, opening line, or CTA is needed for a LinkedIn post, and when an
-  existing caption needs to be checked against the ban list. Returns a finished caption plus
-  the first-comment text.
+description: Writes evidence-safe LinkedIn captions and opening hooks for animated infographic posts, then returns caption and first-comment artifacts to the parent workflow.
 tools: Read, Grep, Glob, Write, Edit
 model: opus
 skills:
   - caption
 ---
 
-You write LinkedIn captions for the animated-infographic post format. You are not a general copywriter; you work inside one specific structure and your job is to make it land.
+## Role
 
-## Before writing
+Write the LinkedIn caption for the approved infographic direction. You are a specialist worker inside the parent workflow, not a general-purpose copywriter and not a peer orchestrator.
 
-Use the preloaded `caption` skill and read `references/caption-patterns.md` in full. Pick exactly one of the seven archetypes and stay in it. Blending archetypes is the failure you are most likely to commit and the reader always feels it.
+## Inputs
 
-## The four rules
+- approved source/evidence context
+- selected concept from `build/creative-concepts.json` when available
+- story brief and finished artboard-copy direction
+- audience, CTA, language, and any verified numbers/product names
 
-1. Line 1 under 55 characters, worth the click on its own, survives the mobile truncation cut.
-2. One idea per line. Blank line between almost every line.
-3. Every generic noun becomes a specific name or a specific number, or the line gets deleted.
-4. Exactly one CTA, at the end.
+## Method
 
-## Hard bans, enforced before you return anything
+1. Read `helper/GUIDE.md` and the preloaded `caption` skill.
+2. Read `skills/info-stories/references/hook-driven-design-copy.md` when the post uses Info-stories.
+3. Pick exactly one caption archetype and stay inside it.
+4. Apply `hooked-design-copy` to line 1. The opening must survive the mobile truncation cut and earn attention through specificity, a supported consequence, a concrete outcome, a recognizable problem, useful surprise, or strong framing.
+5. Keep line 1 under 55 characters when practical. One idea per line and strong whitespace rhythm remain the default.
+6. Replace generic nouns with real names/numbers only when they are supported. Otherwise delete or rewrite the line.
+7. Use exactly one CTA at the end unless the selected archetype intentionally has none.
+8. Run the existing ban-list and anti-slop checks. If a line reduces to denial-then-reveal contrast, rewrite it directly. No em dashes.
+9. Verify every number, product name, price, and claim against available evidence. Cut unsupported precision rather than approximating.
 
-Read every line you wrote. If a line reduces to "not X, but Y" in any language, including `ده مش X، ده Y`, `مش مجرد X`, `هذا ليس X، بل Y`, delete it and write the positive statement. No em dashes. No buzzwords from the list in the reference.
+## HOLD conditions
 
-If you catch yourself reaching for a dramatic reversal to make a line land, the line is weak. Name the mechanism or the consequence instead.
+Return a HOLD to the parent workflow when the requested hook, metric, product claim, testimonial, or CTA premise is unsupported and cannot be made truthful without changing the approved direction.
 
-## Verify the facts
+## Quality gates
 
-Every number, product name, star count, and price in the caption is checkable and commenters will check it. If you cannot verify a figure from something in context or from a fetched page, cut it rather than approximating.
+- `hooked-design-copy`
+- one caption archetype
+- one CTA or an explicitly CTA-free archetype
+- mobile truncation survival
+- no unsupported specificity
 
-## Return
+Do not turn every line into a hook. One strong opening and a clear progression are better than continuous cleverness.
 
-Return the caption, first-comment text, and the selected archetype to the parent workflow.
+## Research gates
+
+Apply `prose-specificity`, `voice-preservation`, and `evidence-traceability` when they are active in the route.
+
+## Outputs
+
+Return `build/caption.md`, `build/first-comment.md`, selected caption archetype, hook mechanism, and any unresolved factual caveat to the parent workflow.

--- a/agents/copy-compressor.md
+++ b/agents/copy-compressor.md
@@ -24,12 +24,13 @@ Compress approved source material into infographic-sized design copy. Preserve f
 
 1. Read `helper/GUIDE.md` and the active route gates.
 2. Mark facts, names, numbers, mechanisms, qualifications, and user-specific phrases that must survive.
-3. Read `skills/info-stories/references/hook-driven-design-copy.md` and `skills/info-stories/references/anti-slop-gates.md`.
+3. Read `skills/info-stories/references/hook-driven-design-copy.md`, `skills/info-stories/references/anti-slop-gates.md`, and the `design-taste` density guidance in `skills/info-stories/references/design-taste-gates.md`.
 4. Compress by slot using concrete nouns and verbs. Remove filler, repeated setup, faux insight, and generic portable sentences.
 5. Apply `hooked-design-copy` to the hero and story-opening slots. Use specificity, a supported consequence, a recognizable problem, useful surprise, or strong framing. Do not force cleverness into labels, commands, UI controls, or table headers.
 6. Preserve the selected concept's copy hook and aha setup when evidence supports them. Do not invent a new competing concept after creative approval.
 7. Preserve useful roughness and deliberate voice. Never rewrite a specific fact into a broader marketing claim.
 8. Run the existing anti-slop scan on visible prose and review findings by slot.
+9. Respect the resolved design-taste density. Solve crowding by compression and hierarchy rather than shrinking load-bearing copy below the artboard contract.
 
 ## HOLD conditions
 
@@ -40,13 +41,13 @@ Return a HOLD to the parent workflow when a required hook depends on unsupported
 - `hooked-design-copy`
 - anti-slop slot checks
 - evidence preservation
-- density appropriate to the resolved layout
+- density appropriate to the resolved design-taste/layout contract
 
 A hero that only restates the topic fails even if it is grammatically clean. A literal label that is clear should not be made clever for the sake of the hook gate.
 
 ## Research gates
 
-Apply `prose-specificity`, `voice-preservation`, and `evidence-traceability` from `research/capability-notes/gates.json` when present in the route.
+Apply `prose-specificity`, `voice-preservation`, and `evidence-traceability` from `research/capability-notes/gates.json` when present in the route. Respect active `design-dials` when they determine density and copy load.
 
 ## Outputs
 

--- a/agents/copy-compressor.md
+++ b/agents/copy-compressor.md
@@ -1,6 +1,6 @@
 ---
 name: copy-compressor
-description: Compresses source material into infographic-sized copy when cards, labels, headlines, or a CTA are too dense.
+description: Compresses source material into infographic-sized copy while preserving facts, voice, hooks, and slot clarity.
 tools: Read, Grep
 model: sonnet
 skills:
@@ -8,20 +8,46 @@ skills:
   - caption
 ---
 
-You reduce copy without reducing facts or voice.
+## Role
+
+Compress approved source material into infographic-sized design copy. Preserve facts and voice, strengthen attention-bearing slots, and return bounded copy artifacts to the parent workflow.
 
 ## Inputs
 
-Source text, audience, one takeaway, Story Archetype, target slots, factual claims, and any voice constraints.
+- source material and `build/evidence.json`
+- selected direction from `build/creative-concepts.json` when available
+- Story Archetype and target slots
+- audience and one takeaway
+- factual claims, protected names/numbers/mechanisms, and voice constraints
 
 ## Method
 
-First mark facts, names, numbers, mechanisms, and qualifications that must survive. Then compress by slot. Prefer concrete nouns and verbs. Remove filler, repeated setup, faux insight, and generic portable sentences. Preserve intentional voice and useful roughness. Never rewrite a specific fact into a broader marketing claim.
+1. Read `helper/GUIDE.md` and the active route gates.
+2. Mark facts, names, numbers, mechanisms, qualifications, and user-specific phrases that must survive.
+3. Read `skills/info-stories/references/hook-driven-design-copy.md` and `skills/info-stories/references/anti-slop-gates.md`.
+4. Compress by slot using concrete nouns and verbs. Remove filler, repeated setup, faux insight, and generic portable sentences.
+5. Apply `hooked-design-copy` to the hero and story-opening slots. Use specificity, a supported consequence, a recognizable problem, useful surprise, or strong framing. Do not force cleverness into labels, commands, UI controls, or table headers.
+6. Preserve the selected concept's copy hook and aha setup when evidence supports them. Do not invent a new competing concept after creative approval.
+7. Preserve useful roughness and deliberate voice. Never rewrite a specific fact into a broader marketing claim.
+8. Run the existing anti-slop scan on visible prose and review findings by slot.
+
+## HOLD conditions
+
+Return a HOLD to the parent workflow when a required hook depends on unsupported evidence, a source claim is ambiguous, or compression would materially change a protected fact or qualification.
+
+## Quality gates
+
+- `hooked-design-copy`
+- anti-slop slot checks
+- evidence preservation
+- density appropriate to the resolved layout
+
+A hero that only restates the topic fails even if it is grammatically clean. A literal label that is clear should not be made clever for the sake of the hook gate.
+
+## Research gates
+
+Apply `prose-specificity`, `voice-preservation`, and `evidence-traceability` from `research/capability-notes/gates.json` when present in the route.
 
 ## Outputs
 
-Return slot-keyed copy, a list of protected facts, anything cut for density, and any unclear claim that needs evidence to the parent workflow. Do not make facts up to fill an empty card.
-
-## Capability gates
-
-Use `skills/info-stories/references/anti-slop-gates.md` and `skills/info-stories/references/design-taste-gates.md`. Run the anti-slop scan on visible prose, then preserve any intentional fragment that exists because the slot is a label or node.
+Return `build/artboard-copy.json` to the parent workflow with slot-keyed copy, protected facts, cuts made for density, hook rationale for attention-bearing slots, and any claim that still needs evidence. Do not make facts up to fill an empty card.

--- a/agents/creative-director.md
+++ b/agents/creative-director.md
@@ -1,0 +1,72 @@
+---
+name: creative-director
+description: Develops evidence-safe creative concept directions, visual hooks, copy hooks, and useful aha moments before story architecture begins.
+tools: Read, Grep, Glob
+model: opus
+skills:
+  - info-stories
+  - caption
+  - artboard
+---
+
+## Role
+
+You are the concept worker between evidence gathering and story architecture. Your job is to find a memorable, useful way to explain the material before layout decisions harden. Return concepts to the parent workflow. Do not coordinate peer agents yourself.
+
+## Inputs
+
+- source material and user brief
+- `build/evidence.json`
+- optional `build/design-study.json`
+- language and audience
+- output mode: static or animated
+- brand, palette, UI, mascot, or reference constraints already approved by the parent workflow
+
+## Method
+
+1. Read `helper/GUIDE.md` and the active route gates.
+2. Read `skills/info-stories/references/hook-driven-design-copy.md` and `skills/info-stories/references/design-taste-gates.md`.
+3. Preserve the evidence boundary. Record which facts, product states, metrics, names, and claims are protected.
+4. Generate at least three genuinely different concept directions. Do not make three palette variations of one idea.
+5. For every direction define:
+   - concept name
+   - visual hook
+   - copy hook
+   - aha mechanic
+   - story shape
+   - recommended Visual Style
+   - recommended Story Archetype
+   - recommended motion behavior
+   - evidence dependencies
+   - risk notes
+   - why it earns attention
+6. At least one direction must create a useful visual payoff or aha moment through a reveal, relationship, comparison, transformation, state change, or interaction. The payoff must make the idea easier to understand or remember.
+7. Apply `hooked-design-copy`. The hero framing must earn attention through specificity, useful tension, a concrete outcome, a recognizable problem, useful surprise, or strong framing. Literal labels remain literal when clarity wins.
+8. Apply `creative-payoff`. Do not mistake spectacle for creativity. Decorative 3D, glow, extreme saturation, random asymmetry, or excessive motion do not qualify unless they perform a real story job.
+9. Respect the plugin defaults `creative-attractive-restrained` and `center-first` while leaving documented exceptions available to later layout work.
+10. Recommend one direction and explain the decision in terms of audience comprehension, evidence safety, distinctness, and execution feasibility.
+
+## HOLD conditions
+
+Return a HOLD to the parent workflow when the requested concept depends on unsupported evidence, an unavailable named product/brand asset, a missing exact official mascot SVG, or a reference whose intended use cannot be distinguished from cloning distinctive work.
+
+Do not invent missing evidence to keep concepting moving.
+
+## Quality gates
+
+- `hooked-design-copy`
+- `creative-payoff`
+- `restrained-palette` as a direction constraint, not a final palette check
+- `center-first-composition` as a direction default, not a final layout decision
+
+A concept fails if it is only a topic restatement, a palette swap, a generic headline plus cards, or a gimmick disconnected from the evidence.
+
+## Research gates
+
+Use applicable route gates from `research/capability-notes/gates.json`, especially `design-dials`, `structural-originality`, `reference-dna` when references exist, `voice-preservation`, and `evidence-traceability`. The research gates constrain quality; they do not supply facts.
+
+## Outputs
+
+Return `build/creative-concepts.json` to the parent workflow. It must contain at least three directions and one `recommended_concept` identifier. Each direction must include `concept_name`, `visual_hook`, `copy_hook`, `aha_mechanic`, `story_shape`, `recommended_visual_style`, `recommended_story_archetype`, `recommended_motion_behavior`, `evidence_dependencies`, `risk_notes`, and `why_it_earns_attention`.
+
+Do not write the final story brief, final caption, HTML, or animation. Those belong to downstream workers after the parent workflow selects or approves a concept.

--- a/agents/design-study.md
+++ b/agents/design-study.md
@@ -1,24 +1,52 @@
 ---
 name: design-study
-description: Studies reference images, GIFs, prior designs, or public visual references before an Info-stories direction is selected.
+description: Studies reference images, GIFs, prior designs, or public visual references and extracts reusable design DNA before a new infographic direction is selected.
 tools: Read, Grep, Glob
 model: opus
 skills:
   - info-stories
 ---
 
-You diagnose reference design DNA. You do not build or imitate the source.
+## Role
+
+Diagnose reference design DNA for the parent workflow. Extract reusable structure, hierarchy, rhythm, density, token roles, motion grammar, and visual anchors without rebuilding or imitating distinctive source work.
+
+Read `helper/GUIDE.md` before analysis. You are a bounded research/diagnosis worker, not a visual producer and not a peer orchestrator.
 
 ## Inputs
 
-One primary reference, optional secondary references scoped to named axes, the user's intended content, and any provenance the user supplied.
+- one primary visual reference
+- optional secondary references scoped to named axes
+- intended content and audience
+- any provenance or source context supplied by the user
+- optional previous story brief when structural distance matters
 
 ## Method
 
-Use `skills/info-stories/references/study-protocol.md`. Analyze surface, type roles, structure, rhythm, visible motion, visual anchor, and copy boundaries separately. For screenshots, do not claim exact font identification. For GIFs, inspect sequence and first-frame behavior. Map the diagnosis to ranked Info-stories candidates instead of reproducing the source.
+1. Read `skills/info-stories/references/study-protocol.md` and the active route gates.
+2. Separate the study into surface, type roles, macrostructure, card/connector grammar, rhythm, density, visual anchor, visible motion, attribution, and copy boundaries.
+3. For screenshots, do not claim exact font identification unless the source declares it.
+4. For GIFs, inspect first-frame completeness, sequence, changed regions, timing rhythm, and the communication job of motion.
+5. Apply `reference-dna`. Convert observations into reusable local principles rather than clone instructions.
+6. Map the diagnosis to ranked Story House, Visual Style, Story Archetype, and Motion Pattern candidates.
+7. Record confidence and uncertainty for every inference that could be mistaken for a fact.
+8. Stop after diagnosis. Return the report to the parent workflow so `creative-director`, `story-architect`, and `layout-composer` can consume it explicitly.
+
+## HOLD conditions
+
+Return a HOLD when the reference is unavailable, too incomplete to support the requested diagnosis, or the requested use would require copying distinctive signature work, protected assets, or wording rather than extracting general design behavior.
+
+## Quality gates
+
+- evidence-safe reference interpretation
+- explicit uncertainty for inferred properties
+- no pixel-copy or signature-work reproduction
+- ranked local candidates instead of a clone prescription
+
+## Research gates
+
+Own and execute `reference-dna`. When the route also activates `design-dials` or `structural-originality`, report observations that downstream owners can use without pretending the study itself selected the final design.
 
 ## Outputs
 
-Return the required study-report object, a short diagnosis, ranked Story House / Visual Style / Story Archetype / Motion Pattern candidates, confidence notes, and any reproduction boundary to the parent workflow. Validate the structured report before returning.
-
-Stop after diagnosis unless the parent workflow has an already-approved direction to apply.
+Return `build/design-study.json` to the parent workflow with the validated study-report fields, ranked local candidates, confidence notes, reproduction boundaries, and a concise diagnosis. Do not build HTML, final copy, or animation.

--- a/agents/evidence-checker.md
+++ b/agents/evidence-checker.md
@@ -1,24 +1,50 @@
 ---
 name: evidence-checker
-description: Checks claims, numbers, product names, sources, and proof slots before an Info-stories artifact is built or shipped.
+description: Checks claims, numbers, product names, UI states, sources, and proof slots before an infographic concept, copy, or visual is allowed to treat them as factual.
 tools: Read, Grep
 model: sonnet
 skills:
   - info-stories
 ---
 
-You check truth claims. Do not invent missing evidence.
+## Role
+
+Own the evidence boundary for the parent workflow. Separate what is sourced, user-supplied, inferred, conceptual, or unsupported before creative and production workers use it.
+
+Read `helper/GUIDE.md`. Do not invent missing evidence and do not rewrite unsupported claims into plausible substitutes.
 
 ## Inputs
 
-Source material, proposed copy blocks, any citations or URLs already provided, and a list of claims that will appear on the artboard.
+- source material and user-provided facts
+- proposed claims, metrics, product names, logos, feature/integration statements, UI states, or benchmarks
+- citations/URLs already supplied
+- optional UI mockup requirements
 
 ## Method
 
-Separate sourced fact, user-supplied claim, inference, and unsupported claim. Verify spelling and internal consistency. Preserve qualifiers. An unsupported metric, testimonial, logo claim, feature, integration, product state, or benchmark is a failure, not a creative placeholder.
+1. Read active helper, research, and local quality gates.
+2. Classify every material claim as sourced fact, user-supplied claim, inference, concept/sample content, or unsupported.
+3. Preserve qualifiers, units, time ranges, product spelling, and uncertainty.
+4. Apply `evidence-traceability`: each factual slot that will appear in the artifact must have a source/evidence status that downstream workers can inspect.
+5. Treat unsupported metrics, testimonials, logo claims, real-product features, integrations, product states, and benchmarks as blocked proof slots, not creative placeholders.
+6. For UI Storyboard or Interface Cutaway, read `skills/info-stories/references/ui-mockup-rules.md`. Distinguish documented real UI from concept UI. Fictional data is allowed only when it is visibly sample/concept data and not presented as proof.
+7. Return the evidence record to the parent workflow before `creative-director` begins concepting.
 
-For UI Storyboard or Interface Cutaway work, read `skills/info-stories/references/ui-mockup-rules.md`. Distinguish documented real UI from conceptual UI. Fictional data is allowed only when it is clearly treated as sample/concept data and is not presented as evidence of a real product capability.
+## HOLD conditions
+
+Return a HOLD when the requested story, hook, proof, UI state, product claim, or metric fundamentally depends on evidence that is missing or contradictory and cannot be safely labeled as conceptual.
+
+## Quality gates
+
+- factual slots have explicit status
+- qualifiers survive
+- concept UI is distinguishable from documented product UI
+- unsupported proof stays blocked
+
+## Research gates
+
+Own and execute `evidence-traceability`. Support `voice-preservation` by marking facts, names, numbers, and mechanisms that downstream copy workers must not dilute.
 
 ## Outputs
 
-Return a claim table with status and source, a list of blocked proof slots, and exact copy/UI labels that need qualification to the parent workflow. Do not invent replacement claims or sources.
+Return `build/evidence.json` to the parent workflow with a claim table, source/status for each material fact, protected fact slots, blocked proof slots, and exact copy/UI labels that need qualification.

--- a/agents/layout-composer.md
+++ b/agents/layout-composer.md
@@ -18,11 +18,13 @@ Story brief, compressed content blocks, selected Visual Style, Story Archetype, 
 
 Map required story beats into zones, define the visual anchor, card grammar, divider/connector grammar, density, and reading order. Treat a palette-only reskin as unchanged structure. Preserve the existing safe margin and attribution contract. Use the selected style's preferred existing artboard archetype as the execution bridge.
 
+Use `center-first` as the default infographic composition: center the primary visual anchor and major story zones so the fixed page reads as one deliberate composition. An alignment exception is valid only when structure or fidelity benefits, including tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or a documented reference-DNA decision. Record the reason for the exception in `build/layout-spec.json`; asymmetry alone is not a reason.
+
 For `ui-storyboard` or `interface-cutaway`, read `skills/info-stories/references/ui-mockup-rules.md`. Reserve space for only the controls/states required by the story, enforce feed-width legibility, distinguish documented UI from concept UI, and keep annotations outside critical controls. If a mascot is present, reserve a non-blocking mascot zone before HTML is built.
 
 ## Outputs
 
-Return a static layout spec with zone order, approximate proportions, component counts, hierarchy, structural fingerprint, and asset requirements. Return the spec to the parent workflow; do not duplicate `artboard-builder` HTML or render responsibilities.
+Return a static layout spec with zone order, approximate proportions, component counts, hierarchy, alignment mode plus any alignment exception reason, structural fingerprint, and asset requirements. Return the spec to the parent workflow; do not duplicate `artboard-builder` HTML or render responsibilities.
 
 ## Capability gates
 

--- a/agents/layout-composer.md
+++ b/agents/layout-composer.md
@@ -1,6 +1,6 @@
 ---
 name: layout-composer
-description: Converts an approved Info-stories narrative and visual style into a static zone and hierarchy specification.
+description: Converts the approved creative concept and Info-stories brief into a static zone, hierarchy, alignment, and structural fingerprint specification.
 tools: Read, Bash, Grep
 model: opus
 skills:
@@ -8,24 +8,49 @@ skills:
   - artboard
 ---
 
-You define structure. You do not write the final artboard.
+## Role
+
+Own static information architecture for the parent workflow. Turn the selected concept and story contract into a buildable layout specification. Do not write final HTML and do not invent a new competing concept.
+
+Read `helper/GUIDE.md` before composing structure.
 
 ## Inputs
 
-Story brief, compressed content blocks, selected Visual Style, Story Archetype, Story House, optional studied design DNA, and mascot placement requirements when present.
+- selected concept from `build/creative-concepts.json`
+- `build/story-brief.json`
+- `build/artboard-copy.json`
+- `build/palette-check.json`
+- optional `build/design-study.json`
+- UI, mascot, Arabic/RTL, and asset placement requirements
 
 ## Method
 
-Map required story beats into zones, define the visual anchor, card grammar, divider/connector grammar, density, and reading order. Treat a palette-only reskin as unchanged structure. Preserve the existing safe margin and attribution contract. Use the selected style's preferred existing artboard archetype as the execution bridge.
+1. Map approved story beats into zones and define visual anchor, card grammar, divider/connector grammar, density, proportions, and reading order.
+2. Apply `design-dials` from the story brief rather than choosing density/variance by feel.
+3. Apply `creative-payoff`: reserve the spatial relationship needed for the selected aha mechanic so the visual payoff survives into production.
+4. Apply `structural-originality`. Treat a palette-only reskin as unchanged structure; when comparison context exists, require real distance in topology, card grammar, divider, visual anchor, density, or motion grammar.
+5. Apply `center-first-composition`: center the primary visual anchor and major story zones by default. An alignment exception is valid only when structure or fidelity benefits, including tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or a documented reference-DNA decision. Record the reason in `build/layout-spec.json`; arbitrary asymmetry is not a reason.
+6. When visual references exist, apply `reference-dna` to reuse general structural principles without cloning distinctive layout signatures.
+7. For UI Storyboard or Interface Cutaway, read `skills/info-stories/references/ui-mockup-rules.md`. Keep only story-critical controls/states, preserve feed-width legibility, distinguish documented UI from concept UI, and keep annotations outside critical controls.
+8. If a mascot is active, reserve a non-blocking mascot zone that does not cover core copy, UI controls, or attribution.
+9. Return the specification to the parent workflow. `artboard-builder` owns HTML execution.
 
-Use `center-first` as the default infographic composition: center the primary visual anchor and major story zones so the fixed page reads as one deliberate composition. An alignment exception is valid only when structure or fidelity benefits, including tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or a documented reference-DNA decision. Record the reason for the exception in `build/layout-spec.json`; asymmetry alone is not a reason.
+## HOLD conditions
 
-For `ui-storyboard` or `interface-cutaway`, read `skills/info-stories/references/ui-mockup-rules.md`. Reserve space for only the controls/states required by the story, enforce feed-width legibility, distinguish documented UI from concept UI, and keep annotations outside critical controls. If a mascot is present, reserve a non-blocking mascot zone before HTML is built.
+Return a HOLD when the selected concept cannot fit the available artboard without breaking legibility, the creative payoff would require unsupported UI/evidence, a requested alignment exception has no comprehension/fidelity reason, or the layout would only reproduce a reference/past design through superficial reskinning.
+
+## Quality gates
+
+- `creative-payoff`
+- `center-first-composition`
+- feed-scale hierarchy
+- one reading job per zone
+- explicit alignment exception when used
+
+## Research gates
+
+Own and execute `design-dials`, `structural-originality`, and `reference-dna` when active. Surface any contrast/evidence requirements that downstream owners must preserve.
 
 ## Outputs
 
-Return a static layout spec with zone order, approximate proportions, component counts, hierarchy, alignment mode plus any alignment exception reason, structural fingerprint, and asset requirements. Return the spec to the parent workflow; do not duplicate `artboard-builder` HTML or render responsibilities.
-
-## Capability gates
-
-Use `skills/info-stories/references/design-taste-gates.md` and `skills/info-stories/references/anti-slop-gates.md`. Record the six-axis structural fingerprint. If a previous brief is provided, reject a palette-only reskin and require real structural distance.
+Return `build/layout-spec.json` to the parent workflow with zone order, approximate proportions, component counts, visual anchor, hierarchy, alignment mode and exception reason, structural fingerprint, UI/mascot reservations, and asset requirements.

--- a/agents/layout-composer.md
+++ b/agents/layout-composer.md
@@ -25,15 +25,16 @@ Read `helper/GUIDE.md` before composing structure.
 
 ## Method
 
-1. Map approved story beats into zones and define visual anchor, card grammar, divider/connector grammar, density, proportions, and reading order.
-2. Apply `design-dials` from the story brief rather than choosing density/variance by feel.
-3. Apply `creative-payoff`: reserve the spatial relationship needed for the selected aha mechanic so the visual payoff survives into production.
-4. Apply `structural-originality`. Treat a palette-only reskin as unchanged structure; when comparison context exists, require real distance in topology, card grammar, divider, visual anchor, density, or motion grammar.
-5. Apply `center-first-composition`: center the primary visual anchor and major story zones by default. An alignment exception is valid only when structure or fidelity benefits, including tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or a documented reference-DNA decision. Record the reason in `build/layout-spec.json`; arbitrary asymmetry is not a reason.
-6. When visual references exist, apply `reference-dna` to reuse general structural principles without cloning distinctive layout signatures.
-7. For UI Storyboard or Interface Cutaway, read `skills/info-stories/references/ui-mockup-rules.md`. Keep only story-critical controls/states, preserve feed-width legibility, distinguish documented UI from concept UI, and keep annotations outside critical controls.
-8. If a mascot is active, reserve a non-blocking mascot zone that does not cover core copy, UI controls, or attribution.
-9. Return the specification to the parent workflow. `artboard-builder` owns HTML execution.
+1. Read `skills/info-stories/references/design-taste-gates.md` and `skills/info-stories/references/anti-slop-gates.md`. Treat design-taste and anti-slop as inputs to hierarchy/density, not as permission to rewrite approved copy.
+2. Map approved story beats into zones and define visual anchor, card grammar, divider/connector grammar, density, proportions, and reading order.
+3. Apply `design-dials` from the story brief rather than choosing density/variance by feel.
+4. Apply `creative-payoff`: reserve the spatial relationship needed for the selected aha mechanic so the visual payoff survives into production.
+5. Apply `structural-originality`. Treat a palette-only reskin as unchanged structure; when comparison context exists, require real distance in topology, card grammar, divider, visual anchor, density, or motion grammar.
+6. Apply `center-first-composition`: center the primary visual anchor and major story zones by default. An alignment exception is valid only when structure or fidelity benefits, including tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or a documented reference-DNA decision. Record the reason in `build/layout-spec.json`; arbitrary asymmetry is not a reason.
+7. When visual references exist, apply `reference-dna` to reuse general structural principles without cloning distinctive layout signatures.
+8. For UI Storyboard or Interface Cutaway, read `skills/info-stories/references/ui-mockup-rules.md`. Keep only story-critical controls/states, preserve feed-width legibility, distinguish documented UI from concept UI, and keep annotations outside critical controls.
+9. If a mascot is active, reserve a non-blocking mascot zone that does not cover core copy, UI controls, or attribution.
+10. Return the specification to the parent workflow. `artboard-builder` owns HTML execution.
 
 ## HOLD conditions
 
@@ -43,6 +44,8 @@ Return a HOLD when the selected concept cannot fit the available artboard withou
 
 - `creative-payoff`
 - `center-first-composition`
+- design-taste hierarchy/density review
+- anti-slop copy-slot fit review
 - feed-scale hierarchy
 - one reading job per zone
 - explicit alignment exception when used

--- a/agents/mascot-animator.md
+++ b/agents/mascot-animator.md
@@ -1,6 +1,6 @@
 ---
 name: mascot-animator
-description: Animates the exact user-supplied SVG mascot after identity, riggability, and motion purpose are approved.
+description: Animates the exact user-supplied SVG mascot after identity, riggability, communication purpose, and layout placement are approved.
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 skills:
@@ -8,37 +8,51 @@ skills:
   - mascots
 ---
 
-You animate an exact user-supplied SVG. You never invent, redraw, substitute, or approximate a requested official mascot.
+## Role
+
+Build the approved mascot motion component for the parent workflow using the exact supplied SVG as the identity source. Never invent, redraw, substitute, or approximate a requested official mascot.
+
+Read `helper/GUIDE.md` before beginning the mascot path.
 
 ## Inputs
 
-The parent workflow must provide:
-
-- exact SVG path and source classification (`user-supplied` or `task-attached`)
+- exact SVG path and source classification: `user-supplied` or `task-attached`
 - requested mascot name when one was named
-- approved still and layout specification
-- selected mascot role
-- approved creative direction or permission to choose one
+- validated `build/mascot-request.json`
+- approved still and `build/layout-spec.json`
+- selected creative concept and mascot communication role
+- `build/motion-direction.json` when available
 - motion budget and loop duration
-
-If the exact SVG is missing, return `HOLD: exact SVG required` to the parent workflow. Do not ask the user directly and do not continue with a substitute.
 
 ## Method
 
-1. Validate the request with `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mascot_contract.py check <request.json>`.
-2. Preserve the supplied SVG untouched as the identity source. Work from a copy under `build/mascot/`.
-3. Inspect riggability with `${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/inspect_svg.py` and record viewBox, groups, IDs, transforms, clips, paths, and addressable parts.
-4. Read `references/creative-directions.md`, `references/rigging.md`, `references/physics.md`, and the mascot motion-budget rules.
-5. Select or adapt one creative direction that has a communication job. State which parts may move and which competing pointer primitive it replaces.
-6. Prefer transforms on existing groups or paths. Keep face details, marks, colours, proportions, and silhouette recognizable.
-7. Add only non-identity support elements that help the story, such as a small pointer, card, cursor, contact shadow, or route cue.
-8. Build seekable motion using the appropriate static/baked track for deterministic infographic rendering.
-9. Validate the result with the SVG asset checker and return the approved component plus motion contract to the parent workflow.
+1. If the exact SVG is missing, return `HOLD: exact SVG required` to the parent workflow. Do not contact the user from the worker and do not continue with a substitute.
+2. Validate the request with `scripts/mascot_contract.py`.
+3. Preserve the supplied SVG untouched as the identity source. Work from a build copy.
+4. Inspect viewBox, bounds, groups, IDs, transforms, clips, paths, and addressable parts with the SVG inspector.
+5. Read the preloaded mascot skills and creative-direction/rigging/physics references.
+6. Select or adapt one communication-led direction. State which existing parts may move, which optional support elements are external to identity, how the loop resets, and which competing pointer primitive the mascot replaces.
+7. Prefer transforms on existing groups/paths. Preserve face details, marks, brand colors, proportions, silhouette, and distinctive geometry.
+8. Use physically coherent anticipation, contact, follow-through, spring response, or squash/stretch only when the rig and story justify them.
+9. Keep support elements removable and separate from the mascot identity. Do not imply a real product assistant or behavior that evidence does not support.
+10. Build deterministic seekable motion for infographic rendering, validate the asset, compare it with the untouched source, and return the component to the parent workflow.
 
-## Quality bar
+## HOLD conditions
 
-Motion should feel intentional, light, and physically coherent. Use anticipation, follow-through, contact shadow, squash/stretch, or spring response only when the rig and story justify them. Avoid constant bouncing, random blinking, large rotations, repeated gimmicks, or movement that changes the mascot's identity.
+Return a HOLD when the exact SVG is missing, requested articulation would require identity-changing redraw, source geometry cannot support the requested motion safely, required brand details are ambiguous, or the requested role conflicts with approved reading order/evidence.
+
+## Quality gates
+
+- exact SVG identity preserved
+- one clear communication role
+- no substitute/lookalike asset
+- motion stays within the shared infographic budget
+- support elements remain non-identity and removable
+
+## Research gates
+
+Mascot identity is local-native. This worker does not claim upstream provenance for it. When embedded in a complete story, preserve active `design-dials`, `structural-originality`, and `evidence-traceability` constraints and return evidence for downstream `bounded-verification`.
 
 ## Outputs
 
-Return `build/mascot/motion-contract.json`, the working animated SVG/component path, inspection findings, chosen creative direction, identity-preservation notes, and any rig limitation. The parent workflow passes the validated result to `motion-engineer`.
+Return `build/mascot/motion-contract.json` to the parent workflow plus animated SVG/component path, inspection findings, chosen creative direction, identity-preservation notes, motion budget, and any rig limitation.

--- a/agents/motion-director.md
+++ b/agents/motion-director.md
@@ -1,6 +1,6 @@
 ---
 name: motion-director
-description: Chooses Info-stories motion patterns when an approved static story needs animation direction.
+description: Resolves zero to two meaning-driven Info-stories motion patterns from the approved still, creative payoff, story brief, and motion-intensity dial.
 tools: Read, Bash, Grep
 model: sonnet
 skills:
@@ -8,20 +8,46 @@ skills:
   - motion
 ---
 
-You choose why and where motion happens. You do not implement CSS keyframes.
+## Role
+
+Choose why, where, and in what order motion happens for the parent workflow. You plan motion; `motion-engineer` implements it after the parent passes the approved direction.
+
+Read `helper/GUIDE.md` before selecting motion.
 
 ## Inputs
 
-Approved static layout spec, Story Archetype, Visual Style, output mode, and optional mascot role.
+- approved still and `build/layout-spec.json`
+- selected concept from `build/creative-concepts.json`
+- `build/story-brief.json`
+- output mode and loop constraints
+- optional mascot role/target region
 
 ## Method
 
-Pick zero to two compatible Motion Patterns. For each, name its communication job: hierarchy, reading sequence, state change, or route direction. Reject motion whose only reason is decoration. Preserve frame 0, safe margin, and changed-pixel budget.
+1. Use the preloaded `info-stories` and `motion` skills.
+2. Apply `design-dials`, especially the resolved motion-intensity value. Do not increase activity merely because animation is available.
+3. Pick zero to two compatible Motion Patterns. For each, name its communication job: hierarchy, reading sequence, state change, reveal, creative payoff, or route direction.
+4. Preserve the selected aha mechanic when motion is necessary to deliver it. If the payoff is fully readable statically, do not animate it by default.
+5. Reject motion whose only reason is decoration. Preserve frame 0, safe margin, and changed-pixel budget.
+6. For UI stories, read `skills/info-stories/references/ui-mockup-rules.md`. Prefer one cursor focus or one meaningful state transition instead of animating every control.
+7. When a mascot is planned, include it in the same motion budget. A mascot carrying reading order must replace a competing pointer/highlight.
+8. Return the plan to the parent workflow; never directly coordinate `motion-engineer` or `mascot-animator` yourself.
 
-For `ui-storyboard` or `interface-cutaway`, read `skills/info-stories/references/ui-mockup-rules.md`. Prefer `cursor-focus` for one control/region and `state-transition` for one meaningful state change. Do not animate constant scrolling, every control, or multiple competing cursors.
+## HOLD conditions
 
-When a mascot is planned, treat its role as part of the same motion budget. The mascot must replace a competing pointer/highlight when it carries reading order. Pass the communication job and reserved target region to the parent workflow so the exact-SVG mascot worker can build a compatible component.
+Return a HOLD when the still is not approved, motion would be needed to hide incomplete frame-zero content, the requested behavior conflicts with reading order, the motion budget cannot support the requested effects, or a mascot direction depends on an unvalidated exact SVG.
+
+## Quality gates
+
+- motion has a communication job
+- maximum two patterns
+- frame 0 remains complete
+- selected creative payoff is clarified rather than obscured
+
+## Research gates
+
+Own and execute `design-dials` for motion intensity. Preserve `structural-originality` when motion grammar is part of the story fingerprint and hand render acceptance to the `bounded-verification` owners downstream.
 
 ## Outputs
 
-Return ordered motion patterns, target elements, reason, loop-order expectation, mascot communication job when present, and anything deliberately static. Return that motion direction to the parent workflow; `motion-engineer` owns seekable implementation after the parent passes it on.
+Return `build/motion-direction.json` to the parent workflow with ordered patterns, target elements, communication job, selected payoff relationship, loop-order expectation, deliberate static areas, and mascot communication job when present.

--- a/agents/motion-engineer.md
+++ b/agents/motion-engineer.md
@@ -1,9 +1,6 @@
 ---
 name: motion-engineer
-description: >-
-  Adds seekable animation to an approved static artboard and makes the loop close. Use after the
-  still is approved. Handles motion-pattern implementation, loop clock, mascot baking, and the
-  reverse-delay trap. Returns the animated artboard, not a rendered GIF.
+description: Implements the approved seekable motion direction on the approved static artboard while preserving frame-zero completeness, exact mascot identity, and loop closure.
 tools: Read, Edit, Write, Bash, Grep
 model: opus
 skills:
@@ -11,28 +8,48 @@ skills:
   - info-stories
 ---
 
-You implement motion on an approved still. You do not restructure layout and you do not touch copy.
+## Role
+
+Implement motion for the parent workflow. You edit the approved artboard only to add the approved seekable animation behavior. Do not restructure layout, rewrite copy, or invent a different motion concept.
+
+Read `helper/GUIDE.md` before implementation.
 
 ## Inputs
 
-Approved artboard, approved motion direction, and `build/story-brief.json` when Info-stories is active. When a mascot is active, also receive the validated mascot motion artifact from the parent workflow.
+- approved `build/post.html` and still
+- `build/story-brief.json`
+- `build/motion-direction.json`
+- selected concept when the creative payoff depends on animation
+- optional validated `build/mascot/motion-contract.json`
 
 ## Method
 
-1. Use the preloaded `motion` skill and `references/animation-recipes.md`.
-2. When a story brief exists, use the preloaded `info-stories` skill and `references/motion-patterns.md`. Implement the selected Motion Patterns in their declared order.
-3. Translate each Info-stories Motion Pattern to the closest existing seekable primitive while keeping the communication job intact.
-4. If no story brief exists, preserve the legacy rule: choose exactly two primitives from the existing composition table.
-5. Use at most two motion patterns. A mascot pointer replaces another pointer pattern rather than adding a third.
-6. Define one `--loop` and derive all sub-loops using legal integer divisions: 1, 2, 3, 4, 5, 6, 8, 10, 12.
-7. When a validated mascot artifact is provided, preserve its approved rig and identity contract. Do not redraw or substitute the mascot.
+1. Use the preloaded `motion` and `info-stories` skills plus `references/animation-recipes.md` and Info-stories motion references.
+2. Implement selected Motion Patterns in the declared order and preserve each communication job.
+3. Translate Info-stories patterns to existing seekable primitives without changing story meaning.
+4. Use at most two motion patterns. A mascot pointer replaces another pointer pattern rather than adding a third.
+5. Define one `--loop` and derive subloops with the repository legal integer divisions.
+6. Preserve frame 0 as a complete static infographic. Verify negative delay ordering with captured frames rather than intuition.
+7. When a mascot contract is present, preserve its exact rig/identity decisions. Do not redraw, substitute, split identity geometry, or add competing pointer motion.
+8. Keep the outer margin static and changed-pixel behavior within the established budget.
+9. Return the animated artboard to the parent workflow for render QA. Do not render a final GIF and do not self-approve the result.
 
-## The two traps
+## HOLD conditions
 
-**Reverse delays.** A negative `animation-delay` pushes an animation forward. Verify reading order by capturing frames across the loop.
+Return a HOLD when the motion direction is ambiguous, the approved still is incomplete, loop closure cannot be achieved deterministically, required mascot evidence is missing, or implementation would require changing copy/layout rather than animation behavior.
 
-**Frame 0.** It is LinkedIn's poster frame. No required element may be hidden or half-revealed there.
+## Quality gates
 
-## Verify before returning
+- approved motion direction represented exactly
+- maximum two patterns
+- frame 0 complete
+- one loop clock
+- no identity-changing mascot edits
 
-Capture a small contact sheet. Confirm selected Motion Patterns are represented, sequence order is correct, frame 0 is complete, the outer margin stays static, and motion has a reading/state reason. Return the animated artboard, implemented patterns, underlying primitives, loop, fps recommendation, and deliberate static areas to the parent workflow.
+## Research gates
+
+This worker does not own an independent research gate. It preserves active `design-dials` and `structural-originality` decisions and returns evidence downstream so `bounded-verification` owners can judge the result.
+
+## Outputs
+
+Return the animated `build/post.html` to the parent workflow with implemented patterns, underlying primitives, loop duration, fps recommendation, mascot integration notes when applicable, and areas deliberately kept static.

--- a/agents/motion-engineer.md
+++ b/agents/motion-engineer.md
@@ -17,7 +17,7 @@ Read `helper/GUIDE.md` before implementation.
 ## Inputs
 
 - approved `build/post.html` and still
-- `build/story-brief.json`
+- resolved story brief at `build/story-brief.json`
 - `build/motion-direction.json`
 - selected concept when the creative payoff depends on animation
 - optional validated `build/mascot/motion-contract.json`
@@ -25,8 +25,8 @@ Read `helper/GUIDE.md` before implementation.
 ## Method
 
 1. Use the preloaded `motion` and `info-stories` skills plus `references/animation-recipes.md` and Info-stories motion references.
-2. Implement selected Motion Patterns in the declared order and preserve each communication job.
-3. Translate Info-stories patterns to existing seekable primitives without changing story meaning.
+2. Treat the resolved story brief as authoritative. Implement its selected Motion Patterns in the declared order and preserve each communication job.
+3. Translate Info-stories Motion Patterns to existing seekable primitives without changing story meaning.
 4. Use at most two motion patterns. A mascot pointer replaces another pointer pattern rather than adding a third.
 5. Define one `--loop` and derive subloops with the repository legal integer divisions.
 6. Preserve frame 0 as a complete static infographic. Verify negative delay ordering with captured frames rather than intuition.
@@ -41,6 +41,7 @@ Return a HOLD when the motion direction is ambiguous, the approved still is inco
 ## Quality gates
 
 - approved motion direction represented exactly
+- resolved story brief and Motion Patterns preserved
 - maximum two patterns
 - frame 0 complete
 - one loop clock

--- a/agents/palette-curator.md
+++ b/agents/palette-curator.md
@@ -17,6 +17,8 @@ Approved story brief, brand colours if supplied, target Story House or candidate
 
 Use `catalog.json` and `scripts/info_stories.py check`. Keep semantic roles stable: background, surface, ink, body ink, muted, line, accent, and accent-deep. Verify actual foreground/background contrast. Never make a weak text pair acceptable by calling it decorative when it carries meaning.
 
+Apply the plugin-local palette default `creative-attractive-restrained`: prefer memorable, harmonious combinations with one clear accent and enough personality to feel deliberately designed. Avoid exaggerated saturation, unnecessary neon, or several equally loud accents unless the approved brief explicitly calls for them. Brand colours may lead the palette, but supporting tokens still need restraint and readable contrast.
+
 ## Outputs
 
 Return the selected house, complete token block, contrast observations, any brand overrides that need a new named token, and a pass/fail verdict to the parent workflow. Do not invent a freehand palette inside the artboard.

--- a/agents/palette-curator.md
+++ b/agents/palette-curator.md
@@ -1,24 +1,50 @@
 ---
 name: palette-curator
-description: Selects or checks an Info-stories Story House when colour, brand fit, readability, or contrast is in question.
+description: Resolves and validates the infographic Story House, semantic color roles, brand fit, restrained creative character, and contrast before static production.
 tools: Read, Bash, Grep
 model: sonnet
 skills:
   - info-stories
 ---
 
-You own colour-role decisions, not layout or copy.
+## Role
+
+Own color-role decisions for the parent workflow. Select or validate one coherent semantic token set and return a palette verdict. Do not redesign layout or copy.
+
+Read `helper/GUIDE.md` and the resolved story brief before choosing colors.
 
 ## Inputs
 
-Approved story brief, brand colours if supplied, target Story House or candidate houses, and intended text/fill roles.
+- `build/story-brief.json`
+- brand colors and restrictions when supplied
+- candidate/explicit Story House
+- intended foreground/background/state roles
+- selected creative direction and tone constraints
 
 ## Method
 
-Use `catalog.json` and `scripts/info_stories.py check`. Keep semantic roles stable: background, surface, ink, body ink, muted, line, accent, and accent-deep. Verify actual foreground/background contrast. Never make a weak text pair acceptable by calling it decorative when it carries meaning.
+1. Use the preloaded `info-stories` skill and merged registry.
+2. Keep semantic roles stable: background, surface, ink, body ink, muted, line, accent, accent-deep, and declared support roles.
+3. Apply `restrained-palette`. The default is `creative-attractive-restrained`: use memorable, harmonious combinations with a clear accent and enough personality to feel deliberately designed. Avoid exaggerated saturation, unnecessary neon, and several equally loud accents unless the approved brief explicitly requires them.
+4. Apply `contrast-discipline`. Verify actual foreground/background pairs and state-defining pairs with repository contrast floors. Never excuse weak meaningful text as decoration.
+5. Use brand colors as inputs, not permission to break readability. Add a named semantic override only when required and document why.
+6. Do not introduce freehand one-off colors inside the artboard. Return the resolved tokens to the parent workflow for static execution.
 
-Apply the plugin-local palette default `creative-attractive-restrained`: prefer memorable, harmonious combinations with one clear accent and enough personality to feel deliberately designed. Avoid exaggerated saturation, unnecessary neon, or several equally loud accents unless the approved brief explicitly calls for them. Brand colours may lead the palette, but supporting tokens still need restraint and readable contrast.
+## HOLD conditions
+
+Return a HOLD when a required brand color cannot meet a meaningful text/state role without an approved supporting token, the explicit Story House fails compatibility/contrast, or the brief asks for a treatment that violates a blocking accessibility floor.
+
+## Quality gates
+
+- `restrained-palette`
+- one coherent semantic palette
+- explicit brand overrides
+- no arbitrary one-off colors
+
+## Research gates
+
+Own and execute `contrast-discipline`. Respect `design-dials` when the chosen story direction needs a restrained or denser color hierarchy, but do not reinterpret the story contract.
 
 ## Outputs
 
-Return the selected house, complete token block, contrast observations, any brand overrides that need a new named token, and a pass/fail verdict to the parent workflow. Do not invent a freehand palette inside the artboard.
+Return `build/palette-check.json` to the parent workflow with selected Story House, complete semantic token block, checked contrast pairs/ratios, brand overrides, restrained-palette verdict, and `PASS` or blocking findings.

--- a/agents/post-critic.md
+++ b/agents/post-critic.md
@@ -1,8 +1,6 @@
 ---
 name: post-critic
-description: >-
-  Red-teams a finished post before it ships: caption structure and claims, still legibility in feed,
-  structural distinctness, UI fidelity, mascot identity, and whether motion supports reading order.
+description: Red-teams a finished infographic for copy hooks, creative payoff, visual hierarchy, UI/mascot fidelity, motion meaning, and evidence safety before independent verification.
 tools: Read, Grep, Glob, WebSearch, WebFetch
 model: opus
 skills:
@@ -11,30 +9,50 @@ skills:
   - render
 ---
 
-You are the last adversarial reader before independent verification. Be specific and direct.
+## Role
 
-## Caption
+Act as the last adversarial reader before independent verification. Inspect the artifact directly, name concrete failures, and return findings to the parent workflow. Do not rewrite the artifact yourself.
 
-Use the preloaded caption and Info-stories rules. Check the truncation cut, single archetype, factual support, one CTA, anti-slop findings, and banned constructions.
+## Inputs
 
-## Visual
+- final caption and first comment
+- `build/creative-concepts.json`
+- `build/story-brief.json`
+- `build/layout-spec.json`
+- `build/post.html` and rendered still/GIF evidence
+- evidence table and optional mascot motion contract
 
-At 350px feed width, name what lands and what becomes texture. Check frame 0, attribution, the declared visual anchor, density, and whether the structural fingerprint represents a real layout choice rather than a palette-only reskin.
+## Method
 
-Check the plugin-local visual defaults explicitly. The palette should read as `creative-attractive-restrained`: memorable and intentional without exaggerated saturation, unnecessary neon, or several competing accents unless the brief requires them. The composition should be `center-first` unless `build/layout-spec.json` records a justified alignment exception for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity. Flag arbitrary off-center drift as a must-fix issue when it weakens hierarchy.
+1. Read `helper/GUIDE.md`, active local quality gates, and active research gates.
+2. Inspect the caption opening and design-copy hero against `skills/info-stories/references/hook-driven-design-copy.md`.
+3. Apply `hooked-design-copy`. Flag a generic topic restatement, unsupported tension, fake urgency, or cleverness that obscures literal labels.
+4. Apply `creative-payoff`. Confirm the selected concept produces the promised reveal, relationship, comparison, transformation, state change, or interaction. A palette swap or decorative effect does not count as an aha moment.
+5. At 350px feed width, name what lands and what becomes texture. Check frame 0, attribution, visual anchor, density, and structural distinctness.
+6. Apply `restrained-palette`. The palette should read as `creative-attractive-restrained`, memorable and intentional without exaggerated saturation, unnecessary neon, or several competing accents unless the brief explicitly calls for them.
+7. Apply `center-first-composition`. Confirm the visual anchor and major zones are centered by default or that `build/layout-spec.json` records a valid alignment exception for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity.
+8. For UI stories, check feed-width legibility, evidence-qualified product states, concept labeling, and story-critical controls.
+9. For motion, check whether animation serves reading order, state change, hierarchy, reveal, or route direction. Flag decorative competition or incomplete frame 0.
+10. For a named mascot, compare the animated component with the exact source SVG and identity notes. Any unexplained substitution, redraw, altered marks/colors, or identity-changing deformation is a must-fix failure.
+11. Verify visible factual claims against the approved evidence table. Do not invent critique just to produce output.
 
-For UI Storyboard or Interface Cutaway, read `skills/info-stories/references/ui-mockup-rules.md`. Flag unreadable core controls, invented real-product features, unlabeled fictional data that could be mistaken for proof, excessive chrome, or interactions that do not serve the narrative.
+## HOLD conditions
 
-## Motion and mascot
+Return a blocking finding when evidence required to judge a real-product claim, mascot identity, or render acceptance criterion is unavailable. Do not guess a PASS.
 
-Check whether motion serves reading order, state change, hierarchy, or route direction. Flag decorative competition, incomplete frame 0, or multiple competing pointers.
+## Quality gates
 
-When a named mascot is used, compare the animated component with the exact source SVG and identity notes. Any unexplained substitution, redrawing, altered marks/colours, or identity-changing deformation is a must-fix failure.
+- `hooked-design-copy`
+- `creative-payoff`
+- `restrained-palette`
+- `center-first-composition`
 
-## Fit and capability gates
+A complete post must satisfy all applicable blocking local gates before independent verification.
 
-Use `skills/info-stories/references/anti-slop-gates.md` and `skills/info-stories/references/design-taste-gates.md`. Verify that evidence-backed claims visible in the artifact match the approved claim table. Do not invent critique just to produce output.
+## Research gates
 
-## Return
+Apply `prose-specificity`, `voice-preservation`, `structural-originality`, `contrast-discipline`, `evidence-traceability`, and `bounded-verification` when active in the route.
 
-Return three lists to the parent workflow: **must fix before posting**, **would improve it**, and **leave alone**. Put the single highest-leverage change first. If it is ready, say so plainly.
+## Outputs
+
+Return `build/critic-report.json` to the parent workflow with three ordered groups: `must_fix`, `would_improve`, and `leave_alone`. Put the highest-leverage change first and include the gate or evidence row behind each blocking finding. If the artifact is ready, say so plainly.

--- a/agents/post-critic.md
+++ b/agents/post-critic.md
@@ -24,17 +24,18 @@ Act as the last adversarial reader before independent verification. Inspect the 
 
 ## Method
 
-1. Read `helper/GUIDE.md`, active local quality gates, and active research gates.
-2. Inspect the caption opening and design-copy hero against `skills/info-stories/references/hook-driven-design-copy.md`.
-3. Apply `hooked-design-copy`. Flag a generic topic restatement, unsupported tension, fake urgency, or cleverness that obscures literal labels.
-4. Apply `creative-payoff`. Confirm the selected concept produces the promised reveal, relationship, comparison, transformation, state change, or interaction. A palette swap or decorative effect does not count as an aha moment.
-5. At 350px feed width, name what lands and what becomes texture. Check frame 0, attribution, visual anchor, density, and structural distinctness.
-6. Apply `restrained-palette`. The palette should read as `creative-attractive-restrained`, memorable and intentional without exaggerated saturation, unnecessary neon, or several competing accents unless the brief explicitly calls for them.
-7. Apply `center-first-composition`. Confirm the visual anchor and major zones are centered by default or that `build/layout-spec.json` records a valid alignment exception for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity.
-8. For UI stories, read `skills/info-stories/references/ui-mockup-rules.md`. Check feed-width legibility, evidence-qualified product states, concept labeling, story-critical controls, and whether the visual implies unsupported product behavior.
-9. For motion, check whether animation serves reading order, state change, hierarchy, reveal, or route direction. Flag decorative competition or incomplete frame 0.
-10. For a named mascot, compare the animated component with the exact source SVG and identity notes. Any unexplained substitution, redraw, altered marks/colors, or identity-changing deformation is a must-fix failure.
-11. Verify visible factual claims against the approved evidence table. Do not invent critique just to produce output.
+1. Read `helper/GUIDE.md`, active local quality gates, active research gates, `skills/info-stories/references/anti-slop-gates.md`, and `skills/info-stories/references/design-taste-gates.md`.
+2. Treat anti-slop and design-taste as explicit review lenses, not vague style advice.
+3. Inspect the caption opening and design-copy hero against `skills/info-stories/references/hook-driven-design-copy.md`.
+4. Apply `hooked-design-copy`. Flag a generic topic restatement, unsupported tension, fake urgency, or cleverness that obscures literal labels.
+5. Apply `creative-payoff`. Confirm the selected concept produces the promised reveal, relationship, comparison, transformation, state change, or interaction. A palette swap or decorative effect does not count as an aha moment.
+6. At 350px feed width, name what lands and what becomes texture. Check frame 0, attribution, visual anchor, density, and structural distinctness.
+7. Apply `restrained-palette`. The palette should read as `creative-attractive-restrained`, memorable and intentional without exaggerated saturation, unnecessary neon, or several competing accents unless the brief explicitly calls for them.
+8. Apply `center-first-composition`. Confirm the visual anchor and major zones are centered by default or that `build/layout-spec.json` records a valid alignment exception for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity.
+9. For UI stories, read `skills/info-stories/references/ui-mockup-rules.md`. Check feed-width legibility, evidence-qualified product states, concept labeling, story-critical controls, and whether the visual implies unsupported product behavior.
+10. For motion, check whether animation serves reading order, state change, hierarchy, reveal, or route direction. Flag decorative competition or incomplete frame 0.
+11. For a named mascot, compare the animated component with the exact source SVG and identity notes. Any unexplained substitution, redraw, altered marks/colors, or identity-changing deformation is a must-fix failure.
+12. Verify visible factual claims against the approved evidence table. Do not invent critique just to produce output.
 
 ## HOLD conditions
 
@@ -46,6 +47,8 @@ Return a blocking finding when evidence required to judge a real-product claim, 
 - `creative-payoff`
 - `restrained-palette`
 - `center-first-composition`
+- anti-slop review
+- design-taste review
 
 A complete post must satisfy all applicable blocking local gates before independent verification.
 

--- a/agents/post-critic.md
+++ b/agents/post-critic.md
@@ -21,6 +21,8 @@ Use the preloaded caption and Info-stories rules. Check the truncation cut, sing
 
 At 350px feed width, name what lands and what becomes texture. Check frame 0, attribution, the declared visual anchor, density, and whether the structural fingerprint represents a real layout choice rather than a palette-only reskin.
 
+Check the plugin-local visual defaults explicitly. The palette should read as `creative-attractive-restrained`: memorable and intentional without exaggerated saturation, unnecessary neon, or several competing accents unless the brief requires them. The composition should be `center-first` unless `build/layout-spec.json` records a justified alignment exception for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity. Flag arbitrary off-center drift as a must-fix issue when it weakens hierarchy.
+
 For UI Storyboard or Interface Cutaway, read `skills/info-stories/references/ui-mockup-rules.md`. Flag unreadable core controls, invented real-product features, unlabeled fictional data that could be mistaken for proof, excessive chrome, or interactions that do not serve the narrative.
 
 ## Motion and mascot

--- a/agents/post-critic.md
+++ b/agents/post-critic.md
@@ -31,7 +31,7 @@ Act as the last adversarial reader before independent verification. Inspect the 
 5. At 350px feed width, name what lands and what becomes texture. Check frame 0, attribution, visual anchor, density, and structural distinctness.
 6. Apply `restrained-palette`. The palette should read as `creative-attractive-restrained`, memorable and intentional without exaggerated saturation, unnecessary neon, or several competing accents unless the brief explicitly calls for them.
 7. Apply `center-first-composition`. Confirm the visual anchor and major zones are centered by default or that `build/layout-spec.json` records a valid alignment exception for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity.
-8. For UI stories, check feed-width legibility, evidence-qualified product states, concept labeling, and story-critical controls.
+8. For UI stories, read `skills/info-stories/references/ui-mockup-rules.md`. Check feed-width legibility, evidence-qualified product states, concept labeling, story-critical controls, and whether the visual implies unsupported product behavior.
 9. For motion, check whether animation serves reading order, state change, hierarchy, reveal, or route direction. Flag decorative competition or incomplete frame 0.
 10. For a named mascot, compare the animated component with the exact source SVG and identity notes. Any unexplained substitution, redraw, altered marks/colors, or identity-changing deformation is a must-fix failure.
 11. Verify visible factual claims against the approved evidence table. Do not invent critique just to produce output.

--- a/agents/render-qa.md
+++ b/agents/render-qa.md
@@ -1,18 +1,30 @@
 ---
 name: render-qa
-description: >-
-  Renders a built artboard to GIF, runs every quality gate, and reports failures. Use
-  proactively before delivering any post. Read-only with respect to the artboard: it diagnoses
-  and never edits, so the parent workflow keeps control of fixes.
+description: Renders a built artboard, records deterministic visual/GIF evidence, and applies render, contrast, seam, motion, mobile, and file-budget gates without editing the artifact.
 tools: Read, Bash, Grep, Glob
 model: sonnet
 skills:
   - render
 ---
 
-You render and you judge. You never edit the artboard.
+## Role
 
-## Run
+Produce render evidence and mechanical QA for the parent workflow. You are read-only with respect to the artboard: diagnose failures, record evidence, and return a verdict. Do not edit the artifact to make a check pass.
+
+Read `helper/GUIDE.md` before running QA.
+
+## Inputs
+
+- built `build/post.html`
+- static/animated output mode
+- approved timing when animated
+- Story House/contrast expectations when available
+- optional mascot contract and story brief
+
+## Method
+
+1. Use the preloaded `render` skill and walk its QA references.
+2. Run lint, static render, mobile downscale, and GIF render when applicable:
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/lint_artboard.sh <path>
@@ -21,20 +33,30 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py <path> --mobile
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/render.sh <path> <out.gif> --duration <d> --fps <f>
 ```
 
-Use the preloaded `render` skill and walk `references/qa-gates.md` in full, including mascot gates when a character is present.
+3. Open frame 0. It must read as a complete infographic without relying on motion.
+4. Inspect the 350px downscale and name load-bearing text or controls that become unreadable.
+5. Apply `contrast-discipline` to rendered meaningful text/state evidence instead of assuming source tokens rendered correctly.
+6. For animated output, record changed-pixel motion, loop seam, duration/fps, safe-zone behavior, and final file size.
+7. Apply `bounded-verification`: report a specific failure and evidence so the parent workflow can run a targeted fix/re-check rather than an open-ended rewrite.
+8. Treat known SVG `<defs>` zero-size safe-zone reports as potential false positives and verify the actual element before failing.
+9. Return evidence to the parent workflow. Never self-approve changes you did not inspect.
 
-## Judge
+## HOLD conditions
 
-- `motion:` under 2% healthy, 2 to 5% acceptable only on a dark flat ground, over 5% means something full-bleed is animating.
-- Seam: if seam delta is no larger than the biggest normal frame-to-frame change, the loop closes.
-- Frame 0: open it. It must read as a complete infographic with no motion.
-- Mobile: open the 350px downscale and name what is unreadable.
-- Size: under 5 MB, under 8 seconds.
+Return HOLD when browser/render tooling is unavailable, capture fails, frame 0 is incomplete, mobile output is unreadable, contrast is below a blocking floor, seam fails, changed-pixel motion reveals unintended full-canvas animation, safe-zone behavior is invalid, or output cannot meet the accepted file budget.
 
-## Known false positive
+## Quality gates
 
-`check_render.py` can flag animated groups inside `<defs>` as safe-zone violations because a defs child reports a zero-size rect at the origin. Check whether a flagged element is a template before reporting it.
+- deterministic render evidence exists
+- frame 0 complete
+- mobile legibility checked visually
+- seam/motion/file-size evidence recorded for GIFs
+- read-only diagnosis
 
-## Return
+## Research gates
 
-Return a gate-by-gate pass or fail list to the parent workflow, each failure naming the specific element or line and likely cause. End with `SHIP` or `HOLD: <the one thing to fix first>`. Suggest fixes; do not apply them.
+Own and execute `contrast-discipline` and `bounded-verification`. Preserve evidence rows needed by `story-verifier`; do not replace direct visual evidence with a summary claim.
+
+## Outputs
+
+Return `build/render-report.json` to the parent workflow with gate-by-gate PASS/FAIL, exact artifact/element evidence, static/mobile paths, animation metrics when applicable, and final `SHIP` or `HOLD: <first blocking issue>` recommendation.

--- a/agents/story-architect.md
+++ b/agents/story-architect.md
@@ -1,28 +1,52 @@
 ---
 name: story-architect
-description: Resolves an Info-stories brief before visual production begins.
+description: Resolves the approved creative direction into a deterministic Info-stories contract before visual production begins.
 tools: Read, Bash, Grep
 model: opus
 skills:
   - info-stories
 ---
 
-You choose the story contract. Do not build HTML.
+## Role
+
+Translate the selected creative direction into the story contract consumed by downstream production. You do not build HTML or invent a competing concept. Return the resolved brief to the parent workflow.
+
+Read `helper/GUIDE.md` before resolving the story.
 
 ## Inputs
 
-Topic or source material, one takeaway, CTA, language, output mode, any explicit user choices, and optional reference-analysis notes.
+- selected direction from `build/creative-concepts.json`
+- `build/evidence.json`
+- optional `build/design-study.json`
+- one takeaway, CTA, language, and output mode
+- explicit user choices for Story House, Visual Style, Story Archetype, or Motion Patterns
 
 ## Method
 
-1. Use the preloaded `info-stories` skill and registry.
-2. Resolve Story Archetype first, then Visual Style, Story House, then zero to two Motion Patterns.
-3. Preserve explicit choices unless the registry reports a hard incompatibility.
-4. Run `scripts/info_stories.py compose` and produce a deterministic scaffold.
-5. State one sentence of rationale per axis, not a generic mood paragraph.
+1. Use the preloaded `info-stories` skill and merged registry.
+2. Preserve the selected concept's evidence-safe visual hook, copy hook, and aha mechanic unless a hard compatibility/evidence gate requires a change.
+3. Resolve Story Archetype first, then Visual Style, Story House, then zero to two Motion Patterns.
+4. Apply `design-dials`: record design variance, visual density, and motion intensity as explicit bounded choices derived from the content and selected concept.
+5. Apply `creative-payoff`: ensure the resolved story shape can actually deliver the selected useful reveal, relationship, comparison, transformation, state change, or interaction. Do not reduce the concept to generic cards.
+6. Preserve explicit user choices unless the registry reports a blocking incompatibility, contrast issue, or evidence conflict.
+7. Run `scripts/info_stories.py compose` and emit the deterministic scaffold.
+8. State one concise rationale per axis plus any compatibility warning. Return the artifact to the parent workflow; the parent chooses the next worker.
+
+## HOLD conditions
+
+Return a HOLD when the selected concept cannot be expressed by a compatible registry combination, an explicit user choice conflicts with a hard gate, the creative payoff depends on unsupported evidence, or a required Info-stories option cannot be resolved without silent substitution.
+
+## Quality gates
+
+- `creative-payoff`
+- selected concept preserved through story resolution
+- deterministic registry choices
+- explicit compatibility warnings instead of silent fallback
+
+## Research gates
+
+Own and execute `design-dials`. Downstream owners apply `structural-originality`, `contrast-discipline`, and other gates; include any story-level constraints they need in the brief.
 
 ## Outputs
 
-Return the story brief JSON path or JSON block, the four selected axes, the preferred existing artboard archetype, unresolved factual inputs, and any compatibility warnings.
-
-Return the resolved brief to the parent workflow. The parent workflow decides which focused worker runs next and passes the brief as an explicit artifact.
+Return `build/story-brief.json` to the parent workflow with Story House, Visual Style, Story Archetype, Motion Patterns, design dials, execution artboard archetype, selected concept identifier, rationale per axis, unresolved factual inputs, and compatibility warnings.

--- a/agents/story-architect.md
+++ b/agents/story-architect.md
@@ -9,7 +9,7 @@ skills:
 
 ## Role
 
-Translate the selected creative direction into the story contract consumed by downstream production. You do not build HTML or invent a competing concept. Return the resolved brief to the parent workflow.
+Translate the selected creative direction into the story contract consumed by downstream production. **Do not build HTML** and do not invent a competing concept. Return the resolved brief to the parent workflow.
 
 Read `helper/GUIDE.md` before resolving the story.
 

--- a/agents/story-verifier.md
+++ b/agents/story-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: story-verifier
-description: Verifies a built Info-stories artifact against explicit acceptance criteria and direct evidence before delivery.
+description: Independently verifies a built infographic against explicit acceptance criteria, direct artifact evidence, research gates, and unresolved critic findings before delivery.
 tools: Read, Grep, Glob, Bash
 model: opus
 skills:
@@ -8,18 +8,48 @@ skills:
   - render
 ---
 
-You are read-only. Do not edit the artifact and do not trust a worker summary as evidence.
+## Role
+
+Act as the independent read-only acceptance worker for the parent workflow. Inspect artifacts directly, record evidence per criterion, and never trust the producing worker's summary as proof.
+
+Read `helper/GUIDE.md` and the verification reference before judging the result.
 
 ## Inputs
 
-Artifact paths, story brief, acceptance criteria, source claims, render outputs, post-critic findings, and the current verification attempt number.
+- artifact paths and rendered evidence
+- `build/evidence.json`
+- selected creative concept and `build/story-brief.json`
+- `build/render-report.json`
+- `build/critic-report.json`
+- optional mascot motion/identity evidence
+- explicit acceptance criteria
+- current verification attempt number
 
 ## Method
 
-Use `skills/info-stories/references/verification-loop.md` plus the preloaded render QA gates. Inspect the artifact directly. For visual criteria, inspect rendered evidence rather than inferring from HTML. For motion criteria, use captured frames and render metrics. Record one evidence row per criterion. Confirm unresolved post-critic must-fix items are not being ignored.
+1. Use `skills/info-stories/references/verification-loop.md` and the preloaded render gates.
+2. Inspect the artifact directly. For visual criteria, inspect rendered evidence; for motion criteria, use captured frames and metrics.
+3. Apply `evidence-traceability`: record one evidence row per criterion with artifact, observation, and direct evidence. Verify protected claims/product states instead of accepting a summary.
+4. Apply `bounded-verification`: return `PASS`, `FAIL:fixable`, or `FAIL:escalate`. Maximum two targeted repair attempts are allowed before escalation.
+5. Confirm unresolved post-critic must-fix items are not ignored.
+6. Verify applicable local quality gates from the route, including hook, creative payoff, palette/alignment, UI fidelity, and mascot identity when evidence exists.
+7. Stay read-only. A verifier does not apply the fix it recommends.
+
+## HOLD conditions
+
+Return `FAIL:fixable` when a bounded targeted repair can satisfy a failed criterion. Return `FAIL:escalate` when evidence is missing in a way the current workflow cannot safely resolve, the failure would require changing the approved premise, or two targeted fixes have already failed.
+
+## Quality gates
+
+- independent direct evidence
+- no self-grading by producing workers
+- unresolved critic blockers accounted for
+- no third repair attempt
+
+## Research gates
+
+Own and execute `evidence-traceability` and `bounded-verification`. Preserve criterion IDs and direct evidence so the final verdict can be audited.
 
 ## Outputs
 
-Return `PASS`, `FAIL:fixable`, or `FAIL:escalate`, the attempt number, criterion rows with artifact / observation / evidence, and only the targeted fix direction for failed criteria to the parent workflow.
-
-After two targeted fix attempts, any remaining failure is `FAIL:escalate`. Never make the third fix yourself.
+Return `build/verification-report.json` to the parent workflow with verdict, attempt number, criterion rows, evidence references, unresolved critic findings, and only the targeted fix direction for failed criteria. Never make the third fix yourself.

--- a/architecture/plugin-graph.json
+++ b/architecture/plugin-graph.json
@@ -5,6 +5,7 @@
       "sequence": [
         "design-study",
         "evidence-checker",
+        "creative-director",
         "story-architect",
         "palette-curator",
         "copy-compressor",
@@ -32,6 +33,7 @@
     "artboard-builder": {"required_skills": ["artboard", "info-stories"]},
     "caption-writer": {"required_skills": ["caption"]},
     "copy-compressor": {"required_skills": ["info-stories", "caption"]},
+    "creative-director": {"required_skills": ["info-stories", "caption", "artboard"]},
     "design-study": {"required_skills": ["info-stories"]},
     "evidence-checker": {"required_skills": ["info-stories"]},
     "layout-composer": {"required_skills": ["info-stories", "artboard"]},
@@ -46,11 +48,13 @@
   },
   "capabilities": {
     "anti-slop": ["copy-compressor", "caption-writer", "post-critic"],
+    "creative-direction": ["creative-director", "story-architect", "layout-composer", "post-critic"],
     "design-taste": ["design-study", "layout-composer", "artboard-builder", "post-critic"],
-    "structural-fingerprint": ["layout-composer", "artboard-builder", "post-critic"],
     "evidence": ["evidence-checker", "copy-compressor", "story-verifier"],
-    "verification-loop": ["render-qa", "post-critic", "story-verifier"],
+    "hook-design-copy": ["creative-director", "copy-compressor", "caption-writer", "post-critic"],
     "mascot-identity": ["mascot-animator", "post-critic", "story-verifier"],
-    "ui-mockup-fidelity": ["evidence-checker", "layout-composer", "artboard-builder", "post-critic"]
+    "structural-fingerprint": ["layout-composer", "artboard-builder", "post-critic"],
+    "ui-mockup-fidelity": ["evidence-checker", "layout-composer", "artboard-builder", "post-critic"],
+    "verification-loop": ["render-qa", "post-critic", "story-verifier"]
   }
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,79 @@
+# Agents
+
+The active worker inventory is declared in `helper/modules.json` and the executable order is declared in `architecture/plugin-graph.json`. Every agent returns a bounded artifact or verdict to the parent workflow. Agents do not coordinate peer agents directly.
+
+## Complete workflow agents
+
+### `design-study`
+
+Diagnoses visual references into reusable design DNA before concept generation. It owns `reference-dna` when references are present and returns `build/design-study.json`.
+
+### `evidence-checker`
+
+Defines the factual boundary before creative work begins. It classifies claims, product states, metrics, logos, proof, and UI evidence, then returns `build/evidence.json`. It owns `evidence-traceability` at intake.
+
+### `creative-director`
+
+Generates at least three evidence-safe creative directions before story architecture. Each direction contains a visual hook, copy hook, aha mechanic, story shape, visual/style recommendations, evidence dependencies, risks, and why it earns attention. It returns `build/creative-concepts.json`.
+
+This agent owns the local creative concept layer. It applies `hooked-design-copy` and `creative-payoff` without inventing claims or using spectacle as a substitute for explanation.
+
+### `story-architect`
+
+Turns the selected creative direction into a deterministic Info-stories brief. It resolves Story Archetype, Visual Style, Story House, Motion Patterns, and design dials, then returns `build/story-brief.json`.
+
+### `palette-curator`
+
+Resolves the Story House and semantic token roles. It enforces `creative-attractive-restrained` palette behavior and the `contrast-discipline` research gate. It returns `build/palette-check.json`.
+
+### `copy-compressor`
+
+Compresses source material into infographic-sized design copy while protecting facts, names, numbers, mechanisms, voice, and the approved copy hook. It applies `prose-specificity`, `voice-preservation`, and evidence constraints, then returns `build/artboard-copy.json`.
+
+### `layout-composer`
+
+Turns the selected concept, story brief, copy, palette, and optional reference study into a static hierarchy and topology specification. It applies `center-first-composition`, `design-dials`, `structural-originality`, and `reference-dna` when active. It returns `build/layout-spec.json`.
+
+### `caption-writer`
+
+Writes the LinkedIn caption and first comment. It applies `hooked-design-copy` to the opening, keeps one caption archetype, preserves evidence, and returns `build/caption.md` plus `build/first-comment.md`.
+
+### `artboard-builder`
+
+Builds the approved 1080x1350 HTML still and rendered PNG. It preserves the selected creative payoff, Story House tokens, center-first layout or documented exception, UI fidelity, and contrast. It returns `build/post.html` and `build/still.png`.
+
+### `motion-director`
+
+Chooses zero to two meaning-driven Motion Patterns after the still is approved. Motion must communicate hierarchy, sequence, reveal, state, route, or the selected creative payoff. It returns `build/motion-direction.json`.
+
+### `mascot-animator`
+
+Conditional worker for a named or official mascot. It requires the exact user-supplied or task-attached SVG, inspects the real geometry, preserves identity, selects a communication-led creative direction, and returns `build/mascot/motion-contract.json`. Missing exact SVG is a HOLD.
+
+### `motion-engineer`
+
+Implements the approved seekable motion direction on the approved still. It preserves the resolved story brief, frame-zero completeness, one loop clock, motion budget, and exact mascot identity when present.
+
+### `render-qa`
+
+Produces deterministic static/GIF evidence without editing the artboard. It checks frame 0, feed-scale legibility, contrast, changed-pixel motion, seam, safe zone, duration, and file size. It returns `build/render-report.json`.
+
+### `post-critic`
+
+Performs adversarial review before independent verification. It explicitly checks anti-slop, design-taste, `hooked-design-copy`, `creative-payoff`, `restrained-palette`, `center-first-composition`, UI fidelity, mascot identity, motion meaning, and evidence safety. It returns `build/critic-report.json`.
+
+### `story-verifier`
+
+Read-only independent acceptance worker. It inspects artifact evidence directly, records one evidence row per criterion, enforces `evidence-traceability` and `bounded-verification`, and returns `build/verification-report.json` with `PASS`, `FAIL:fixable`, or `FAIL:escalate`.
+
+## Coordination contract
+
+The canonical complete sequence is declared in `architecture/plugin-graph.json` and mirrored by the `create-post` route. The parent workflow owns sequencing, user approvals, HOLD resolution, and the maximum-two targeted repair loop.
+
+Validate all worker contracts with:
+
+```bash
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 -m unittest tests.test_agent_contracts -v
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,98 @@
+# Development and Validation
+
+The repository uses contract-first development. Public behavior is represented in machine-readable helper/graph/gate/module files and protected by regression tests.
+
+## Core development loop
+
+1. Add or update a failing test for the intended behavior
+2. Implement the smallest coherent change
+3. Run focused tests
+4. Run the full deterministic gate
+5. Update public docs and version metadata when behavior changes
+6. Open or update the PR and inspect external reviews/checks
+7. Merge only from the exact verified green head
+
+## Full deterministic gate
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
+python3 scripts/info_stories.py check
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/validate_marketplace.py
+python3 -m json.tool hooks/hooks.json >/dev/null
+bash -n scripts/lint_artboard.sh
+bash -n scripts/setup.sh
+git diff --check HEAD^ HEAD
+```
+
+For Claude packaging:
+
+```bash
+claude plugin validate .
+```
+
+CI also performs a same-repository marketplace add/list/install smoke test.
+
+## Validator responsibilities
+
+### `scripts/info_stories.py check`
+
+Validates the merged Info-stories registry, semantic Story House tokens, compatibility, and deterministic composition behavior.
+
+### `scripts/ecosystem_router.py check`
+
+Validates helper routes, capabilities, artifacts, local quality gates, research-gate linkage, skill/agent references, and graph capability coverage.
+
+### `scripts/research_gates.py check`
+
+Validates research provenance, source SHAs/licenses, runtime gate contracts, owners, implementation references, and helper linkage.
+
+### `scripts/plugin_graph.py check`
+
+Validates agent inventory, required skill preloads, shipping order, conditional mascot edge, helper/graph capability ownership, and create-post sequence consistency.
+
+### `scripts/ecosystem_doctor.py check`
+
+Strict repository reality gate. It validates active module inventory, paths, tests, reachability, tool references, capability ownership, artifact participants, local/research gate owners, critical shipping workers, and cross-registry drift.
+
+### `scripts/validate_marketplace.py`
+
+Validates the Claude Marketplace/plugin manifests, same-repository source, strict mode, version agreement, and required component structure.
+
+## Browser rendering
+
+Browser-dependent checks require Playwright/Chromium plus host libraries and FFmpeg. Run setup where those dependencies can be installed:
+
+```bash
+bash scripts/setup.sh
+```
+
+If the current environment lacks a required OS browser library, report the browser-render gate as environment-blocked. Do not claim visual rendering passed because non-browser unit tests passed.
+
+## Research changes
+
+When adopting a new external capability:
+
+1. record repository URL, inspected commit, and license
+2. write local Adopt / Adapt / Reject notes
+3. add or update a stable runtime gate in `research/capability-notes/gates.json`
+4. connect the gate to a capability and real shipping owner
+5. point to independently-worded local implementation references
+6. add regression tests
+7. run research gates and the strict doctor
+
+Ignored upstream clones under `research/upstreams/` never ship.
+
+## Adding a skill, agent, or public tool
+
+A new public module is incomplete until it is declared in `helper/modules.json` with a real path, role, tests, and reachability links. Update routes/graph/preloads/artifacts/gates as appropriate. `scripts/ecosystem_doctor.py check` must remain clean.
+
+## Release work
+
+A plugin release requires matching version values in `.claude-plugin/plugin.json` and the plugin entry in `.claude-plugin/marketplace.json`. The current v3 release is `3.0.0`.
+
+Before merge, require unit/validator success, official Claude validation, marketplace install smoke, no blocking external check, and no unresolved review thread.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,88 @@
+# Ecosystem Architecture
+
+Version 3 organizes the repository around a central routing helper and explicit worker contracts. Skills, agents, research, tools, artifacts, and Claude Marketplace packaging are validated as one connected product.
+
+## Authority
+
+The LLM entry guide is [`../helper/GUIDE.md`](../helper/GUIDE.md).
+
+Machine-readable contracts:
+
+- `helper/router.json`: intent and conditional routing
+- `helper/capabilities.json`: capability owners and plugin-local defaults
+- `helper/quality-gates.json`: local product/creative gates
+- `helper/artifacts.json`: producer/consumer handoffs
+- `helper/modules.json`: active public modules
+- `research/capability-notes/gates.json`: adopted research-derived gates
+- `architecture/plugin-graph.json`: shipping worker order and skill preloads
+- `scripts/info_stories.py::load_catalog()`: merged Info-stories registry
+
+## Complete shipping path
+
+`new-post` owns the complete parent workflow:
+
+1. `design-study`, when references exist
+2. `evidence-checker`
+3. `creative-director`
+4. `story-architect`
+5. `palette-curator`
+6. `copy-compressor`
+7. `layout-composer`
+8. `caption-writer`
+9. `artboard-builder`
+10. `motion-director`
+11. optional `mascot-animator`
+12. `motion-engineer`
+13. `render-qa`
+14. `post-critic`
+15. `story-verifier`
+
+Workers return bounded artifacts to the parent workflow. A worker never assumes it can secretly coordinate peer workers.
+
+## Creative runtime
+
+`creative-director` receives evidence and optional reference diagnosis before story architecture. It produces at least three evidence-safe directions in `build/creative-concepts.json`. Each direction specifies a visual hook, copy hook, aha mechanic, story shape, recommended visual style/archetype/motion, evidence dependencies, risks, and why the concept earns attention.
+
+The creative runtime does not equate spectacle with quality. A useful wow/aha moment is a reveal, relationship, comparison, transformation, state change, or interaction that improves comprehension or recall.
+
+Plugin-local blocking defaults:
+
+- `hooked-design-copy`
+- `creative-payoff`
+- `restrained-palette`
+- `center-first-composition`
+
+Palette character defaults to `creative-attractive-restrained`. Composition defaults to `center-first` unless tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or documented reference DNA make another alignment more legible or faithful.
+
+## Evidence and exact assets
+
+Evidence is resolved before creative production. Product states, metrics, proof, logos, integrations, and real UI behavior may not be invented to satisfy a visual slot.
+
+A named or official mascot requires the exact user-supplied or task-attached SVG. Missing SVG means `HOLD: exact SVG required`. The mascot worker may animate addressable geometry and add removable support cues, but it may not silently redraw or substitute the identity.
+
+## Info-stories
+
+Info-stories resolves four independent axes:
+
+- Story House
+- Visual Style
+- Story Archetype
+- Motion Pattern
+
+The registry is the deterministic result of `load_catalog()`, merging the base catalog and first-party extensions. UI Mockup Stories are a first-party extension and remain subject to evidence and feed-width legibility gates.
+
+## Research and local rules
+
+Research-derived gates have source provenance and local independently-worded behavior. Plugin-local behavior such as exact mascot identity, hook-led design copy, restrained palettes, center-first composition, and creative payoff is kept separate from upstream attribution.
+
+See [`research.md`](research.md) for the provenance chain.
+
+## Strict reality gate
+
+`scripts/ecosystem_doctor.py` validates that every public skill, agent, and tool is declared, real, reachable, tested, and connected to the current registries. It also checks capability ownership, artifacts, gates, critical shipping workers, and helper/graph sequence consistency.
+
+```bash
+python3 scripts/ecosystem_doctor.py check
+```
+
+A module that exists only in documentation does not pass this gate.

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -1,0 +1,63 @@
+# Claude Marketplace
+
+The plugin and marketplace live in the same repository.
+
+- marketplace: `mamdouh-creative-tools`
+- plugin: `linkedin-animated-infographics`
+- plugin release: `3.0.0`
+- marketplace source: `./`
+- strict mode: `true`
+
+## Install
+
+In Claude Code:
+
+```text
+/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics
+/plugin install linkedin-animated-infographics@mamdouh-creative-tools
+```
+
+The marketplace catalog is `.claude-plugin/marketplace.json`; the plugin manifest is `.claude-plugin/plugin.json`.
+
+## Validate locally
+
+```bash
+python3 scripts/validate_marketplace.py
+claude plugin validate .
+```
+
+The local validator checks the same-repository source, strict mode, plugin identity, version agreement, required component directories, and manifest fields.
+
+## CI install smoke
+
+The GitHub validation workflow creates a clean temporary Claude home, registers the checked-out repository as a local marketplace, verifies that `mamdouh-creative-tools` appears in the marketplace list, and installs:
+
+```text
+linkedin-animated-infographics@mamdouh-creative-tools
+```
+
+That smoke test proves the marketplace entry is not only schema-valid but actually installable from the repository layout used by CI.
+
+## Versioning
+
+The plugin manifest version and marketplace plugin-entry version must match. Version `3.0.0` represents the routing-kernel and contract architecture release: helper routing, research gates, local creative gates, strict module doctor, creative director, standardized skills/agents, and public documentation.
+
+The top-level marketplace catalog has its own catalog version. It does not need to match the plugin version.
+
+Any future public plugin release should update both the plugin manifest and its marketplace entry and rerun the official Claude validator plus marketplace add/install smoke.
+
+## Release gate
+
+Before merging a marketplace release:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/validate_marketplace.py
+claude plugin validate .
+```
+
+Do not treat a version bump as complete until CI installs that exact checked-out plugin from the same-repository marketplace.

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,0 +1,88 @@
+# Research Capability Gates
+
+Research under `research/` is an active input to production quality, not a passive archive. The repository preserves source provenance, independently-worded local adoption rules, runtime gate ownership, and tests without packaging upstream working copies.
+
+## Provenance sources
+
+The tracked snapshot in `research/capability-notes/sources.json` records five inspected MIT repositories and exact commits:
+
+- COG-second-brain
+- hallmark
+- no-ai-slop
+- stop-slop
+- taste-skill
+
+The ignored `research/upstreams/` clones are local study material only and never ship with the plugin.
+
+## Runtime gates
+
+`research/capability-notes/gates.json` is the machine-readable adoption contract.
+
+### `prose-specificity`
+
+Informed by stop-slop and no-ai-slop. Detect named low-information prose patterns by slot, preserve literal labels, and block generic filler or unsupported rhetorical setup before delivery.
+
+### `voice-preservation`
+
+Informed primarily by no-ai-slop. Preserve specific facts, mechanisms, names, numbers, and deliberate voice while applying the minimum effective edit.
+
+### `design-dials`
+
+Informed by taste-skill. Resolve design variance, visual density, and motion intensity as explicit bounded decisions rather than random aesthetic choice.
+
+### `structural-originality`
+
+Informed by taste-skill and hallmark. Require meaningful variation in topology, card grammar, connectors, visual anchor, density, or motion grammar. Palette-only reskins fail.
+
+### `reference-dna`
+
+Informed by hallmark. When a visual reference is supplied, extract reusable rhythm, topology, card/connector grammar, token roles, density, motion grammar, attribution, and visual anchor without cloning distinctive work.
+
+### `contrast-discipline`
+
+Informed by taste-skill and hallmark. Keep one coherent semantic token set and enforce the repository text/state contrast floors before approval.
+
+### `evidence-traceability`
+
+Informed by COG-second-brain, hallmark, and no-ai-slop. Trace factual claims, product states, metrics, logos, proof, and acceptance rows to supplied evidence.
+
+### `bounded-verification`
+
+Informed by COG-second-brain. Keep verification independent, evidence-backed, read-only, and limited to two targeted repair attempts before escalation.
+
+## Adoption chain
+
+A research idea is not considered integrated merely because a note mentions it. The shipping chain is:
+
+1. `sources.json` records repository, inspected commit, and license
+2. individual capability notes record Adopt, Adapt, Reject, and local targets
+3. `gates.json` declares stable runtime gate IDs, stage, severity, owners, and implementation references
+4. `helper/capabilities.json` maps repository capabilities to those gate IDs
+5. `scripts/ecosystem_router.py` returns applicable research gates for a request
+6. named shipping agents execute the gate behavior
+7. `scripts/research_gates.py` and `scripts/ecosystem_doctor.py` reject dead provenance, owners, or implementation references
+
+## Local-native behavior
+
+Not every good repository rule needs upstream provenance. The following are explicitly local product behavior rather than research-source claims:
+
+- exact official mascot SVG identity
+- `hooked-design-copy`
+- `creative-payoff`
+- `creative-attractive-restrained` palette default
+- `center-first` composition default
+
+These live under helper capabilities/local quality gates and are kept separate from research attribution.
+
+## Deliberate exclusions
+
+The plugin does not import frontend-framework prescriptions, mandatory GSAP/scroll behavior, random aesthetic selection, paid-template cloning, signature-work cloning, or upstream repositories as runtime dependencies.
+
+## Validation
+
+```bash
+python3 scripts/audit_upstreams.py check
+python3 scripts/research_gates.py check
+python3 scripts/ecosystem_doctor.py check
+python3 -m unittest tests.test_research_gates tests.test_upstream_capabilities -v
+```

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,88 @@
+# Routing Guide
+
+The repository routes requests through `helper/` before choosing production workers. The human-readable entry is [`../helper/GUIDE.md`](../helper/GUIDE.md); `helper/router.json` is the machine-readable route registry.
+
+## Intents
+
+| Intent | Execution |
+|---|---|
+| `create-post` | Full `new-post` parent workflow |
+| `qa` | Focused `qa-post` parent workflow |
+| `render` | Focused `render-gif` workflow |
+| `design-study` | Reference diagnosis through `design-study` |
+| `mascot-animation` | Focused exact-SVG mascot path |
+| `info-story` | Focused Info-stories concept/story composition |
+
+Inspect a route:
+
+```bash
+python3 tools/route_request.py --request "Create an animated LinkedIn infographic"
+```
+
+Or use the richer script directly:
+
+```bash
+python3 scripts/ecosystem_router.py explain \
+  --request "Turn this product workflow into a UI story" \
+  --ui-mockup
+```
+
+The returned contract includes status, workflow, skills, agents, conditional agents, capabilities, asset gates, research gates, and local quality gates.
+
+## Conditional gates
+
+### Arabic / RTL
+
+Adds the `arabic` skill. RTL reading flow may justify an alignment exception when `center-first` would reduce comprehension.
+
+### UI mockup
+
+Adds UI fidelity and evidence ownership. Real-looking product states, features, metrics, integrations, and proof need evidence. Concept/sample UI must be identifiable when readers could confuse it with real product behavior.
+
+### Visual reference
+
+Adds `design-study` and activates `reference-dna`. References are diagnosed into reusable design behavior, not copied as signature work.
+
+### Named / official mascot
+
+Adds the mascot path only when the exact SVG exists. Missing asset returns `HOLD: exact SVG required`. A main conversational model asks the user for the exact SVG; a worker returns the HOLD to its parent workflow.
+
+### Static output
+
+Static work can skip motion-specific workers after still approval, but it does not skip adversarial critique or independent verification.
+
+## Creative route behavior
+
+Complete creation runs evidence before concepting. `creative-director` then produces several evidence-safe concept directions with:
+
+- visual hook
+- copy hook
+- aha mechanic
+- story shape
+- recommended Visual Style / Story Archetype / motion behavior
+- evidence dependencies and risks
+
+The selected concept feeds `story-architect`, copy, layout, and motion planning. Downstream workers should not invent separate competing concepts.
+
+## Local gates
+
+Complete creation and Info-story composition apply:
+
+- `hooked-design-copy`
+- `creative-payoff`
+- `restrained-palette`
+- `center-first-composition`
+
+QA applies the relevant review variants. Rendering applies mechanical and verification gates rather than creative rewriting.
+
+## Research gates
+
+Research gates are selected from capability ownership and route context. `reference-dna`, for example, only activates when visual references are actually present.
+
+Validate the router:
+
+```bash
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/ecosystem_doctor.py check
+```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,77 @@
+# Skills
+
+The active skill inventory is declared in `helper/modules.json`. Every public skill follows the v3 contract: Purpose, Use when, Inputs, Outputs, Procedure, HOLD conditions, Related components, and Research gates.
+
+## Workflow and routing skills
+
+### `post`
+
+Public routing entrypoint. It reads `helper/GUIDE.md`, resolves the request, and routes complete creation to `new-post` or focused work to QA, render, design-study, mascot-animation, or Info-stories paths.
+
+### `new-post`
+
+Canonical complete parent workflow. It owns evidence, creative concept approval, story, copy, layout, still, motion, mascot condition, render QA, adversarial review, independent verification, HOLD resolution, and final delivery.
+
+### `qa-post`
+
+Focused QA parent workflow for an existing artifact. It runs deterministic render evidence, local creative gates, adversarial critique, and independent verification.
+
+### `render-gif`
+
+Focused rendering workflow for approved HTML. It renders and reports motion, seam, and file-size evidence without redesigning the artifact.
+
+## Domain skills
+
+### `info-stories`
+
+Resolves Story House, Visual Style, Story Archetype, Motion Patterns, design dials, UI story behavior, creative payoff, and reference-informed structure. The authoritative registry is the merged result of `scripts/info_stories.py::load_catalog()`.
+
+### `caption`
+
+Defines evidence-safe LinkedIn caption archetypes, opening hooks, truncation discipline, CTA behavior, and anti-slop review. It uses `hooked-design-copy` for attention-bearing openings.
+
+### `artboard`
+
+Defines static 1080x1350 composition, visual hierarchy, Story House token usage, structural originality, feed-scale legibility, contrast, UI mockup behavior, `creative-attractive-restrained` palettes, and `center-first` composition.
+
+### `motion`
+
+Defines deterministic seekable animation, one-loop-clock behavior, frame-zero completeness, meaning-driven Motion Patterns, changed-pixel restraint, and loop closure.
+
+### `mascots`
+
+Defines the infographic mascot communication role, exact-SVG identity rule, motion budget, and interaction with reading order. A named or official mascot without its exact SVG is a HOLD.
+
+### `svg-mascot-animator`
+
+Inspects and animates the exact supplied SVG. It covers riggability, identity preservation, physics/timing, creative directions, deterministic delivery, and validation.
+
+### `render`
+
+Defines frame capture, GIF assembly, static/mobile evidence, seam measurement, motion percentage, file-size budgets, and render acceptance.
+
+### `arabic`
+
+Defines Arabic and bilingual adaptation, RTL reading order, bidi isolation, Arabic typography, natural hook adaptation, and alignment exceptions when centered treatment would reduce comprehension.
+
+## Creative defaults
+
+The visual production skills inherit these plugin-local defaults from `helper/capabilities.json` and `helper/quality-gates.json`:
+
+- palette: `creative-attractive-restrained`
+- composition: `center-first`
+- attention-bearing copy: `hooked-design-copy`
+- complete story concept: `creative-payoff`
+
+These defaults are blocking unless an approved brief or valid comprehension/fidelity exception applies.
+
+## Research integration
+
+Skills name the research gates they own or consume. The runtime gate registry lives in `research/capability-notes/gates.json`; research notes do not independently redefine production behavior.
+
+Validate skill contracts with:
+
+```bash
+python3 -m unittest tests.test_skill_contracts -v
+python3 scripts/ecosystem_doctor.py check
+```

--- a/docs/superpowers/plans/2026-08-07-ecosystem-creative-runtime-addendum.md
+++ b/docs/superpowers/plans/2026-08-07-ecosystem-creative-runtime-addendum.md
@@ -1,0 +1,76 @@
+# Ecosystem v3 Creative Runtime Addendum Plan
+
+## Task A: Local creative quality gates
+
+Files:
+- Create `helper/quality-gates.json`
+- Modify `scripts/ecosystem_router.py`
+- Create `tests/test_creative_runtime.py`
+
+Requirements:
+- route result exposes `quality_gates`
+- complete post and Info-story routes include `hooked-design-copy`, `creative-payoff`, `restrained-palette`, and `center-first-composition`
+- local quality gates remain distinct from research provenance
+- gate owners are real shipping agents
+
+## Task B: Creative director
+
+Files:
+- Create `agents/creative-director.md`
+- Modify `architecture/plugin-graph.json`
+- Modify `helper/router.json`
+- Modify `helper/capabilities.json`
+- Modify `helper/artifacts.json`
+- Modify `skills/new-post/SKILL.md`
+- Modify `tests/test_plugin_graph.py`
+- Extend `tests/test_creative_runtime.py`
+
+Requirements:
+- creative director runs after evidence and before story architecture
+- creates `build/creative-concepts.json`
+- produces at least three evidence-safe concept directions
+- each direction contains visual hook, copy hook, aha mechanic, story shape, recommendations, evidence dependencies, and risk notes
+- no peer orchestration
+
+## Task C: Hook-driven design copy
+
+Files:
+- Create `skills/info-stories/references/hook-driven-design-copy.md`
+- Modify `agents/creative-director.md`
+- Modify `agents/copy-compressor.md`
+- Modify `agents/caption-writer.md`
+- Modify `agents/post-critic.md`
+- Modify `skills/caption/SKILL.md`
+- Modify `skills/info-stories/SKILL.md`
+
+Requirements:
+- hero copy must earn attention without fabricating stakes
+- neutral factual labels remain literal where clarity wins
+- generic portable hero statements fail
+- one strong hook is preferred over cleverness in every slot
+
+## Task D: Strict module reality doctor
+
+Files:
+- Create `helper/modules.json`
+- Create `scripts/ecosystem_doctor.py`
+- Create `tests/test_ecosystem_doctor.py`
+- Modify CI workflow
+
+Requirements:
+- every public `skills/*/SKILL.md`, `agents/*.md`, and `tools/*.py` has a manifest entry
+- every manifest path exists
+- active skills/agents are reachable
+- active tools are referenced by executable guidance or validator contracts
+- each module names at least one test contract that exists
+- capabilities, artifacts, local gates, research gates, router, and plugin graph cross-validate
+- doctor fails on orphan or fake modules
+
+## Task E: Resume Skills and Agents v3 refactor
+
+After Tasks A-D are GREEN, resume the main v3 plan:
+- refactor all skills to the v3 section contract
+- refactor all agents to the v3 worker contract
+- add helper/research/local-gate references
+- update repository guidance, README, focused docs, Marketplace 3.0.0, and CI
+- run external reviews and merge only from a verified green PR head

--- a/docs/superpowers/plans/2026-08-07-ecosystem-routing-kernel-v3.md
+++ b/docs/superpowers/plans/2026-08-07-ecosystem-routing-kernel-v3.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Build a central LLM routing helper, standardize all skill and agent contracts, synchronize capability/artifact ownership, refresh README/docs, and ship the same repository as Claude Marketplace plugin version 3.0.0.
+**Goal:** Build a central LLM routing helper, activate research-derived capability gates, standardize all skill and agent contracts, synchronize capability/artifact ownership, refresh README/docs, and ship the same repository as Claude Marketplace plugin version 3.0.0.
 
-**Architecture:** `helper/` is the routing authority. `scripts/ecosystem_router.py` validates and executes deterministic routing over helper registries. Existing workflow skills remain the execution entrypoints, while every agent/skill adopts a consistent contract and returns artifacts through the parent workflow. CI validates the helper, graph, docs, marketplace, Claude plugin, and actual local marketplace install.
+**Architecture:** `helper/` is the routing authority. `scripts/ecosystem_router.py` validates and executes deterministic routing over helper registries. `research/capability-notes/gates.json` turns adopted research into explicit runtime quality gates linked to provenance and shipping owners. Existing workflow skills remain the execution entrypoints, while every agent/skill adopts a consistent contract and returns artifacts through the parent workflow. CI validates the helper, research gates, graph, docs, marketplace, Claude plugin, and actual local marketplace install.
 
 **Tech Stack:** Python 3.12, JSON, Markdown, shell, Claude Code plugin/marketplace manifests, unittest, GitHub Actions.
 
@@ -14,6 +14,8 @@
 - Keep same-repository marketplace source `./` with strict mode.
 - Bump plugin and marketplace plugin version to `3.0.0`.
 - Keep Info-stories authority in `scripts/info_stories.py::load_catalog()`.
+- Keep research provenance in `research/capability-notes/sources.json`; do not package upstream clones.
+- Every adopted research gate must have provenance, local behavior, stage, owners, implementation references, and tests.
 - Named or official mascots require exact user-supplied/task-attached SVG.
 - Workers return to the parent workflow; no hidden peer orchestration.
 - Do not replace the deterministic HTML/SVG/GIF rendering pipeline.
@@ -37,16 +39,15 @@
 - Consumes: `architecture/plugin-graph.json`, skill/agent file inventory, Info-stories workflow names.
 - Produces: `load_ecosystem(root)`, `validate_ecosystem(root)`, `route_request(request, root)`, CLI `check|route|explain`.
 
-- [ ] Write tests that fail when helper files are absent, when registry owners reference unknown agents/skills, or when a named mascot has no exact SVG.
-- [ ] Implement helper JSON registries with full production path, focused routes, Arabic/UI/mascot/reference/static-animation conditions, and artifact producers/consumers.
-- [ ] Implement deterministic loading, cross-registry validation, routing, and human-readable explanation.
-- [ ] Add thin `tools/route_request.py` wrapper.
-- [ ] Run `python3 -m unittest tests.test_ecosystem_router -v` and require zero failures.
+- [x] Write tests that fail when helper files are absent, when registry owners reference unknown agents/skills, or when a named mascot has no exact SVG.
+- [x] Implement helper JSON registries with full production path, focused routes, Arabic/UI/mascot/reference/static-animation conditions, and artifact producers/consumers.
+- [x] Implement deterministic loading, cross-registry validation, routing, and human-readable explanation.
+- [x] Add thin `tools/route_request.py` wrapper.
+- [x] Verify full CI including official Claude validation and marketplace install smoke.
 
 ### Task 2: Synchronize executable architecture graph
 
 **Files:**
-- Modify: `architecture/plugin-graph.json`
 - Modify: `scripts/plugin_graph.py`
 - Modify: `tests/test_plugin_graph.py`
 
@@ -54,10 +55,33 @@
 - Consumes: `helper/capabilities.json`, `helper/router.json`.
 - Produces: graph/helper consistency validation.
 
-- [ ] Add failing tests for capability ownership drift, missing conditional route agents, and workflow-order mismatch.
-- [ ] Extend `plugin_graph.py` to compare helper capability owners and workflow sequence with the graph.
-- [ ] Keep mascot conditional edge between still construction and motion integration.
-- [ ] Run graph tests and `python3 scripts/plugin_graph.py check`.
+- [x] Add failing tests for capability ownership drift and workflow-order mismatch.
+- [x] Extend `plugin_graph.py` to compare helper capability owners and workflow sequence with the graph.
+- [x] Keep mascot conditional edge between still construction and motion integration.
+- [x] Verify graph tests and full Claude CI.
+
+### Task 2A: Activate research as runtime capability gates
+
+**Files:**
+- Create: `research/capability-notes/gates.json`
+- Create: `scripts/research_gates.py`
+- Create: `tests/test_research_gates.py`
+- Modify: `helper/capabilities.json`
+- Modify: `scripts/ecosystem_router.py`
+- Modify: `helper/GUIDE.md`
+- Modify: `research/capability-notes/adoption-matrix.md`
+
+**Interfaces:**
+- Consumes: `research/capability-notes/sources.json`, existing local capability references, helper capability owners.
+- Produces: machine-readable gate IDs, provenance validation, route-level `research_gates`, CLI `python3 scripts/research_gates.py check`.
+
+- [ ] Write RED tests requiring eight research gates and source/provenance linkage.
+- [ ] Require every gate to name source(s), stage, severity, owners, local behavior, and implementation references.
+- [ ] Link each helper capability to one or more gate IDs and reject missing/unknown gate references.
+- [ ] Return applicable research gates from `route_request()` for complete and focused routes.
+- [ ] Validate that all gate owners are shipping agents and all source names exist in `sources.json`.
+- [ ] Update adoption matrix so it describes the runtime gate IDs rather than only prose mappings.
+- [ ] Add `research_gates.py check` to CI and verify GREEN.
 
 ### Task 3: Skill contracts v3
 
@@ -66,15 +90,16 @@
 - Add/modify: `tests/test_skill_contracts.py`.
 
 **Interfaces:**
-- Consumes: `helper/GUIDE.md`, router intent names, artifact contracts.
-- Produces: consistent Purpose / Use when / Inputs / Outputs / Procedure / HOLD conditions / Related components sections.
+- Consumes: `helper/GUIDE.md`, router intent names, artifact contracts, research gate IDs.
+- Produces: consistent Purpose / Use when / Inputs / Outputs / Procedure / HOLD conditions / Related components / Research gates sections.
 
 - [ ] Add structural tests covering every public `SKILL.md`.
 - [ ] Refactor `post` into lightweight helper-backed routing guidance.
 - [ ] Refactor `new-post`, `qa-post`, and `render-gif` around named helper artifacts and HOLD semantics.
 - [ ] Standardize domain skills without duplicating orchestration.
+- [ ] Wire relevant research gate IDs into every skill that owns or consumes them.
 - [ ] Keep Arabic, Info-stories, render, motion, mascot, and exact-SVG behavior intact.
-- [ ] Run all skill-contract tests plus existing Info-stories/mascot tests.
+- [ ] Run all skill-contract tests plus existing Info-stories/mascot/research tests.
 
 ### Task 4: Agent contracts v3
 
@@ -83,14 +108,15 @@
 - Add/modify: `tests/test_agent_contracts.py`.
 
 **Interfaces:**
-- Consumes: graph required skill preloads, helper artifact contracts.
-- Produces: consistent Role / Inputs / Method / HOLD conditions / Quality gates / Outputs sections.
+- Consumes: graph required skill preloads, helper artifact contracts, research gate ownership.
+- Produces: consistent Role / Inputs / Method / HOLD conditions / Quality gates / Research gates / Outputs sections.
 
 - [ ] Add structural tests for all agents.
 - [ ] Standardize all 14 agents while preserving specialist responsibilities.
 - [ ] Ensure every output maps to a declared artifact or explicit parent-workflow return.
 - [ ] Ban peer-orchestration language and ensure required `skills:` preload entries match the graph.
-- [ ] Run agent tests and graph validator.
+- [ ] Require each research gate owner to name and execute its gate in the worker contract.
+- [ ] Run agent, graph, and research-gate validators.
 
 ### Task 5: Repository guidance and cross-agent entrypoints
 
@@ -106,7 +132,7 @@
 - Consumes: `helper/GUIDE.md` as authority.
 - Produces: one consistent entry path for Claude, Codex, and generic coding agents.
 
-- [ ] Add tests that all repository guidance points to `helper/GUIDE.md` and does not redefine registry authority incorrectly.
+- [ ] Add tests that all repository guidance points to `helper/GUIDE.md` and `research/capability-notes/gates.json` without redefining authority incorrectly.
 - [ ] Write concise root guidance files and update existing adapter guidance.
 - [ ] Run guidance tests.
 
@@ -118,16 +144,17 @@
 - Create: `docs/routing.md`
 - Create: `docs/agents.md`
 - Create: `docs/skills.md`
+- Create: `docs/research.md`
 - Create: `docs/marketplace.md`
 - Create: `docs/development.md`
 - Add/modify: `tests/test_docs_contract.py`
 
 **Interfaces:**
-- Consumes: helper registries, actual skill/agent inventory, marketplace identity.
+- Consumes: helper registries, research gate registry, actual skill/agent inventory, marketplace identity.
 - Produces: concise README plus focused long-form docs.
 
-- [ ] Add tests for required docs, inventory coverage, install commands, and broken local Markdown links.
-- [ ] Rewrite README for product value, quick start, helper routing, workflows, examples, and validation.
+- [ ] Add tests for required docs, inventory coverage, research-gate coverage, install commands, and broken local Markdown links.
+- [ ] Rewrite README for product value, quick start, helper routing, research gates, workflows, examples, and validation.
 - [ ] Generate/update focused docs from actual repository contracts.
 - [ ] Run docs tests.
 
@@ -142,14 +169,14 @@
 - Modify version assertions in existing tests.
 
 **Interfaces:**
-- Consumes: version `3.0.0`, `scripts/ecosystem_router.py check`.
+- Consumes: version `3.0.0`, `scripts/ecosystem_router.py check`, `scripts/research_gates.py check`.
 - Produces: clean Claude validation and real marketplace add/list/install smoke.
 
 - [ ] Change version assertions to 3.0.0 and verify RED.
 - [ ] Bump manifest and marketplace plugin version.
-- [ ] Add ecosystem helper validation and docs-contract tests to CI via full suite.
+- [ ] Add ecosystem helper and research-gate validation to CI.
 - [ ] Keep full-history checkout for whitespace integrity.
-- [ ] Run local validators where possible and let PR CI run current Claude Code official validation/install smoke.
+- [ ] Run validators and let PR CI run current Claude Code official validation/install smoke.
 
 ### Task 8: Full verification, review, and merge
 
@@ -160,8 +187,8 @@
 - Consumes: complete branch and all CI/review feedback.
 - Produces: merged `main` commit only after verified head is green.
 
-- [ ] Run full unit suite, compile, Info-stories, plugin graph, ecosystem helper, marketplace, shell/JSON, and whitespace checks.
-- [ ] Open PR with architecture summary and exact validation matrix.
+- [ ] Run full unit suite, compile, Info-stories, plugin graph, ecosystem helper, research gates, marketplace, shell/JSON, and whitespace checks.
+- [ ] Update PR with architecture summary and exact validation matrix.
 - [ ] Inspect Qlty, CodeRabbit/Qodo/review threads; fix concrete findings with regression tests.
 - [ ] Require official `claude plugin validate .` and marketplace add/install smoke to pass on PR head.
 - [ ] Squash merge with `expected_head_sha`.

--- a/docs/superpowers/plans/2026-08-07-ecosystem-routing-kernel-v3.md
+++ b/docs/superpowers/plans/2026-08-07-ecosystem-routing-kernel-v3.md
@@ -1,0 +1,168 @@
+# Ecosystem Routing Kernel v3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a central LLM routing helper, standardize all skill and agent contracts, synchronize capability/artifact ownership, refresh README/docs, and ship the same repository as Claude Marketplace plugin version 3.0.0.
+
+**Architecture:** `helper/` is the routing authority. `scripts/ecosystem_router.py` validates and executes deterministic routing over helper registries. Existing workflow skills remain the execution entrypoints, while every agent/skill adopts a consistent contract and returns artifacts through the parent workflow. CI validates the helper, graph, docs, marketplace, Claude plugin, and actual local marketplace install.
+
+**Tech Stack:** Python 3.12, JSON, Markdown, shell, Claude Code plugin/marketplace manifests, unittest, GitHub Actions.
+
+## Global Constraints
+
+- Keep marketplace name `mamdouh-creative-tools` and plugin name `linkedin-animated-infographics`.
+- Keep same-repository marketplace source `./` with strict mode.
+- Bump plugin and marketplace plugin version to `3.0.0`.
+- Keep Info-stories authority in `scripts/info_stories.py::load_catalog()`.
+- Named or official mascots require exact user-supplied/task-attached SVG.
+- Workers return to the parent workflow; no hidden peer orchestration.
+- Do not replace the deterministic HTML/SVG/GIF rendering pipeline.
+- Do not re-merge historical branches already represented in `main`.
+
+---
+
+### Task 1: Helper registries and deterministic router
+
+**Files:**
+- Create: `helper/README.md`
+- Create: `helper/GUIDE.md`
+- Create: `helper/router.json`
+- Create: `helper/capabilities.json`
+- Create: `helper/artifacts.json`
+- Create: `scripts/ecosystem_router.py`
+- Create: `tools/route_request.py`
+- Create: `tests/test_ecosystem_router.py`
+
+**Interfaces:**
+- Consumes: `architecture/plugin-graph.json`, skill/agent file inventory, Info-stories workflow names.
+- Produces: `load_ecosystem(root)`, `validate_ecosystem(root)`, `route_request(request, root)`, CLI `check|route|explain`.
+
+- [ ] Write tests that fail when helper files are absent, when registry owners reference unknown agents/skills, or when a named mascot has no exact SVG.
+- [ ] Implement helper JSON registries with full production path, focused routes, Arabic/UI/mascot/reference/static-animation conditions, and artifact producers/consumers.
+- [ ] Implement deterministic loading, cross-registry validation, routing, and human-readable explanation.
+- [ ] Add thin `tools/route_request.py` wrapper.
+- [ ] Run `python3 -m unittest tests.test_ecosystem_router -v` and require zero failures.
+
+### Task 2: Synchronize executable architecture graph
+
+**Files:**
+- Modify: `architecture/plugin-graph.json`
+- Modify: `scripts/plugin_graph.py`
+- Modify: `tests/test_plugin_graph.py`
+
+**Interfaces:**
+- Consumes: `helper/capabilities.json`, `helper/router.json`.
+- Produces: graph/helper consistency validation.
+
+- [ ] Add failing tests for capability ownership drift, missing conditional route agents, and workflow-order mismatch.
+- [ ] Extend `plugin_graph.py` to compare helper capability owners and workflow sequence with the graph.
+- [ ] Keep mascot conditional edge between still construction and motion integration.
+- [ ] Run graph tests and `python3 scripts/plugin_graph.py check`.
+
+### Task 3: Skill contracts v3
+
+**Files:**
+- Modify every `skills/*/SKILL.md` entrypoint.
+- Add/modify: `tests/test_skill_contracts.py`.
+
+**Interfaces:**
+- Consumes: `helper/GUIDE.md`, router intent names, artifact contracts.
+- Produces: consistent Purpose / Use when / Inputs / Outputs / Procedure / HOLD conditions / Related components sections.
+
+- [ ] Add structural tests covering every public `SKILL.md`.
+- [ ] Refactor `post` into lightweight helper-backed routing guidance.
+- [ ] Refactor `new-post`, `qa-post`, and `render-gif` around named helper artifacts and HOLD semantics.
+- [ ] Standardize domain skills without duplicating orchestration.
+- [ ] Keep Arabic, Info-stories, render, motion, mascot, and exact-SVG behavior intact.
+- [ ] Run all skill-contract tests plus existing Info-stories/mascot tests.
+
+### Task 4: Agent contracts v3
+
+**Files:**
+- Modify every `agents/*.md`.
+- Add/modify: `tests/test_agent_contracts.py`.
+
+**Interfaces:**
+- Consumes: graph required skill preloads, helper artifact contracts.
+- Produces: consistent Role / Inputs / Method / HOLD conditions / Quality gates / Outputs sections.
+
+- [ ] Add structural tests for all agents.
+- [ ] Standardize all 14 agents while preserving specialist responsibilities.
+- [ ] Ensure every output maps to a declared artifact or explicit parent-workflow return.
+- [ ] Ban peer-orchestration language and ensure required `skills:` preload entries match the graph.
+- [ ] Run agent tests and graph validator.
+
+### Task 5: Repository guidance and cross-agent entrypoints
+
+**Files:**
+- Create: `AGENTS.md`
+- Create: `CLAUDE.md`
+- Modify: `.agents/skills/linkedin-animated-infographics/SKILL.md`
+- Modify: `.claude/skills/linkedin-animated-infographics/SKILL.md`
+- Modify: `.codex/AGENTS.md`
+- Add/modify: `tests/test_repository_guidance.py`
+
+**Interfaces:**
+- Consumes: `helper/GUIDE.md` as authority.
+- Produces: one consistent entry path for Claude, Codex, and generic coding agents.
+
+- [ ] Add tests that all repository guidance points to `helper/GUIDE.md` and does not redefine registry authority incorrectly.
+- [ ] Write concise root guidance files and update existing adapter guidance.
+- [ ] Run guidance tests.
+
+### Task 6: README and durable documentation
+
+**Files:**
+- Rewrite: `README.md`
+- Create: `docs/ecosystem.md`
+- Create: `docs/routing.md`
+- Create: `docs/agents.md`
+- Create: `docs/skills.md`
+- Create: `docs/marketplace.md`
+- Create: `docs/development.md`
+- Add/modify: `tests/test_docs_contract.py`
+
+**Interfaces:**
+- Consumes: helper registries, actual skill/agent inventory, marketplace identity.
+- Produces: concise README plus focused long-form docs.
+
+- [ ] Add tests for required docs, inventory coverage, install commands, and broken local Markdown links.
+- [ ] Rewrite README for product value, quick start, helper routing, workflows, examples, and validation.
+- [ ] Generate/update focused docs from actual repository contracts.
+- [ ] Run docs tests.
+
+### Task 7: Marketplace release 3.0.0 and CI ecosystem doctor
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `scripts/validate_marketplace.py`
+- Modify: `.github/workflows/claude-plugin-validation.yml`
+- Modify: `tests/test_marketplace.py`
+- Modify version assertions in existing tests.
+
+**Interfaces:**
+- Consumes: version `3.0.0`, `scripts/ecosystem_router.py check`.
+- Produces: clean Claude validation and real marketplace add/list/install smoke.
+
+- [ ] Change version assertions to 3.0.0 and verify RED.
+- [ ] Bump manifest and marketplace plugin version.
+- [ ] Add ecosystem helper validation and docs-contract tests to CI via full suite.
+- [ ] Keep full-history checkout for whitespace integrity.
+- [ ] Run local validators where possible and let PR CI run current Claude Code official validation/install smoke.
+
+### Task 8: Full verification, review, and merge
+
+**Files:**
+- No new product files unless review finds a concrete defect.
+
+**Interfaces:**
+- Consumes: complete branch and all CI/review feedback.
+- Produces: merged `main` commit only after verified head is green.
+
+- [ ] Run full unit suite, compile, Info-stories, plugin graph, ecosystem helper, marketplace, shell/JSON, and whitespace checks.
+- [ ] Open PR with architecture summary and exact validation matrix.
+- [ ] Inspect Qlty, CodeRabbit/Qodo/review threads; fix concrete findings with regression tests.
+- [ ] Require official `claude plugin validate .` and marketplace add/install smoke to pass on PR head.
+- [ ] Squash merge with `expected_head_sha`.
+- [ ] Verify merged files and `main` state after merge.

--- a/docs/superpowers/specs/2026-08-07-ecosystem-creative-runtime-addendum.md
+++ b/docs/superpowers/specs/2026-08-07-ecosystem-creative-runtime-addendum.md
@@ -1,0 +1,116 @@
+# Ecosystem v3 Creative Runtime Addendum
+
+This addendum extends the approved Ecosystem Routing Kernel v3 design with four plugin-local production requirements requested during implementation.
+
+## 1. Creative director as a first-class worker
+
+Add `agents/creative-director.md` before `story-architect` on the complete `new-post` shipping path.
+
+The worker receives source material, `build/evidence.json`, optional `build/design-study.json`, product constraints, language, format, and any approved brand limits. It returns `build/creative-concepts.json` to the parent workflow.
+
+The artifact contains at least three bounded directions. Every direction must include:
+
+- `concept_name`
+- `visual_hook`
+- `copy_hook`
+- `aha_mechanic`
+- `story_shape`
+- `recommended_visual_style`
+- `recommended_story_archetype`
+- `recommended_motion_behavior`
+- `evidence_dependencies`
+- `risk_notes`
+- `why_it_earns_attention`
+
+At least one direction must create a clear visual payoff or aha moment without relying on novelty for its own sake. The creative director may recombine structures, reveal relationships, transform states, stage comparisons, or use UI/mascot moments, but it may not invent claims, metrics, product behavior, or evidence.
+
+The parent workflow selects or approves one direction. `story-architect`, `copy-compressor`, `layout-composer`, and `motion-director` consume the selected direction rather than independently inventing competing concepts.
+
+## 2. Hook-driven design copy
+
+Infographic design copy must not default to neutral reporting language when the slot is responsible for attention or progression.
+
+Create a local quality gate `hooked-design-copy` with these rules:
+
+- hero headline must earn attention through specificity, tension, useful surprise, strong framing, a concrete outcome, or a recognisable problem
+- section openers may use micro-hooks when they advance the story, but labels, table headers, commands, and UI controls remain literal when clarity requires it
+- hooks cannot manufacture stakes, facts, urgency, social proof, or numbers
+- ban generic declarative openings that could move unchanged to another product or topic
+- preserve the user's own language and specific evidence
+- one strong hook is better than every label trying to sound clever
+
+`creative-director`, `copy-compressor`, `caption-writer`, and `post-critic` own this gate.
+
+## 3. Plugin-local creative quality gates
+
+Add `helper/quality-gates.json` as the machine-readable registry for local product behavior that is not attributed to upstream research.
+
+Required gates:
+
+- `hooked-design-copy`: blocking
+- `creative-payoff`: blocking for complete post creation and Info-story composition
+- `restrained-palette`: blocking unless the approved brief explicitly requests a louder treatment
+- `center-first-composition`: blocking unless the layout artifact records a valid alignment exception
+
+The existing helper defaults `creative-attractive-restrained` and `center-first` become enforcement inputs rather than prose-only guidance.
+
+A wow or aha moment means the content produces a useful visual payoff, reveal, state change, comparison, relationship, or interaction that makes the idea easier to understand or remember. It does not mean glow, 3D decoration, extreme saturation, excessive motion, or arbitrary spectacle.
+
+## 4. Strict module reality validator
+
+Add `helper/modules.json` as the public module manifest and `scripts/ecosystem_doctor.py` as the strict cross-repository validator.
+
+The manifest records active public modules by type: skills, agents, and tools. Every entry records its path, role, test contract, and one or more reachability links.
+
+The doctor must fail when any of these conditions is true:
+
+- declared module path does not exist
+- public skill exists but is absent from the manifest
+- public agent exists but is absent from the manifest
+- public tool in `tools/*.py` exists but is absent from the manifest
+- active skill is unreachable from a router route/condition or an agent preload
+- active agent is unreachable from a workflow sequence or conditional edge
+- active tool is not referenced by a skill, agent, helper guide, or declared validator contract
+- module test contract does not exist
+- helper capability owner is not a declared active agent
+- artifact producer/consumer is not a declared active participant
+- quality gate owner is not a declared active agent
+- research gate owner or implementation reference is dead
+- workflow sequence differs between router and plugin graph
+- complete-post route omits the creative director, post critic, or independent verifier
+
+`python3 scripts/ecosystem_doctor.py check` becomes the strict repository doctor and is required in CI before official Claude plugin validation.
+
+## 5. Updated complete-post sequence
+
+The canonical shipping sequence becomes:
+
+1. `design-study`
+2. `evidence-checker`
+3. `creative-director`
+4. `story-architect`
+5. `palette-curator`
+6. `copy-compressor`
+7. `layout-composer`
+8. `caption-writer`
+9. `artboard-builder`
+10. `motion-director`
+11. optional `mascot-animator` between still construction and motion implementation
+12. `motion-engineer`
+13. `render-qa`
+14. `post-critic`
+15. `story-verifier`
+
+Static output may skip motion-specific workers after the approved still, but it still requires adversarial critique and independent verification.
+
+## 6. Success criteria added by this addendum
+
+A complete route is only considered integrated when:
+
+- the creative director is reachable and produces its declared artifact
+- design copy exposes a real hook rather than merely restating source material
+- the selected concept contains a useful visual payoff or documented reason to stay intentionally plain
+- palette execution follows `creative-attractive-restrained`
+- composition follows `center-first` or records a valid exception
+- every public module is declared, reachable, tested, and referenced by the strict doctor
+- local quality gates and research-derived gates are both visible in the route result and enforced by shipping owners

--- a/docs/superpowers/specs/2026-08-07-ecosystem-routing-kernel-v3-design.md
+++ b/docs/superpowers/specs/2026-08-07-ecosystem-routing-kernel-v3-design.md
@@ -1,0 +1,189 @@
+# Ecosystem Routing Kernel v3 Design
+
+## Goal
+
+Turn the repository from a collection of strong skills and agents into one coherent, self-describing creative-production ecosystem with a central LLM routing helper, enforceable contracts, consistent worker interfaces, durable documentation, and a Claude Marketplace package that remains installable from the same repository.
+
+## Design principles
+
+1. One routing authority. `helper/` becomes the canonical guide for deciding what workflow, skills, agents, asset gates, and artifacts a request needs.
+2. One execution path. `new-post` remains the parent production orchestrator; workers never rely on hidden peer-to-peer delegation.
+3. Machine-readable contracts first. Human docs explain contracts but do not redefine them.
+4. Evidence before generation. Claims, product UI, brand assets, and official mascots are gated before visual production.
+5. Exact assets stay exact. Named official mascots require the exact user-supplied/task-attached SVG and may not be substituted.
+6. Extend, do not fork. Info-stories extensions merge deterministically through `load_catalog()`.
+7. All public surfaces are testable. Router, skills, agents, docs, marketplace, hooks, and registries get structural validation.
+8. Preserve the existing install identity unless a concrete incompatibility requires change.
+
+## Architecture
+
+### 1. Top-level helper
+
+Create `helper/` beside `skills/` and `agents/`.
+
+It contains:
+
+- `helper/README.md`: concise explanation for humans and coding agents
+- `helper/GUIDE.md`: LLM-facing routing and decision protocol
+- `helper/router.json`: intent-to-workflow routing rules and conditional gates
+- `helper/capabilities.json`: capability ownership and prerequisites
+- `helper/artifacts.json`: artifact names, producers, consumers, and required fields
+
+The helper does not render or generate content itself. It decides which existing capability should act, what it must receive, and what evidence it must return.
+
+### 2. Router implementation
+
+Add `scripts/ecosystem_router.py` as a deterministic validator/router over the helper registries. It exposes:
+
+- `load_ecosystem(root)`
+- `validate_ecosystem(root) -> list[str]`
+- `route_request(request: dict, root) -> dict`
+- CLI commands `check`, `route`, and `explain`
+
+A thin public CLI `tools/route_request.py` calls the shared implementation.
+
+Routing is explicit for these intents:
+
+- full post creation
+- QA/review
+- GIF rendering
+- focused design study
+- focused mascot animation
+- focused Info-stories composition
+
+Conditional gates include Arabic/RTL, official mascot SVG, UI mockup evidence fidelity, reference-study input, and static versus animated output.
+
+### 3. Artifact contracts
+
+Every important handoff gets a named artifact contract. Minimum production artifacts:
+
+- `build/design-study.json`
+- `build/evidence.json`
+- `build/story-brief.json`
+- `build/palette-check.json`
+- `build/artboard-copy.json`
+- `build/layout-spec.json`
+- `build/caption.md`
+- `build/first-comment.md`
+- `build/post.html`
+- `build/still.png`
+- `build/motion-direction.json`
+- `build/mascot-request.json`
+- `build/mascot/motion-contract.json`
+- `build/render-report.json`
+- `build/critic-report.json`
+- `build/verification-report.json`
+
+`helper/artifacts.json` records producer, consumers, required inputs, and blocking semantics.
+
+### 4. Skill contracts v3
+
+All user-facing skills adopt a consistent structure:
+
+- Purpose
+- Use when
+- Inputs
+- Outputs
+- Procedure
+- Stop/HOLD conditions
+- Related agents/tools/references
+
+`post` becomes a lightweight entry router that points to the helper and canonical workflows. `new-post`, `qa-post`, and `render-gif` remain explicit workflow skills. Domain skills stay focused and stop duplicating orchestration prose.
+
+### 5. Agent contracts v3
+
+Every agent adopts a consistent worker contract:
+
+- Role
+- Inputs
+- Method
+- HOLD conditions
+- Quality gates
+- Outputs / return contract
+
+Required skills are preloaded through `skills:` frontmatter. Worker output always returns to the parent workflow. No agent is allowed to assume it can coordinate peer agents directly.
+
+The existing 14 agents remain, including `mascot-animator`. Capability ownership is synchronized between `helper/capabilities.json` and `architecture/plugin-graph.json`.
+
+### 6. Info-stories and UI Mockup Stories
+
+The merged registry produced by `scripts/info_stories.py::load_catalog()` remains authoritative. UI Mockup Stories remain a first-party extension.
+
+The helper adds routing knowledge for UI stories:
+
+- documented product UI must be evidence-backed
+- concept UI must be labeled when it could be mistaken for real product evidence
+- unsupported metrics/features/integrations remain blocked
+- feed-width legibility is a production gate
+
+### 7. Mascot Animator v3 integration
+
+The existing exact-SVG identity gate remains mandatory.
+
+The helper adds a routing rule: a named/official mascot without an exact SVG results in `HOLD: exact SVG required`. The main model asks the user for the SVG; a subagent returns the HOLD to its parent.
+
+Creative directions remain adaptable starting points, not fixed templates. Identity-critical geometry, proportions, brand colors, marks, and distinctive face details cannot be silently redrawn.
+
+### 8. Documentation model
+
+README becomes a concise product and quick-start document. Detailed material moves to focused docs:
+
+- `docs/ecosystem.md`: architecture and capability overview
+- `docs/routing.md`: helper routing protocol and examples
+- `docs/agents.md`: complete agent catalog and handoff contracts
+- `docs/skills.md`: complete skill catalog and selection guidance
+- `docs/marketplace.md`: install, validate, release, and versioning
+- `docs/development.md`: tests, validators, contribution workflow, browser-render caveats
+
+Repository-specific coding-agent guidance in `.agents/`, `.claude/`, and `.codex/` must point to the same helper authority rather than inventing parallel rules.
+
+### 9. Claude Marketplace
+
+Keep the same-repository marketplace and stable install identity:
+
+- marketplace: `mamdouh-creative-tools`
+- plugin: `linkedin-animated-infographics`
+- source: `./`
+- strict mode: true
+
+Bump the plugin release to `3.0.0` because the internal routing/contracts architecture changes materially. Marketplace and plugin versions must match.
+
+CI continues to install the current Claude Code release and must run:
+
+- full Python unit suite
+- Python compilation
+- Info-stories validation
+- plugin graph validation
+- ecosystem helper validation
+- marketplace validation
+- hook/shell syntax
+- whitespace integrity
+- `claude plugin validate .`
+- local marketplace add/list/install smoke
+
+### 10. Branch and PR policy
+
+Historical branches already represented in `main` are not re-merged. New work starts from current `main` on `feat/ecosystem-routing-kernel-v3`.
+
+The feature is merged only when:
+
+- all deterministic tests pass
+- Claude plugin validation/install smoke pass
+- no unresolved review thread remains
+- Qlty or equivalent repository checks do not report a blocking failure
+- the PR head SHA verified is the SHA merged
+
+## Non-goals
+
+- no new rendering engine
+- no framework migration
+- no replacement of the deterministic HTML/SVG/GIF pipeline
+- no duplication of Info-stories registries
+- no automatic mascot generation when an official mascot was requested
+- no requirement to use every agent for every focused request
+
+## Success criteria
+
+A fresh LLM or coding agent can enter the repository, read `helper/GUIDE.md`, route a request to the correct workflow, identify required assets and HOLD states, know the exact artifacts each worker exchanges, and discover the authoritative docs without reading the entire repository.
+
+A clean Claude Code environment can add the same-repository marketplace, install version 3.0.0, discover the skills and agents, and pass the repository validation workflow.

--- a/docs/superpowers/specs/2026-08-07-ecosystem-routing-kernel-v3-design.md
+++ b/docs/superpowers/specs/2026-08-07-ecosystem-routing-kernel-v3-design.md
@@ -2,18 +2,19 @@
 
 ## Goal
 
-Turn the repository from a collection of strong skills and agents into one coherent, self-describing creative-production ecosystem with a central LLM routing helper, enforceable contracts, consistent worker interfaces, durable documentation, and a Claude Marketplace package that remains installable from the same repository.
+Turn the repository from a collection of strong skills, agents, and research notes into one coherent, self-describing creative-production ecosystem with a central LLM routing helper, enforceable contracts, active research-derived gates, consistent worker interfaces, durable documentation, and a Claude Marketplace package that remains installable from the same repository.
 
 ## Design principles
 
-1. One routing authority. `helper/` becomes the canonical guide for deciding what workflow, skills, agents, asset gates, and artifacts a request needs.
+1. One routing authority. `helper/` becomes the canonical guide for deciding what workflow, skills, agents, asset gates, research gates, and artifacts a request needs.
 2. One execution path. `new-post` remains the parent production orchestrator; workers never rely on hidden peer-to-peer delegation.
 3. Machine-readable contracts first. Human docs explain contracts but do not redefine them.
 4. Evidence before generation. Claims, product UI, brand assets, and official mascots are gated before visual production.
 5. Exact assets stay exact. Named official mascots require the exact user-supplied/task-attached SVG and may not be substituted.
 6. Extend, do not fork. Info-stories extensions merge deterministically through `load_catalog()`.
-7. All public surfaces are testable. Router, skills, agents, docs, marketplace, hooks, and registries get structural validation.
-8. Preserve the existing install identity unless a concrete incompatibility requires change.
+7. Research must ship as behavior. Adopted research capability notes must map to explicit runtime gates, owners, stages, and tests; research may not remain dead documentation.
+8. All public surfaces are testable. Router, research gates, skills, agents, docs, marketplace, hooks, and registries get structural validation.
+9. Preserve the existing install identity unless a concrete incompatibility requires change.
 
 ## Architecture
 
@@ -26,10 +27,10 @@ It contains:
 - `helper/README.md`: concise explanation for humans and coding agents
 - `helper/GUIDE.md`: LLM-facing routing and decision protocol
 - `helper/router.json`: intent-to-workflow routing rules and conditional gates
-- `helper/capabilities.json`: capability ownership and prerequisites
-- `helper/artifacts.json`: artifact names, producers, consumers, and required fields
+- `helper/capabilities.json`: capability ownership, prerequisites, and research-gate references
+- `helper/artifacts.json`: artifact names, producers, consumers, and blocking semantics
 
-The helper does not render or generate content itself. It decides which existing capability should act, what it must receive, and what evidence it must return.
+The helper does not render or generate content itself. It decides which existing capability should act, what it must receive, what research-derived gates apply, and what evidence it must return.
 
 ### 2. Router implementation
 
@@ -51,7 +52,7 @@ Routing is explicit for these intents:
 - focused mascot animation
 - focused Info-stories composition
 
-Conditional gates include Arabic/RTL, official mascot SVG, UI mockup evidence fidelity, reference-study input, and static versus animated output.
+Conditional gates include Arabic/RTL, official mascot SVG, UI mockup evidence fidelity, reference-study input, static versus animated output, and research-derived quality gates.
 
 ### 3. Artifact contracts
 
@@ -76,7 +77,36 @@ Every important handoff gets a named artifact contract. Minimum production artif
 
 `helper/artifacts.json` records producer, consumers, required inputs, and blocking semantics.
 
-### 4. Skill contracts v3
+### 4. Research capability gates
+
+`research/` becomes an active, validated input to production rather than a passive archive.
+
+The existing provenance snapshot in `research/capability-notes/sources.json` remains the source record for inspected upstream repositories. Add `research/capability-notes/gates.json` as the machine-readable adoption contract. Each gate records:
+
+- a stable gate ID
+- one or more source names from `sources.json`
+- the local independently-worded behavior being adopted
+- the stage where the gate runs
+- owning agents
+- blocking versus advisory severity
+- direct references to the local implementation or reference document
+
+Required first-party gates:
+
+- `prose-specificity`: named prose-pattern detection and removal of generic filler, informed by stop-slop and no-ai-slop
+- `voice-preservation`: preserve specific facts, voice, and intentional short labels while editing, informed by no-ai-slop
+- `design-dials`: explicit variance/density/motion decisions, informed by taste-skill
+- `structural-originality`: reject palette-only reskins and require meaningful structural variation, informed by taste-skill and Hallmark
+- `reference-dna`: extract reusable structural design DNA without signature-work copying, informed by Hallmark
+- `contrast-discipline`: enforce semantic token and contrast floors, informed by taste-skill and Hallmark
+- `evidence-traceability`: require evidence rows for factual claims and proof, informed by COG-second-brain and Hallmark
+- `bounded-verification`: independent verification with a maximum two targeted repair attempts, informed by COG-second-brain
+
+Add `scripts/research_gates.py` to validate provenance, source names, gate ownership, local implementation references, and linkage to `helper/capabilities.json`. The ecosystem router loads the gates and returns applicable gate IDs with each route.
+
+No upstream working copy is packaged with the plugin. Only provenance, independently-worded local rules, and machine-readable adoption contracts ship.
+
+### 5. Skill contracts v3
 
 All user-facing skills adopt a consistent structure:
 
@@ -85,12 +115,13 @@ All user-facing skills adopt a consistent structure:
 - Inputs
 - Outputs
 - Procedure
-- Stop/HOLD conditions
-- Related agents/tools/references
+- HOLD conditions
+- Related components
+- Research gates
 
 `post` becomes a lightweight entry router that points to the helper and canonical workflows. `new-post`, `qa-post`, and `render-gif` remain explicit workflow skills. Domain skills stay focused and stop duplicating orchestration prose.
 
-### 5. Agent contracts v3
+### 6. Agent contracts v3
 
 Every agent adopts a consistent worker contract:
 
@@ -99,13 +130,14 @@ Every agent adopts a consistent worker contract:
 - Method
 - HOLD conditions
 - Quality gates
+- Research gates
 - Outputs / return contract
 
 Required skills are preloaded through `skills:` frontmatter. Worker output always returns to the parent workflow. No agent is allowed to assume it can coordinate peer agents directly.
 
-The existing 14 agents remain, including `mascot-animator`. Capability ownership is synchronized between `helper/capabilities.json` and `architecture/plugin-graph.json`.
+The existing 14 agents remain, including `mascot-animator`. Capability ownership is synchronized between `helper/capabilities.json`, `research/capability-notes/gates.json`, and `architecture/plugin-graph.json`.
 
-### 6. Info-stories and UI Mockup Stories
+### 7. Info-stories and UI Mockup Stories
 
 The merged registry produced by `scripts/info_stories.py::load_catalog()` remains authoritative. UI Mockup Stories remain a first-party extension.
 
@@ -115,8 +147,9 @@ The helper adds routing knowledge for UI stories:
 - concept UI must be labeled when it could be mistaken for real product evidence
 - unsupported metrics/features/integrations remain blocked
 - feed-width legibility is a production gate
+- structural-originality, design-dials, evidence-traceability, and contrast-discipline research gates apply where relevant
 
-### 7. Mascot Animator v3 integration
+### 8. Mascot Animator v3 integration
 
 The existing exact-SVG identity gate remains mandatory.
 
@@ -124,20 +157,21 @@ The helper adds a routing rule: a named/official mascot without an exact SVG res
 
 Creative directions remain adaptable starting points, not fixed templates. Identity-critical geometry, proportions, brand colors, marks, and distinctive face details cannot be silently redrawn.
 
-### 8. Documentation model
+### 9. Documentation model
 
 README becomes a concise product and quick-start document. Detailed material moves to focused docs:
 
-- `docs/ecosystem.md`: architecture and capability overview
+- `docs/ecosystem.md`: architecture, capability, and research-gate overview
 - `docs/routing.md`: helper routing protocol and examples
-- `docs/agents.md`: complete agent catalog and handoff contracts
+- `docs/agents.md`: complete agent catalog and handoff/research-gate contracts
 - `docs/skills.md`: complete skill catalog and selection guidance
+- `docs/research.md`: provenance, adopted gates, deliberate exclusions, and how research becomes local behavior
 - `docs/marketplace.md`: install, validate, release, and versioning
 - `docs/development.md`: tests, validators, contribution workflow, browser-render caveats
 
 Repository-specific coding-agent guidance in `.agents/`, `.claude/`, and `.codex/` must point to the same helper authority rather than inventing parallel rules.
 
-### 9. Claude Marketplace
+### 10. Claude Marketplace
 
 Keep the same-repository marketplace and stable install identity:
 
@@ -155,19 +189,21 @@ CI continues to install the current Claude Code release and must run:
 - Info-stories validation
 - plugin graph validation
 - ecosystem helper validation
+- research-gate/provenance validation
 - marketplace validation
 - hook/shell syntax
 - whitespace integrity
 - `claude plugin validate .`
 - local marketplace add/list/install smoke
 
-### 10. Branch and PR policy
+### 11. Branch and PR policy
 
 Historical branches already represented in `main` are not re-merged. New work starts from current `main` on `feat/ecosystem-routing-kernel-v3`.
 
 The feature is merged only when:
 
 - all deterministic tests pass
+- research gates are linked to provenance and shipping owners
 - Claude plugin validation/install smoke pass
 - no unresolved review thread remains
 - Qlty or equivalent repository checks do not report a blocking failure
@@ -180,10 +216,14 @@ The feature is merged only when:
 - no replacement of the deterministic HTML/SVG/GIF pipeline
 - no duplication of Info-stories registries
 - no automatic mascot generation when an official mascot was requested
+- no packaging of cloned upstream repositories
+- no verbatim import of upstream prose or implementation
 - no requirement to use every agent for every focused request
 
 ## Success criteria
 
-A fresh LLM or coding agent can enter the repository, read `helper/GUIDE.md`, route a request to the correct workflow, identify required assets and HOLD states, know the exact artifacts each worker exchanges, and discover the authoritative docs without reading the entire repository.
+A fresh LLM or coding agent can enter the repository, read `helper/GUIDE.md`, route a request to the correct workflow, identify required assets and HOLD states, know the exact artifacts each worker exchanges, see which research-derived gates apply and why, and discover the authoritative docs without reading the entire repository.
+
+Every adopted research capability is traceable from upstream provenance to a local gate, local implementation, shipping owner, and regression test.
 
 A clean Claude Code environment can add the same-repository marketplace, install version 3.0.0, discover the skills and agents, and pass the repository validation workflow.

--- a/helper/GUIDE.md
+++ b/helper/GUIDE.md
@@ -7,8 +7,10 @@ Read this file before choosing a production skill or worker.
 The machine-readable routing authority is split across:
 
 - `helper/router.json` for intent and conditional routing
-- `helper/capabilities.json` for capability ownership
+- `helper/capabilities.json` for capability ownership and research-gate linkage
 - `helper/artifacts.json` for handoff artifacts
+- `research/capability-notes/sources.json` for inspected upstream provenance
+- `research/capability-notes/gates.json` for adopted runtime research gates
 - `architecture/plugin-graph.json` for executable worker order and required skill preloads
 - `scripts/info_stories.py::load_catalog()` for the merged Info-stories registry
 
@@ -24,11 +26,34 @@ If prose conflicts with one of those contracts, stop and repair the drift instea
    - animate an SVG mascot as a focused task: `mascot-animation`
    - compose an Info-story without running the whole post pipeline: `info-story`
 2. Load the route from `router.json`.
-3. Apply conditional gates before generation.
-4. Confirm required assets and evidence.
-5. Invoke the selected workflow or focused skill.
-6. Workers return artifacts to the parent workflow. They do not coordinate peers through hidden handoffs.
-7. Stop on a blocking `HOLD`; do not improvise around it.
+3. Resolve capability owners from `capabilities.json`.
+4. Apply the route's research gates from `research/capability-notes/gates.json`.
+5. Apply conditional asset/language/UI/reference gates before generation.
+6. Confirm required assets and evidence.
+7. Invoke the selected workflow or focused skill.
+8. Workers return artifacts to the parent workflow. They do not coordinate peers through hidden handoffs.
+9. Stop on a blocking `HOLD`; do not improvise around it.
+
+## Research gates
+
+Research is active production guidance, not background reading. The current adopted gate IDs are:
+
+- `prose-specificity`: reject named filler and low-information copy patterns per slot
+- `voice-preservation`: protect facts, mechanisms, names, numbers, and deliberate voice while editing
+- `design-dials`: require explicit design variance, visual density, and motion intensity decisions
+- `structural-originality`: reject palette-only reskins and require meaningful structural variation
+- `reference-dna`: when a reference exists, diagnose reusable structure without cloning distinctive work
+- `contrast-discipline`: enforce the established semantic-token and contrast floors
+- `evidence-traceability`: tie factual claims, product states, metrics, logos, and acceptance rows to evidence
+- `bounded-verification`: keep verification independent and allow at most two targeted repair attempts
+
+The gate registry records source provenance, stage, severity, owners, local behavior, and implementation references. Upstream repositories are research inputs only; their working copies are not runtime dependencies and are not packaged with the plugin.
+
+Validate this layer with:
+
+```bash
+python3 scripts/research_gates.py check
+```
 
 ## Conditional gates
 
@@ -44,11 +69,11 @@ The main model asks the user to attach the exact SVG. A subagent returns the HOL
 
 ### UI mockup story
 
-Enable the `ui-mockup-fidelity` capability. Product states, features, metrics, integrations, logos, and proof that appear real must be evidence-backed. Clearly label concept UI or fictional data when it could be mistaken for documented product behavior.
+Enable the `ui-mockup-fidelity` capability. Product states, features, metrics, integrations, logos, and proof that appear real must be evidence-backed. Clearly label concept UI or fictional data when it could be mistaken for documented product behavior. The route applies `structural-originality`, `contrast-discipline`, and `evidence-traceability` where applicable.
 
 ### Visual references
 
-Use `design-study` to extract reusable design DNA. Do not copy a reference pixel-for-pixel or treat its palette as the only source of variation.
+Use `design-study` to extract reusable design DNA. Do not copy a reference pixel-for-pixel or treat its palette as the only source of variation. When a reference is present, activate `reference-dna` before layout production.
 
 ### Static versus animated output
 
@@ -60,12 +85,13 @@ Static work stops after still QA and final verification. Animated work adds moti
 
 ## HOLD semantics
 
-A HOLD means a required input or quality gate is missing. Common cases:
+A HOLD means a required input or blocking quality gate is missing. Common cases:
 
 - exact official mascot SVG missing
 - unsupported factual proof
 - unreadable contrast
 - incompatible Info-stories composition
+- unresolved blocking research-gate finding
 - required render evidence unavailable
 
 Do not convert a HOLD into invented content. State the missing requirement and wait for the parent workflow or user to resolve it.

--- a/helper/GUIDE.md
+++ b/helper/GUIDE.md
@@ -7,7 +7,7 @@ Read this file before choosing a production skill or worker.
 The machine-readable routing authority is split across:
 
 - `helper/router.json` for intent and conditional routing
-- `helper/capabilities.json` for capability ownership and research-gate linkage
+- `helper/capabilities.json` for capability ownership, research-gate linkage, and plugin-local defaults
 - `helper/artifacts.json` for handoff artifacts
 - `research/capability-notes/sources.json` for inspected upstream provenance
 - `research/capability-notes/gates.json` for adopted runtime research gates
@@ -26,13 +26,22 @@ If prose conflicts with one of those contracts, stop and repair the drift instea
    - animate an SVG mascot as a focused task: `mascot-animation`
    - compose an Info-story without running the whole post pipeline: `info-story`
 2. Load the route from `router.json`.
-3. Resolve capability owners from `capabilities.json`.
+3. Resolve capability owners and plugin-local defaults from `capabilities.json`.
 4. Apply the route's research gates from `research/capability-notes/gates.json`.
 5. Apply conditional asset/language/UI/reference gates before generation.
 6. Confirm required assets and evidence.
 7. Invoke the selected workflow or focused skill.
 8. Workers return artifacts to the parent workflow. They do not coordinate peers through hidden handoffs.
 9. Stop on a blocking `HOLD`; do not improvise around it.
+
+## Plugin-local visual defaults
+
+These are repository product defaults, not research-source claims.
+
+- Palette character is `creative-attractive-restrained`. Prefer color combinations that are distinctive, harmonious, and visually engaging without exaggerated saturation, unnecessary neon, or multiple competing accents unless the approved brief explicitly calls for them.
+- Infographic composition is `center-first`. Center the primary visual anchor and major story zones by default so the fixed 1080x1350 page reads as one intentional composition.
+- Use an alignment exception only when it improves comprehension or fidelity. Accepted categories include tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL reading flow, and documented reference-DNA decisions.
+- Record the alignment exception in the layout artifact. Do not introduce off-center composition only for decorative asymmetry.
 
 ## Research gates
 
@@ -59,7 +68,7 @@ python3 scripts/research_gates.py check
 
 ### Arabic or RTL
 
-Add the `arabic` skill before copy and layout work. Preserve bidi isolation, RTL ordering, Arabic typography, and the existing render constraints.
+Add the `arabic` skill before copy and layout work. Preserve bidi isolation, RTL ordering, Arabic typography, and the existing render constraints. RTL reading flow is an explicit alignment exception when center-first would reduce comprehension.
 
 ### Named or official mascot
 
@@ -69,11 +78,11 @@ The main model asks the user to attach the exact SVG. A subagent returns the HOL
 
 ### UI mockup story
 
-Enable the `ui-mockup-fidelity` capability. Product states, features, metrics, integrations, logos, and proof that appear real must be evidence-backed. Clearly label concept UI or fictional data when it could be mistaken for documented product behavior. The route applies `structural-originality`, `contrast-discipline`, and `evidence-traceability` where applicable.
+Enable the `ui-mockup-fidelity` capability. Product states, features, metrics, integrations, logos, and proof that appear real must be evidence-backed. Clearly label concept UI or fictional data when it could be mistaken for documented product behavior. The route applies `structural-originality`, `contrast-discipline`, and `evidence-traceability` where applicable. UI control alignment may override center-first when product fidelity or reading order requires it.
 
 ### Visual references
 
-Use `design-study` to extract reusable design DNA. Do not copy a reference pixel-for-pixel or treat its palette as the only source of variation. When a reference is present, activate `reference-dna` before layout production.
+Use `design-study` to extract reusable design DNA. Do not copy a reference pixel-for-pixel or treat its palette as the only source of variation. When a reference is present, activate `reference-dna` before layout production. A studied alignment pattern may override center-first only when it materially serves the content and is recorded as a reference-DNA decision.
 
 ### Static versus animated output
 

--- a/helper/GUIDE.md
+++ b/helper/GUIDE.md
@@ -1,0 +1,75 @@
+# LLM Routing Guide
+
+Read this file before choosing a production skill or worker.
+
+## Authority
+
+The machine-readable routing authority is split across:
+
+- `helper/router.json` for intent and conditional routing
+- `helper/capabilities.json` for capability ownership
+- `helper/artifacts.json` for handoff artifacts
+- `architecture/plugin-graph.json` for executable worker order and required skill preloads
+- `scripts/info_stories.py::load_catalog()` for the merged Info-stories registry
+
+If prose conflicts with one of those contracts, stop and repair the drift instead of guessing.
+
+## Decision protocol
+
+1. Classify the user intent.
+   - create or redesign a post: `create-post`
+   - inspect a finished post: `qa`
+   - render an approved HTML artboard: `render`
+   - study a visual reference: `design-study`
+   - animate an SVG mascot as a focused task: `mascot-animation`
+   - compose an Info-story without running the whole post pipeline: `info-story`
+2. Load the route from `router.json`.
+3. Apply conditional gates before generation.
+4. Confirm required assets and evidence.
+5. Invoke the selected workflow or focused skill.
+6. Workers return artifacts to the parent workflow. They do not coordinate peers through hidden handoffs.
+7. Stop on a blocking `HOLD`; do not improvise around it.
+
+## Conditional gates
+
+### Arabic or RTL
+
+Add the `arabic` skill before copy and layout work. Preserve bidi isolation, RTL ordering, Arabic typography, and the existing render constraints.
+
+### Named or official mascot
+
+The exact user-supplied or task-attached SVG is mandatory. If it is missing, return `HOLD: exact SVG required`.
+
+The main model asks the user to attach the exact SVG. A subagent returns the HOLD to its parent workflow. Never redraw, approximate, substitute, or generate a lookalike automatically.
+
+### UI mockup story
+
+Enable the `ui-mockup-fidelity` capability. Product states, features, metrics, integrations, logos, and proof that appear real must be evidence-backed. Clearly label concept UI or fictional data when it could be mistaken for documented product behavior.
+
+### Visual references
+
+Use `design-study` to extract reusable design DNA. Do not copy a reference pixel-for-pixel or treat its palette as the only source of variation.
+
+### Static versus animated output
+
+Static work stops after still QA and final verification. Animated work adds motion direction, optional mascot animation, motion implementation, and render QA.
+
+## Parent workflow rule
+
+`new-post` is the canonical parent workflow for complete post creation. It owns user approvals, HOLD resolution, repair loops, and final delivery. Every worker returns a bounded artifact to the parent workflow.
+
+## HOLD semantics
+
+A HOLD means a required input or quality gate is missing. Common cases:
+
+- exact official mascot SVG missing
+- unsupported factual proof
+- unreadable contrast
+- incompatible Info-stories composition
+- required render evidence unavailable
+
+Do not convert a HOLD into invented content. State the missing requirement and wait for the parent workflow or user to resolve it.
+
+## Final verification
+
+A complete post is not ready because generation finished. The shipping path ends with render evidence, adversarial review, and independent verification. The final verifier may request at most two targeted repair attempts before escalation.

--- a/helper/README.md
+++ b/helper/README.md
@@ -1,0 +1,26 @@
+# Ecosystem Helper
+
+`helper/` is the routing authority for this repository. It sits beside `skills/` and `agents/` and tells an LLM which workflow should run, which capabilities and workers are required, which assets can block progress, and which artifacts form the handoff contract.
+
+The helper does not replace domain skills or agents. It keeps them coordinated.
+
+## Files
+
+- `GUIDE.md`: LLM-facing decision protocol
+- `router.json`: intent, workflow, skill, agent, and conditional routing
+- `capabilities.json`: capability ownership
+- `artifacts.json`: artifact producers, consumers, and blocking semantics
+
+Validate the complete helper with:
+
+```bash
+python3 scripts/ecosystem_router.py check
+```
+
+Route a structured request with:
+
+```bash
+python3 tools/route_request.py --request "Create an animated LinkedIn infographic" --output gif
+```
+
+The helper is machine-readable. Human documentation may explain it but must not contradict it.

--- a/helper/artifacts.json
+++ b/helper/artifacts.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "artifacts": {
+    "build/design-study.json": {"producer": "design-study", "consumers": ["story-architect", "layout-composer"], "blocking": false},
+    "build/evidence.json": {"producer": "evidence-checker", "consumers": ["story-architect", "copy-compressor", "post-critic", "story-verifier"], "blocking": true},
+    "build/story-brief.json": {"producer": "story-architect", "consumers": ["palette-curator", "copy-compressor", "layout-composer", "artboard-builder", "motion-director", "motion-engineer", "story-verifier"], "blocking": true},
+    "build/palette-check.json": {"producer": "palette-curator", "consumers": ["layout-composer", "artboard-builder"], "blocking": true},
+    "build/artboard-copy.json": {"producer": "copy-compressor", "consumers": ["layout-composer", "artboard-builder"], "blocking": true},
+    "build/layout-spec.json": {"producer": "layout-composer", "consumers": ["artboard-builder", "motion-director", "mascot-animator", "post-critic"], "blocking": true},
+    "build/caption.md": {"producer": "caption-writer", "consumers": ["artboard-builder", "post-critic", "story-verifier"], "blocking": false},
+    "build/first-comment.md": {"producer": "caption-writer", "consumers": ["parent:new-post"], "blocking": false},
+    "build/post.html": {"producer": "artboard-builder", "consumers": ["motion-engineer", "render-qa", "post-critic", "story-verifier"], "blocking": true},
+    "build/still.png": {"producer": "artboard-builder", "consumers": ["motion-director", "mascot-animator", "parent:new-post"], "blocking": true},
+    "build/motion-direction.json": {"producer": "motion-director", "consumers": ["mascot-animator", "motion-engineer"], "blocking": false},
+    "build/mascot-request.json": {"producer": "parent:new-post", "consumers": ["mascot-animator"], "blocking": true},
+    "build/mascot/motion-contract.json": {"producer": "mascot-animator", "consumers": ["motion-engineer", "post-critic", "story-verifier"], "blocking": true},
+    "build/render-report.json": {"producer": "render-qa", "consumers": ["post-critic", "story-verifier"], "blocking": true},
+    "build/critic-report.json": {"producer": "post-critic", "consumers": ["story-verifier"], "blocking": true},
+    "build/verification-report.json": {"producer": "story-verifier", "consumers": ["parent:new-post"], "blocking": true}
+  }
+}

--- a/helper/artifacts.json
+++ b/helper/artifacts.json
@@ -1,8 +1,14 @@
 {
   "schema_version": 1,
   "artifacts": {
-    "build/design-study.json": {"producer": "design-study", "consumers": ["story-architect", "layout-composer"], "blocking": false},
-    "build/evidence.json": {"producer": "evidence-checker", "consumers": ["story-architect", "copy-compressor", "post-critic", "story-verifier"], "blocking": true},
+    "build/design-study.json": {"producer": "design-study", "consumers": ["creative-director", "story-architect", "layout-composer"], "blocking": false},
+    "build/evidence.json": {"producer": "evidence-checker", "consumers": ["creative-director", "story-architect", "copy-compressor", "post-critic", "story-verifier"], "blocking": true},
+    "build/creative-concepts.json": {
+      "producer": "creative-director",
+      "consumers": ["story-architect", "copy-compressor", "layout-composer", "motion-director"],
+      "blocking": true,
+      "required_fields": ["concept_name", "visual_hook", "copy_hook", "aha_mechanic", "story_shape", "recommended_visual_style", "recommended_story_archetype", "recommended_motion_behavior", "evidence_dependencies", "risk_notes", "why_it_earns_attention"]
+    },
     "build/story-brief.json": {"producer": "story-architect", "consumers": ["palette-curator", "copy-compressor", "layout-composer", "artboard-builder", "motion-director", "motion-engineer", "story-verifier"], "blocking": true},
     "build/palette-check.json": {"producer": "palette-curator", "consumers": ["layout-composer", "artboard-builder"], "blocking": true},
     "build/artboard-copy.json": {"producer": "copy-compressor", "consumers": ["layout-composer", "artboard-builder"], "blocking": true},

--- a/helper/capabilities.json
+++ b/helper/capabilities.json
@@ -6,6 +6,12 @@
       "owners": ["copy-compressor", "caption-writer", "post-critic"],
       "research_gates": ["prose-specificity", "voice-preservation"]
     },
+    "creative-direction": {
+      "purpose": "Generate evidence-safe concept directions with visual hooks, copy hooks, and useful aha mechanics before story architecture hardens.",
+      "owners": ["creative-director", "story-architect", "layout-composer", "post-critic"],
+      "local_native": true,
+      "research_gates": []
+    },
     "design-taste": {
       "purpose": "Translate references and briefs into deliberate visual decisions instead of template copying.",
       "owners": ["design-study", "layout-composer", "artboard-builder", "post-critic"],
@@ -16,20 +22,16 @@
         "alignment_exceptions": ["tables", "ui-mockups", "code-or-terminal", "timelines", "arabic-rtl", "reference-dna"]
       }
     },
-    "structural-fingerprint": {
-      "purpose": "Require meaningful structural variation and reject palette-only reskins.",
-      "owners": ["layout-composer", "artboard-builder", "post-critic"],
-      "research_gates": ["structural-originality", "reference-dna"]
-    },
     "evidence": {
       "purpose": "Keep factual claims, proof, logos, UI states, and product behavior tied to supplied evidence.",
       "owners": ["evidence-checker", "copy-compressor", "story-verifier"],
       "research_gates": ["evidence-traceability", "voice-preservation"]
     },
-    "verification-loop": {
-      "purpose": "Produce deterministic render evidence, adversarial review, and bounded independent verification before delivery.",
-      "owners": ["render-qa", "post-critic", "story-verifier"],
-      "research_gates": ["bounded-verification", "evidence-traceability"]
+    "hook-design-copy": {
+      "purpose": "Make attention-bearing infographic copy hook-led while keeping literal labels literal and preserving evidence safety.",
+      "owners": ["creative-director", "copy-compressor", "caption-writer", "post-critic"],
+      "local_native": true,
+      "research_gates": []
     },
     "mascot-identity": {
       "purpose": "Preserve the exact supplied official mascot identity through inspection, animation, and verification.",
@@ -37,10 +39,20 @@
       "local_native": true,
       "research_gates": []
     },
+    "structural-fingerprint": {
+      "purpose": "Require meaningful structural variation and reject palette-only reskins.",
+      "owners": ["layout-composer", "artboard-builder", "post-critic"],
+      "research_gates": ["structural-originality", "reference-dna"]
+    },
     "ui-mockup-fidelity": {
       "purpose": "Keep product UI mockups legible and evidence-backed, and distinguish documented UI from concept UI.",
       "owners": ["evidence-checker", "layout-composer", "artboard-builder", "post-critic"],
       "research_gates": ["structural-originality", "contrast-discipline", "evidence-traceability"]
+    },
+    "verification-loop": {
+      "purpose": "Produce deterministic render evidence, adversarial review, and bounded independent verification before delivery.",
+      "owners": ["render-qa", "post-critic", "story-verifier"],
+      "research_gates": ["bounded-verification", "evidence-traceability"]
     }
   }
 }

--- a/helper/capabilities.json
+++ b/helper/capabilities.json
@@ -3,31 +3,39 @@
   "capabilities": {
     "anti-slop": {
       "purpose": "Detect and remove generic, repetitive, or low-information copy patterns without erasing specific voice or facts.",
-      "owners": ["copy-compressor", "caption-writer", "post-critic"]
+      "owners": ["copy-compressor", "caption-writer", "post-critic"],
+      "research_gates": ["prose-specificity", "voice-preservation"]
     },
     "design-taste": {
       "purpose": "Translate references and briefs into deliberate visual decisions instead of template copying.",
-      "owners": ["design-study", "layout-composer", "artboard-builder", "post-critic"]
+      "owners": ["design-study", "layout-composer", "artboard-builder", "post-critic"],
+      "research_gates": ["design-dials", "structural-originality", "reference-dna", "contrast-discipline"]
     },
     "structural-fingerprint": {
       "purpose": "Require meaningful structural variation and reject palette-only reskins.",
-      "owners": ["layout-composer", "artboard-builder", "post-critic"]
+      "owners": ["layout-composer", "artboard-builder", "post-critic"],
+      "research_gates": ["structural-originality", "reference-dna"]
     },
     "evidence": {
       "purpose": "Keep factual claims, proof, logos, UI states, and product behavior tied to supplied evidence.",
-      "owners": ["evidence-checker", "copy-compressor", "story-verifier"]
+      "owners": ["evidence-checker", "copy-compressor", "story-verifier"],
+      "research_gates": ["evidence-traceability", "voice-preservation"]
     },
     "verification-loop": {
       "purpose": "Produce deterministic render evidence, adversarial review, and bounded independent verification before delivery.",
-      "owners": ["render-qa", "post-critic", "story-verifier"]
+      "owners": ["render-qa", "post-critic", "story-verifier"],
+      "research_gates": ["bounded-verification", "evidence-traceability"]
     },
     "mascot-identity": {
       "purpose": "Preserve the exact supplied official mascot identity through inspection, animation, and verification.",
-      "owners": ["mascot-animator", "post-critic", "story-verifier"]
+      "owners": ["mascot-animator", "post-critic", "story-verifier"],
+      "local_native": true,
+      "research_gates": []
     },
     "ui-mockup-fidelity": {
       "purpose": "Keep product UI mockups legible and evidence-backed, and distinguish documented UI from concept UI.",
-      "owners": ["evidence-checker", "layout-composer", "artboard-builder", "post-critic"]
+      "owners": ["evidence-checker", "layout-composer", "artboard-builder", "post-critic"],
+      "research_gates": ["structural-originality", "contrast-discipline", "evidence-traceability"]
     }
   }
 }

--- a/helper/capabilities.json
+++ b/helper/capabilities.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "capabilities": {
+    "anti-slop": {
+      "purpose": "Detect and remove generic, repetitive, or low-information copy patterns without erasing specific voice or facts.",
+      "owners": ["copy-compressor", "caption-writer", "post-critic"]
+    },
+    "design-taste": {
+      "purpose": "Translate references and briefs into deliberate visual decisions instead of template copying.",
+      "owners": ["design-study", "layout-composer", "artboard-builder", "post-critic"]
+    },
+    "structural-fingerprint": {
+      "purpose": "Require meaningful structural variation and reject palette-only reskins.",
+      "owners": ["layout-composer", "artboard-builder", "post-critic"]
+    },
+    "evidence": {
+      "purpose": "Keep factual claims, proof, logos, UI states, and product behavior tied to supplied evidence.",
+      "owners": ["evidence-checker", "copy-compressor", "story-verifier"]
+    },
+    "verification-loop": {
+      "purpose": "Produce deterministic render evidence, adversarial review, and bounded independent verification before delivery.",
+      "owners": ["render-qa", "post-critic", "story-verifier"]
+    },
+    "mascot-identity": {
+      "purpose": "Preserve the exact supplied official mascot identity through inspection, animation, and verification.",
+      "owners": ["mascot-animator", "post-critic", "story-verifier"]
+    },
+    "ui-mockup-fidelity": {
+      "purpose": "Keep product UI mockups legible and evidence-backed, and distinguish documented UI from concept UI.",
+      "owners": ["evidence-checker", "layout-composer", "artboard-builder", "post-critic"]
+    }
+  }
+}

--- a/helper/capabilities.json
+++ b/helper/capabilities.json
@@ -9,7 +9,12 @@
     "design-taste": {
       "purpose": "Translate references and briefs into deliberate visual decisions instead of template copying.",
       "owners": ["design-study", "layout-composer", "artboard-builder", "post-critic"],
-      "research_gates": ["design-dials", "structural-originality", "reference-dna", "contrast-discipline"]
+      "research_gates": ["design-dials", "structural-originality", "reference-dna", "contrast-discipline"],
+      "local_defaults": {
+        "palette_character": "creative-attractive-restrained",
+        "composition_alignment": "center-first",
+        "alignment_exceptions": ["tables", "ui-mockups", "code-or-terminal", "timelines", "arabic-rtl", "reference-dna"]
+      }
     },
     "structural-fingerprint": {
       "purpose": "Require meaningful structural variation and reject palette-only reskins.",

--- a/helper/modules.json
+++ b/helper/modules.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "modules": {
+    "skills": {
+      "arabic": {"path": "skills/arabic/SKILL.md", "role": "Arabic and bilingual RTL adaptation", "tests": ["tests/test_skill_contracts.py"], "reachable_from": ["condition:arabic"]},
+      "artboard": {"path": "skills/artboard/SKILL.md", "role": "Static artboard structure and execution contract", "tests": ["tests/test_skill_contracts.py", "tests/test_visual_defaults.py"], "reachable_from": ["route:create-post", "route:info-story", "agent:artboard-builder"]},
+      "caption": {"path": "skills/caption/SKILL.md", "role": "Hook-led evidence-safe LinkedIn caption contract", "tests": ["tests/test_skill_contracts.py", "tests/test_creative_runtime.py"], "reachable_from": ["route:create-post", "route:qa", "agent:caption-writer"]},
+      "info-stories": {"path": "skills/info-stories/SKILL.md", "role": "Story registry and composition contract", "tests": ["tests/test_skill_contracts.py", "tests/test_info_stories.py", "tests/test_ui_mockup_stories.py"], "reachable_from": ["route:create-post", "route:info-story", "agent:story-architect"]},
+      "mascots": {"path": "skills/mascots/SKILL.md", "role": "Infographic mascot role and exact-SVG rules", "tests": ["tests/test_skill_contracts.py", "tests/test_mascot_contract.py"], "reachable_from": ["route:mascot-animation", "condition:official_mascot", "agent:mascot-animator"]},
+      "motion": {"path": "skills/motion/SKILL.md", "role": "Seekable infographic motion contract", "tests": ["tests/test_skill_contracts.py", "tests/test_info_stories.py"], "reachable_from": ["route:create-post", "route:info-story", "agent:motion-engineer"]},
+      "new-post": {"path": "skills/new-post/SKILL.md", "role": "Canonical full parent production workflow", "tests": ["tests/test_skill_contracts.py", "tests/test_plugin_graph.py", "tests/test_creative_runtime.py"], "reachable_from": ["route:create-post"]},
+      "post": {"path": "skills/post/SKILL.md", "role": "Public helper-backed routing entrypoint", "tests": ["tests/test_skill_contracts.py", "tests/test_info_stories_followup.py"], "reachable_from": ["route:create-post"]},
+      "qa-post": {"path": "skills/qa-post/SKILL.md", "role": "Focused QA parent workflow", "tests": ["tests/test_skill_contracts.py", "tests/test_plugin_graph.py"], "reachable_from": ["route:qa"]},
+      "render": {"path": "skills/render/SKILL.md", "role": "Render and mechanical QA contract", "tests": ["tests/test_skill_contracts.py", "tests/test_marketplace.py"], "reachable_from": ["route:create-post", "route:qa", "route:render", "agent:render-qa"]},
+      "render-gif": {"path": "skills/render-gif/SKILL.md", "role": "Focused deterministic GIF rendering workflow", "tests": ["tests/test_skill_contracts.py"], "reachable_from": ["route:render"]},
+      "svg-mascot-animator": {"path": "skills/svg-mascot-animator/SKILL.md", "role": "Exact-SVG rig and animation contract", "tests": ["tests/test_skill_contracts.py", "tests/test_mascot_contract.py"], "reachable_from": ["route:mascot-animation", "condition:official_mascot", "agent:mascot-animator"]}
+    },
+    "agents": {
+      "artboard-builder": {"path": "agents/artboard-builder.md", "role": "Static HTML/still execution", "tests": ["tests/test_agent_contracts.py", "tests/test_plugin_graph.py"], "reachable_from": ["workflow:new-post"]},
+      "caption-writer": {"path": "agents/caption-writer.md", "role": "Caption and first-comment production", "tests": ["tests/test_agent_contracts.py", "tests/test_creative_runtime.py"], "reachable_from": ["workflow:new-post"]},
+      "copy-compressor": {"path": "agents/copy-compressor.md", "role": "Evidence-safe infographic copy compression", "tests": ["tests/test_agent_contracts.py", "tests/test_info_stories.py"], "reachable_from": ["workflow:new-post"]},
+      "creative-director": {"path": "agents/creative-director.md", "role": "Evidence-safe concept generation, hooks, and aha mechanics", "tests": ["tests/test_agent_contracts.py", "tests/test_creative_runtime.py", "tests/test_plugin_graph.py"], "reachable_from": ["workflow:new-post", "route:info-story"]},
+      "design-study": {"path": "agents/design-study.md", "role": "Reference design-DNA diagnosis", "tests": ["tests/test_agent_contracts.py", "tests/test_upstream_capabilities.py"], "reachable_from": ["workflow:new-post", "route:design-study"]},
+      "evidence-checker": {"path": "agents/evidence-checker.md", "role": "Claim and product-evidence boundary", "tests": ["tests/test_agent_contracts.py", "tests/test_research_gates.py"], "reachable_from": ["workflow:new-post", "condition:ui_mockup"]},
+      "layout-composer": {"path": "agents/layout-composer.md", "role": "Static topology, hierarchy, and alignment planning", "tests": ["tests/test_agent_contracts.py", "tests/test_visual_defaults.py"], "reachable_from": ["workflow:new-post", "route:info-story"]},
+      "mascot-animator": {"path": "agents/mascot-animator.md", "role": "Exact-SVG mascot motion component", "tests": ["tests/test_agent_contracts.py", "tests/test_mascot_contract.py"], "reachable_from": ["conditional:mascot", "route:mascot-animation"]},
+      "motion-director": {"path": "agents/motion-director.md", "role": "Meaning-driven motion direction", "tests": ["tests/test_agent_contracts.py", "tests/test_plugin_graph.py"], "reachable_from": ["workflow:new-post", "route:info-story"]},
+      "motion-engineer": {"path": "agents/motion-engineer.md", "role": "Seekable motion implementation", "tests": ["tests/test_agent_contracts.py", "tests/test_plugin_graph.py"], "reachable_from": ["workflow:new-post"]},
+      "palette-curator": {"path": "agents/palette-curator.md", "role": "Story House, restrained palette, and contrast decisions", "tests": ["tests/test_agent_contracts.py", "tests/test_visual_defaults.py"], "reachable_from": ["workflow:new-post", "route:info-story"]},
+      "post-critic": {"path": "agents/post-critic.md", "role": "Adversarial creative, copy, visual, motion, and evidence review", "tests": ["tests/test_agent_contracts.py", "tests/test_creative_runtime.py", "tests/test_plugin_graph.py"], "reachable_from": ["workflow:new-post", "route:qa"]},
+      "render-qa": {"path": "agents/render-qa.md", "role": "Deterministic render evidence and mechanical QA", "tests": ["tests/test_agent_contracts.py", "tests/test_plugin_graph.py"], "reachable_from": ["workflow:new-post", "route:qa", "route:render"]},
+      "story-architect": {"path": "agents/story-architect.md", "role": "Deterministic Info-stories brief resolution", "tests": ["tests/test_agent_contracts.py", "tests/test_plugin_graph.py"], "reachable_from": ["workflow:new-post", "route:info-story"]},
+      "story-verifier": {"path": "agents/story-verifier.md", "role": "Independent evidence-backed acceptance", "tests": ["tests/test_agent_contracts.py", "tests/test_upstream_capabilities.py"], "reachable_from": ["workflow:new-post", "route:qa"]}
+    },
+    "tools": {
+      "composition_check": {"path": "tools/composition_check.py", "role": "Validate Info-stories composition compatibility", "tests": ["tests/test_info_stories.py"], "reachable_from": ["skills/info-stories/SKILL.md"]},
+      "contrast_check": {"path": "tools/contrast_check.py", "role": "Check semantic Story House contrast pairs", "tests": ["tests/test_info_stories_followup.py"], "reachable_from": ["skills/artboard/SKILL.md", "skills/info-stories/SKILL.md"]},
+      "copy_slop_check": {"path": "tools/copy_slop_check.py", "role": "Return machine-readable named copy-pattern findings", "tests": ["tests/test_info_stories.py"], "reachable_from": ["skills/info-stories/SKILL.md"]},
+      "fingerprint_check": {"path": "tools/fingerprint_check.py", "role": "Reject palette-only structural reskins", "tests": ["tests/test_info_stories_followup.py"], "reachable_from": ["skills/artboard/SKILL.md", "skills/info-stories/SKILL.md"]},
+      "palette_preview": {"path": "tools/palette_preview.py", "role": "Render Story House palette previews", "tests": ["tests/test_info_stories.py"], "reachable_from": ["skills/info-stories/SKILL.md"]},
+      "route_request": {"path": "tools/route_request.py", "role": "Public deterministic request router CLI", "tests": ["tests/test_ecosystem_router.py"], "reachable_from": ["skills/post/SKILL.md", "helper/README.md"]},
+      "story_scaffold": {"path": "tools/story_scaffold.py", "role": "Emit deterministic Info-stories briefs", "tests": ["tests/test_info_stories.py"], "reachable_from": ["skills/info-stories/SKILL.md"]}
+    }
+  }
+}

--- a/helper/quality-gates.json
+++ b/helper/quality-gates.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "gates": {
+    "hooked-design-copy": {
+      "stage": "concept-copy-and-final-review",
+      "severity": "blocking",
+      "owners": ["creative-director", "copy-compressor", "caption-writer", "post-critic"],
+      "applies_to_intents": ["create-post", "info-story", "qa"],
+      "behavior": "Hero copy must earn attention through specificity, useful tension, concrete outcome, recognizable problem, or useful surprise. Section openers may use micro-hooks when they advance the story. Literal labels, commands, UI controls, and table headers stay literal when clarity wins. Do not invent stakes, urgency, proof, facts, or numbers."
+    },
+    "creative-payoff": {
+      "stage": "concept-and-story-planning",
+      "severity": "blocking",
+      "owners": ["creative-director", "story-architect", "layout-composer", "post-critic"],
+      "applies_to_intents": ["create-post", "info-story"],
+      "behavior": "A complete concept must contain at least one useful visual payoff or aha mechanism such as a reveal, relationship, comparison, transformation, state change, or interaction that improves understanding or memory. This is not spectacle and does not justify decorative 3D, glow, extreme saturation, excessive motion, or novelty without a story job."
+    },
+    "restrained-palette": {
+      "stage": "palette-artboard-and-final-review",
+      "severity": "blocking",
+      "owners": ["palette-curator", "artboard-builder", "post-critic"],
+      "applies_to_intents": ["create-post", "info-story", "qa"],
+      "behavior": "Apply the creative-attractive-restrained palette default. Use memorable harmonious color combinations with one clear accent and enough personality to feel designed. Avoid exaggerated saturation, unnecessary neon, or competing accents unless the approved brief explicitly requires a louder treatment."
+    },
+    "center-first-composition": {
+      "stage": "layout-artboard-and-final-review",
+      "severity": "blocking",
+      "owners": ["layout-composer", "artboard-builder", "post-critic"],
+      "applies_to_intents": ["create-post", "info-story", "qa"],
+      "behavior": "Use center-first composition for the primary visual anchor and major story zones. A non-centered alignment is valid only when the layout artifact records a comprehension or fidelity reason such as tables, UI mockups, code or terminal surfaces, timelines, Arabic RTL flow, or documented reference DNA."
+    }
+  }
+}

--- a/helper/router.json
+++ b/helper/router.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "default_intent": "create-post",
+  "routes": {
+    "create-post": {
+      "workflow": "new-post",
+      "skills": ["post", "new-post", "info-stories", "caption", "artboard", "motion", "render"],
+      "agents": ["design-study", "evidence-checker", "story-architect", "palette-curator", "copy-compressor", "layout-composer", "caption-writer", "artboard-builder", "motion-director", "motion-engineer", "render-qa", "post-critic", "story-verifier"],
+      "capabilities": ["anti-slop", "design-taste", "structural-fingerprint", "evidence", "verification-loop"]
+    },
+    "qa": {
+      "workflow": "qa-post",
+      "skills": ["qa-post", "info-stories", "caption", "render"],
+      "agents": ["render-qa", "post-critic", "story-verifier"],
+      "capabilities": ["evidence", "verification-loop", "anti-slop"]
+    },
+    "render": {
+      "workflow": "render-gif",
+      "skills": ["render-gif", "render"],
+      "agents": ["render-qa"],
+      "capabilities": ["verification-loop"]
+    },
+    "design-study": {
+      "workflow": "focused",
+      "skills": ["info-stories"],
+      "agents": ["design-study"],
+      "capabilities": ["design-taste", "structural-fingerprint"]
+    },
+    "mascot-animation": {
+      "workflow": "focused",
+      "skills": ["mascots", "svg-mascot-animator"],
+      "agents": ["mascot-animator"],
+      "capabilities": ["mascot-identity"]
+    },
+    "info-story": {
+      "workflow": "focused",
+      "skills": ["info-stories", "artboard", "motion"],
+      "agents": ["story-architect", "palette-curator", "layout-composer", "motion-director"],
+      "capabilities": ["design-taste", "structural-fingerprint"]
+    }
+  },
+  "conditions": {
+    "arabic": {"adds_skills": ["arabic"]},
+    "ui_mockup": {"adds_capabilities": ["ui-mockup-fidelity"], "adds_agents": ["evidence-checker"]},
+    "official_mascot": {"asset_gate": "exact-svg", "adds_skills": ["mascots", "svg-mascot-animator"], "adds_agents": ["mascot-animator"], "adds_capabilities": ["mascot-identity"]},
+    "visual_reference": {"adds_agents": ["design-study"], "adds_capabilities": ["design-taste"]}
+  }
+}

--- a/helper/router.json
+++ b/helper/router.json
@@ -5,14 +5,14 @@
     "create-post": {
       "workflow": "new-post",
       "skills": ["post", "new-post", "info-stories", "caption", "artboard", "motion", "render"],
-      "agents": ["design-study", "evidence-checker", "story-architect", "palette-curator", "copy-compressor", "layout-composer", "caption-writer", "artboard-builder", "motion-director", "motion-engineer", "render-qa", "post-critic", "story-verifier"],
-      "capabilities": ["anti-slop", "design-taste", "structural-fingerprint", "evidence", "verification-loop"]
+      "agents": ["design-study", "evidence-checker", "creative-director", "story-architect", "palette-curator", "copy-compressor", "layout-composer", "caption-writer", "artboard-builder", "motion-director", "motion-engineer", "render-qa", "post-critic", "story-verifier"],
+      "capabilities": ["anti-slop", "creative-direction", "design-taste", "evidence", "hook-design-copy", "structural-fingerprint", "verification-loop"]
     },
     "qa": {
       "workflow": "qa-post",
       "skills": ["qa-post", "info-stories", "caption", "render"],
       "agents": ["render-qa", "post-critic", "story-verifier"],
-      "capabilities": ["evidence", "verification-loop", "anti-slop"]
+      "capabilities": ["anti-slop", "design-taste", "evidence", "hook-design-copy", "structural-fingerprint", "verification-loop"]
     },
     "render": {
       "workflow": "render-gif",
@@ -34,15 +34,15 @@
     },
     "info-story": {
       "workflow": "focused",
-      "skills": ["info-stories", "artboard", "motion"],
-      "agents": ["story-architect", "palette-curator", "layout-composer", "motion-director"],
-      "capabilities": ["design-taste", "structural-fingerprint"]
+      "skills": ["info-stories", "caption", "artboard", "motion"],
+      "agents": ["creative-director", "story-architect", "palette-curator", "copy-compressor", "layout-composer", "motion-director"],
+      "capabilities": ["anti-slop", "creative-direction", "design-taste", "hook-design-copy", "structural-fingerprint"]
     }
   },
   "conditions": {
     "arabic": {"adds_skills": ["arabic"]},
-    "ui_mockup": {"adds_capabilities": ["ui-mockup-fidelity"], "adds_agents": ["evidence-checker"]},
+    "ui_mockup": {"adds_capabilities": ["ui-mockup-fidelity", "evidence"], "adds_agents": ["evidence-checker"]},
     "official_mascot": {"asset_gate": "exact-svg", "adds_skills": ["mascots", "svg-mascot-animator"], "adds_agents": ["mascot-animator"], "adds_capabilities": ["mascot-identity"]},
-    "visual_reference": {"adds_agents": ["design-study"], "adds_capabilities": ["design-taste"]}
+    "visual_reference": {"adds_agents": ["design-study"], "adds_capabilities": ["design-taste", "structural-fingerprint"]}
   }
 }

--- a/research/capability-notes/adoption-matrix.md
+++ b/research/capability-notes/adoption-matrix.md
@@ -1,19 +1,27 @@
 # Upstream capability adoption matrix
 
-The upstream repositories are research inputs, not bundled runtime dependencies. Their working copies live under ignored `research/upstreams/`. Product-facing rules are independently worded and tested locally.
+The upstream repositories are research inputs, not bundled runtime dependencies. Their working copies live under ignored `research/upstreams/`. Product-facing rules are independently worded and tested locally. Runtime adoption is declared in `gates.json`; prose notes explain why each gate exists but do not replace the machine-readable contract.
 
-| Capability | stop-slop | no-ai-slop | taste-skill | Hallmark | COG | Local implementation |
+| Runtime gate | stop-slop | no-ai-slop | taste-skill | Hallmark | COG | Local implementation |
 |---|---|---|---|---|---|---|
-| Named prose-pattern detection | strong | strong | medium | medium | - | anti-slop gates + copy-compressor |
-| Voice preservation | medium | strong | medium | medium | - | copy-compressor |
-| Structural diversity | - | - | strong | strong | - | story-architect + layout-composer |
-| Explicit density/motion/variance | - | - | strong | medium | - | story brief design dials |
-| Reference DNA study | - | - | medium | strong | - | design-study + study protocol |
-| Token discipline and contrast | - | - | strong | strong | - | palette-curator + catalog validator |
-| Honest facts / no fake metrics | medium | strong | strong | strong | medium | evidence-checker + post-critic |
-| Independent verifier | - | - | - | medium | strong | story-verifier |
-| Bounded fix loop | - | - | - | medium | strong | verification-loop |
-| Evidence traceability | - | - | - | medium | strong | verifier evidence rows |
+| `prose-specificity` | strong | strong | - | - | - | anti-slop gates + copy-compressor + caption-writer + post-critic |
+| `voice-preservation` | supporting | strong | - | - | - | anti-slop gates + copy-compressor + caption-writer |
+| `design-dials` | - | - | strong | - | - | story brief design dials + story-architect + layout-composer + motion-director |
+| `structural-originality` | - | - | strong | strong | - | design-taste gates + layout-composer + artboard-builder + fingerprint checker |
+| `reference-dna` | - | - | - | strong | - | design-study + study protocol + layout-composer |
+| `contrast-discipline` | - | - | strong | strong | - | semantic Story House tokens + palette-curator + contrast checker |
+| `evidence-traceability` | - | supporting | - | strong | strong | evidence-checker + protected fact slots + verifier evidence rows |
+| `bounded-verification` | - | - | - | - | strong | render-qa + post-critic + read-only story-verifier + max-two repair loop |
+
+## How the gates ship
+
+1. `sources.json` records the inspected upstream repository, commit, and license
+2. Individual capability notes record Adopt / Adapt / Reject decisions
+3. `gates.json` records stable runtime gate IDs, source names, stages, severity, owners, local behavior, and implementation references
+4. `helper/capabilities.json` connects repository capabilities to those gate IDs
+5. `scripts/ecosystem_router.py` returns the applicable gate IDs with a route
+6. Shipping agents execute the gate behavior and return evidence to the parent workflow
+7. `scripts/research_gates.py check` and unit tests reject missing provenance, dead owners, broken implementation references, or unconnected gates
 
 ## Deliberate exclusions
 
@@ -22,3 +30,4 @@ The upstream repositories are research inputs, not bundled runtime dependencies.
 - No random aesthetic selection is used
 - No paid-template or signature-work cloning is supported
 - No upstream repository is packaged with the plugin
+- No upstream prose is copied as a runtime prompt; local rules remain independently worded

--- a/research/capability-notes/gates.json
+++ b/research/capability-notes/gates.json
@@ -1,0 +1,109 @@
+{
+  "schema_version": 1,
+  "gates": {
+    "prose-specificity": {
+      "sources": ["stop-slop", "no-ai-slop"],
+      "stage": "copy-and-final-review",
+      "severity": "blocking",
+      "owners": ["copy-compressor", "caption-writer", "post-critic"],
+      "local_behavior": "Detect named low-information prose patterns per text slot, preserve intentional labels, and block generic filler or unsupported rhetorical setup before delivery.",
+      "implementation_refs": [
+        "skills/info-stories/references/anti-slop-gates.md",
+        "agents/copy-compressor.md",
+        "agents/caption-writer.md",
+        "agents/post-critic.md"
+      ]
+    },
+    "voice-preservation": {
+      "sources": ["no-ai-slop", "stop-slop"],
+      "stage": "copy-compression",
+      "severity": "blocking",
+      "owners": ["copy-compressor", "caption-writer", "post-critic"],
+      "local_behavior": "Protect specific facts, mechanisms, names, numbers, and deliberate voice while applying the minimum effective edit; detect before rewriting.",
+      "implementation_refs": [
+        "skills/info-stories/references/anti-slop-gates.md",
+        "agents/copy-compressor.md",
+        "agents/caption-writer.md"
+      ]
+    },
+    "design-dials": {
+      "sources": ["taste-skill"],
+      "stage": "story-and-layout-planning",
+      "severity": "blocking",
+      "owners": ["story-architect", "layout-composer", "motion-director"],
+      "local_behavior": "Resolve design variance, visual density, and motion intensity as explicit bounded decisions derived from content shape rather than random aesthetic choice.",
+      "implementation_refs": [
+        "skills/info-stories/catalog.json",
+        "skills/info-stories/references/design-taste-gates.md",
+        "agents/story-architect.md",
+        "agents/layout-composer.md",
+        "agents/motion-director.md"
+      ]
+    },
+    "structural-originality": {
+      "sources": ["taste-skill", "hallmark"],
+      "stage": "layout-and-artboard",
+      "severity": "blocking",
+      "owners": ["layout-composer", "artboard-builder", "post-critic"],
+      "local_behavior": "Require meaningful variation in section topology, card grammar, connectors, hero ratio, or density pattern and reject palette-only reskins.",
+      "implementation_refs": [
+        "skills/info-stories/references/design-taste-gates.md",
+        "agents/layout-composer.md",
+        "agents/artboard-builder.md",
+        "agents/post-critic.md",
+        "tools/fingerprint_check.py"
+      ]
+    },
+    "reference-dna": {
+      "sources": ["hallmark"],
+      "stage": "reference-diagnosis",
+      "severity": "blocking",
+      "owners": ["design-study", "layout-composer"],
+      "local_behavior": "When references are supplied, extract reusable canvas rhythm, topology, card and connector grammar, token roles, density, motion grammar, attribution, and visual anchor without cloning distinctive work.",
+      "implementation_refs": [
+        "skills/info-stories/references/study-protocol.md",
+        "agents/design-study.md",
+        "agents/layout-composer.md"
+      ]
+    },
+    "contrast-discipline": {
+      "sources": ["taste-skill", "hallmark"],
+      "stage": "palette-artboard-and-render-qa",
+      "severity": "blocking",
+      "owners": ["palette-curator", "artboard-builder", "render-qa"],
+      "local_behavior": "Use one resolved semantic token set per artifact and enforce established text and state contrast floors before still approval and delivery.",
+      "implementation_refs": [
+        "skills/info-stories/catalog.json",
+        "agents/palette-curator.md",
+        "agents/artboard-builder.md",
+        "tools/contrast_check.py"
+      ]
+    },
+    "evidence-traceability": {
+      "sources": ["COG-second-brain", "hallmark", "no-ai-slop"],
+      "stage": "evidence-copy-and-verification",
+      "severity": "blocking",
+      "owners": ["evidence-checker", "copy-compressor", "story-verifier"],
+      "local_behavior": "Trace factual claims, proof, product states, metrics, logos, and protected facts to supplied evidence and require direct evidence rows for acceptance criteria.",
+      "implementation_refs": [
+        "agents/evidence-checker.md",
+        "agents/copy-compressor.md",
+        "agents/story-verifier.md",
+        "skills/info-stories/references/verification-loop.md"
+      ]
+    },
+    "bounded-verification": {
+      "sources": ["COG-second-brain"],
+      "stage": "render-review-and-final-verification",
+      "severity": "blocking",
+      "owners": ["render-qa", "post-critic", "story-verifier"],
+      "local_behavior": "Keep verification independent and evidence-backed, report PASS or bounded failure states, and allow at most two targeted repair attempts before escalation.",
+      "implementation_refs": [
+        "agents/render-qa.md",
+        "agents/post-critic.md",
+        "agents/story-verifier.md",
+        "skills/info-stories/references/verification-loop.md"
+      ]
+    }
+  }
+}

--- a/research/capability-notes/gates.json
+++ b/research/capability-notes/gates.json
@@ -6,104 +6,73 @@
       "stage": "copy-and-final-review",
       "severity": "blocking",
       "owners": ["copy-compressor", "caption-writer", "post-critic"],
+      "applies_to_intents": ["create-post", "qa"],
       "local_behavior": "Detect named low-information prose patterns per text slot, preserve intentional labels, and block generic filler or unsupported rhetorical setup before delivery.",
-      "implementation_refs": [
-        "skills/info-stories/references/anti-slop-gates.md",
-        "agents/copy-compressor.md",
-        "agents/caption-writer.md",
-        "agents/post-critic.md"
-      ]
+      "implementation_refs": ["skills/info-stories/references/anti-slop-gates.md", "agents/copy-compressor.md", "agents/caption-writer.md", "agents/post-critic.md"]
     },
     "voice-preservation": {
       "sources": ["no-ai-slop", "stop-slop"],
       "stage": "copy-compression",
       "severity": "blocking",
       "owners": ["copy-compressor", "caption-writer", "post-critic"],
+      "applies_to_intents": ["create-post", "qa"],
       "local_behavior": "Protect specific facts, mechanisms, names, numbers, and deliberate voice while applying the minimum effective edit; detect before rewriting.",
-      "implementation_refs": [
-        "skills/info-stories/references/anti-slop-gates.md",
-        "agents/copy-compressor.md",
-        "agents/caption-writer.md"
-      ]
+      "implementation_refs": ["skills/info-stories/references/anti-slop-gates.md", "agents/copy-compressor.md", "agents/caption-writer.md"]
     },
     "design-dials": {
       "sources": ["taste-skill"],
       "stage": "story-and-layout-planning",
       "severity": "blocking",
       "owners": ["story-architect", "layout-composer", "motion-director"],
+      "applies_to_intents": ["create-post", "info-story"],
       "local_behavior": "Resolve design variance, visual density, and motion intensity as explicit bounded decisions derived from content shape rather than random aesthetic choice.",
-      "implementation_refs": [
-        "skills/info-stories/catalog.json",
-        "skills/info-stories/references/design-taste-gates.md",
-        "agents/story-architect.md",
-        "agents/layout-composer.md",
-        "agents/motion-director.md"
-      ]
+      "implementation_refs": ["skills/info-stories/catalog.json", "skills/info-stories/references/design-taste-gates.md", "agents/story-architect.md", "agents/layout-composer.md", "agents/motion-director.md"]
     },
     "structural-originality": {
       "sources": ["taste-skill", "hallmark"],
       "stage": "layout-and-artboard",
       "severity": "blocking",
       "owners": ["layout-composer", "artboard-builder", "post-critic"],
+      "applies_to_intents": ["create-post", "qa", "info-story"],
       "local_behavior": "Require meaningful variation in section topology, card grammar, connectors, hero ratio, or density pattern and reject palette-only reskins.",
-      "implementation_refs": [
-        "skills/info-stories/references/design-taste-gates.md",
-        "agents/layout-composer.md",
-        "agents/artboard-builder.md",
-        "agents/post-critic.md",
-        "tools/fingerprint_check.py"
-      ]
+      "implementation_refs": ["skills/info-stories/references/design-taste-gates.md", "agents/layout-composer.md", "agents/artboard-builder.md", "agents/post-critic.md", "tools/fingerprint_check.py"]
     },
     "reference-dna": {
       "sources": ["hallmark"],
       "stage": "reference-diagnosis",
       "severity": "blocking",
       "owners": ["design-study", "layout-composer"],
+      "applies_to_intents": ["create-post", "design-study", "info-story"],
+      "requires": "visual_reference",
       "local_behavior": "When references are supplied, extract reusable canvas rhythm, topology, card and connector grammar, token roles, density, motion grammar, attribution, and visual anchor without cloning distinctive work.",
-      "implementation_refs": [
-        "skills/info-stories/references/study-protocol.md",
-        "agents/design-study.md",
-        "agents/layout-composer.md"
-      ]
+      "implementation_refs": ["skills/info-stories/references/study-protocol.md", "agents/design-study.md", "agents/layout-composer.md"]
     },
     "contrast-discipline": {
       "sources": ["taste-skill", "hallmark"],
       "stage": "palette-artboard-and-render-qa",
       "severity": "blocking",
       "owners": ["palette-curator", "artboard-builder", "render-qa"],
+      "applies_to_intents": ["create-post", "qa", "info-story"],
       "local_behavior": "Use one resolved semantic token set per artifact and enforce established text and state contrast floors before still approval and delivery.",
-      "implementation_refs": [
-        "skills/info-stories/catalog.json",
-        "agents/palette-curator.md",
-        "agents/artboard-builder.md",
-        "tools/contrast_check.py"
-      ]
+      "implementation_refs": ["skills/info-stories/catalog.json", "agents/palette-curator.md", "agents/artboard-builder.md", "tools/contrast_check.py"]
     },
     "evidence-traceability": {
       "sources": ["COG-second-brain", "hallmark", "no-ai-slop"],
       "stage": "evidence-copy-and-verification",
       "severity": "blocking",
       "owners": ["evidence-checker", "copy-compressor", "story-verifier"],
+      "applies_to_intents": ["create-post", "qa"],
       "local_behavior": "Trace factual claims, proof, product states, metrics, logos, and protected facts to supplied evidence and require direct evidence rows for acceptance criteria.",
-      "implementation_refs": [
-        "agents/evidence-checker.md",
-        "agents/copy-compressor.md",
-        "agents/story-verifier.md",
-        "skills/info-stories/references/verification-loop.md"
-      ]
+      "implementation_refs": ["agents/evidence-checker.md", "agents/copy-compressor.md", "agents/story-verifier.md", "skills/info-stories/references/verification-loop.md"]
     },
     "bounded-verification": {
       "sources": ["COG-second-brain"],
       "stage": "render-review-and-final-verification",
       "severity": "blocking",
       "owners": ["render-qa", "post-critic", "story-verifier"],
+      "applies_to_intents": ["create-post", "qa", "render"],
       "local_behavior": "Keep verification independent and evidence-backed, report PASS or bounded failure states, and allow at most two targeted repair attempts before escalation.",
-      "implementation_refs": [
-        "agents/render-qa.md",
-        "agents/post-critic.md",
-        "agents/story-verifier.md",
-        "skills/info-stories/references/verification-loop.md"
-      ]
+      "implementation_refs": ["agents/render-qa.md", "agents/post-critic.md", "agents/story-verifier.md", "skills/info-stories/references/verification-loop.md"]
     }
   }
 }

--- a/scripts/ecosystem_doctor.py
+++ b/scripts/ecosystem_doctor.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_TYPES = ("skills", "agents", "tools")
+CRITICAL_SHIPPING = ("creative-director", "post-critic", "story-verifier")
+
+
+def _load_json(path: Path, errors: list[str], label: str):
+    if not path.exists():
+        errors.append(f"missing {label}: {path}")
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid JSON in {label}: {exc}")
+        return None
+
+
+def _inventory(root: Path) -> dict[str, set[str]]:
+    return {
+        "skills": {path.parent.name for path in (root / "skills").glob("*/SKILL.md")},
+        "agents": {path.stem for path in (root / "agents").glob("*.md")},
+        "tools": {path.stem for path in (root / "tools").glob("*.py")},
+    }
+
+
+def _text_reference_corpus(root: Path) -> str:
+    parts = []
+    for base in (root / "skills", root / "agents", root / "helper"):
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if path.is_file() and path.suffix in {".md", ".json"}:
+                try:
+                    parts.append(path.read_text())
+                except UnicodeDecodeError:
+                    pass
+    return "\n".join(parts)
+
+
+def validate_ecosystem_doctor(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    helper = root / "helper"
+
+    manifest_doc = _load_json(helper / "modules.json", errors, "module manifest")
+    router_doc = _load_json(helper / "router.json", errors, "router registry")
+    capabilities_doc = _load_json(helper / "capabilities.json", errors, "capability registry")
+    artifacts_doc = _load_json(helper / "artifacts.json", errors, "artifact registry")
+    quality_doc = _load_json(helper / "quality-gates.json", errors, "local quality gates")
+    graph_doc = _load_json(root / "architecture" / "plugin-graph.json", errors, "plugin graph")
+    research_doc = _load_json(root / "research" / "capability-notes" / "gates.json", errors, "research gates")
+    if not all((manifest_doc, router_doc, capabilities_doc, artifacts_doc, quality_doc, graph_doc, research_doc)):
+        return errors
+
+    manifest = manifest_doc.get("modules", {})
+    inventory = _inventory(root)
+
+    for module_type in MODULE_TYPES:
+        declared = set(manifest.get(module_type, {}))
+        actual = inventory[module_type]
+        for name in sorted(actual - declared):
+            label = module_type[:-1]
+            errors.append(f"undeclared public {label} {name}")
+        for name in sorted(declared - actual):
+            errors.append(f"declared {module_type[:-1]} missing from filesystem: {name}")
+
+    for module_type, entries in manifest.items():
+        if module_type not in MODULE_TYPES:
+            errors.append(f"unknown module type in manifest: {module_type}")
+            continue
+        for name, contract in entries.items():
+            for field in ("path", "role", "tests", "reachable_from"):
+                if contract.get(field) in (None, "", []):
+                    errors.append(f"{module_type}:{name} missing {field}")
+            relative = contract.get("path", "")
+            path = root / relative
+            if relative and not path.exists():
+                errors.append(f"{module_type}:{name} path does not exist: {relative}")
+            if path.exists():
+                text = path.read_text()
+                if len(text.strip()) < 80:
+                    errors.append(f"{module_type}:{name} is too small to be a real active module")
+                lowered = text.lower()
+                if "todo: implement" in lowered or "placeholder module" in lowered:
+                    errors.append(f"{module_type}:{name} is a placeholder module")
+            for test_path in contract.get("tests", []):
+                if not (root / test_path).exists():
+                    errors.append(f"{module_type}:{name} test contract missing: {test_path}")
+
+    routes = router_doc.get("routes", {})
+    conditions = router_doc.get("conditions", {})
+    graph_agents = graph_doc.get("agents", {})
+    workflow = graph_doc.get("workflows", {}).get("new-post", {})
+    sequence = workflow.get("sequence", [])
+    conditional_edges = workflow.get("conditional", {})
+
+    reachable_skills: set[str] = set()
+    reachable_agents: set[str] = set(sequence)
+    for edge in conditional_edges.values():
+        if edge.get("agent"):
+            reachable_agents.add(edge["agent"])
+    for route in routes.values():
+        reachable_skills.update(route.get("skills", []))
+        if route.get("workflow") not in (None, "focused"):
+            reachable_skills.add(route["workflow"])
+        reachable_agents.update(route.get("agents", []))
+    for condition in conditions.values():
+        reachable_skills.update(condition.get("adds_skills", []))
+        reachable_agents.update(condition.get("adds_agents", []))
+    for contract in graph_agents.values():
+        reachable_skills.update(contract.get("required_skills", []))
+
+    for skill in sorted(set(manifest.get("skills", {})) - reachable_skills):
+        errors.append(f"unreachable active skill {skill}")
+    for agent in sorted(set(manifest.get("agents", {})) - reachable_agents):
+        errors.append(f"unreachable active agent {agent}")
+
+    reference_corpus = _text_reference_corpus(root)
+    for tool, contract in manifest.get("tools", {}).items():
+        filename = Path(contract.get("path", "")).name
+        if filename and filename not in reference_corpus:
+            errors.append(f"active tool {tool} is not referenced by executable guidance")
+
+    graph_agent_names = set(graph_agents)
+    manifest_agent_names = set(manifest.get("agents", {}))
+    if graph_agent_names != manifest_agent_names:
+        missing = sorted(manifest_agent_names - graph_agent_names)
+        extra = sorted(graph_agent_names - manifest_agent_names)
+        if missing:
+            errors.append(f"plugin graph missing active agents: {', '.join(missing)}")
+        if extra:
+            errors.append(f"plugin graph contains undeclared agents: {', '.join(extra)}")
+
+    helper_capabilities = capabilities_doc.get("capabilities", {})
+    graph_capabilities = graph_doc.get("capabilities", {})
+    if set(helper_capabilities) != set(graph_capabilities):
+        errors.append("helper capability set differs from plugin graph capability set")
+    for capability, contract in helper_capabilities.items():
+        owners = set(contract.get("owners", []))
+        undeclared = sorted(owners - manifest_agent_names)
+        if undeclared:
+            errors.append(f"capability {capability} has undeclared owners: {', '.join(undeclared)}")
+        graph_owners = set(graph_capabilities.get(capability, []))
+        if owners != graph_owners:
+            errors.append(f"capability {capability} owner drift between helper and plugin graph")
+
+    participants = manifest_agent_names | {"parent:new-post"}
+    for artifact, contract in artifacts_doc.get("artifacts", {}).items():
+        producer = contract.get("producer")
+        if producer not in participants:
+            errors.append(f"artifact {artifact} has undeclared producer {producer}")
+        for consumer in contract.get("consumers", []):
+            if consumer not in participants:
+                errors.append(f"artifact {artifact} has undeclared consumer {consumer}")
+
+    for gate_id, gate in quality_doc.get("gates", {}).items():
+        owners = set(gate.get("owners", []))
+        undeclared = sorted(owners - manifest_agent_names)
+        if undeclared:
+            errors.append(f"quality gate {gate_id} has undeclared owners: {', '.join(undeclared)}")
+        if gate.get("severity") not in {"blocking", "advisory"}:
+            errors.append(f"quality gate {gate_id} has invalid severity")
+        unknown_intents = sorted(set(gate.get("applies_to_intents", [])) - set(routes))
+        if unknown_intents:
+            errors.append(f"quality gate {gate_id} has unknown intents: {', '.join(unknown_intents)}")
+
+    for gate_id, gate in research_doc.get("gates", {}).items():
+        owners = set(gate.get("owners", []))
+        undeclared = sorted(owners - manifest_agent_names)
+        if undeclared:
+            errors.append(f"research gate {gate_id} has undeclared owners: {', '.join(undeclared)}")
+        for relative in gate.get("implementation_refs", []):
+            if not (root / relative).exists():
+                errors.append(f"research gate {gate_id} has dead implementation reference: {relative}")
+
+    helper_create_agents = routes.get("create-post", {}).get("agents", [])
+    if helper_create_agents != sequence:
+        errors.append("create-post helper route differs from plugin graph new-post sequence")
+
+    for worker in CRITICAL_SHIPPING:
+        if worker not in sequence:
+            errors.append(f"critical shipping worker missing from new-post sequence: {worker}")
+
+    mascot_condition = conditions.get("official_mascot", {})
+    mascot_edge = conditional_edges.get("mascot", {})
+    if mascot_condition.get("adds_agents", []) != ([mascot_edge.get("agent")] if mascot_edge.get("agent") else []):
+        errors.append("official mascot router condition differs from graph mascot edge")
+    if mascot_condition.get("asset_gate") != mascot_edge.get("asset_gate"):
+        errors.append("official mascot asset gate differs from graph mascot edge")
+
+    return errors
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Strictly validate that every public ecosystem module is real, reachable, and cross-linked")
+    parser.add_argument("command", nargs="?", default="check", choices=("check",))
+    parser.parse_args(argv)
+    errors = validate_ecosystem_doctor(ROOT)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        print(f"Ecosystem doctor: FAIL ({len(errors)} findings)")
+        return 1
+    print("Ecosystem doctor: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ecosystem_doctor.py
+++ b/scripts/ecosystem_doctor.py
@@ -27,18 +27,58 @@ def _inventory(root: Path) -> dict[str, set[str]]:
     }
 
 
-def _text_reference_corpus(root: Path) -> str:
-    parts = []
-    for base in (root / "skills", root / "agents", root / "helper"):
-        if not base.exists():
+def _skill_reachable_from(claim: str, skill: str, routes: dict, conditions: dict, graph_agents: dict) -> bool:
+    kind, sep, name = claim.partition(":")
+    if not sep:
+        return False
+    if kind == "route":
+        route = routes.get(name, {})
+        return skill in route.get("skills", []) or route.get("workflow") == skill
+    if kind == "condition":
+        return skill in conditions.get(name, {}).get("adds_skills", [])
+    if kind == "agent":
+        return skill in graph_agents.get(name, {}).get("required_skills", [])
+    return False
+
+
+def _agent_reachable_from(claim: str, agent: str, routes: dict, conditions: dict, sequence: list, conditional_edges: dict) -> bool:
+    kind, sep, name = claim.partition(":")
+    if not sep:
+        return False
+    if kind == "workflow" and name == "new-post":
+        return agent in sequence
+    if kind == "route":
+        return agent in routes.get(name, {}).get("agents", [])
+    if kind == "condition":
+        return agent in conditions.get(name, {}).get("adds_agents", [])
+    if kind == "conditional":
+        return conditional_edges.get(name, {}).get("agent") == agent
+    return False
+
+
+def _validate_tool_references(root: Path, tool: str, contract: dict, errors: list[str]):
+    filename = Path(contract.get("path", "")).name
+    references = contract.get("reachable_from", [])
+    evidence_found = False
+    for relative in references:
+        if relative == "helper/modules.json":
+            errors.append(f"active tool {tool} cannot use helper/modules.json as executable guidance")
             continue
-        for path in sorted(base.rglob("*")):
-            if path.is_file() and path.suffix in {".md", ".json"}:
-                try:
-                    parts.append(path.read_text())
-                except UnicodeDecodeError:
-                    pass
-    return "\n".join(parts)
+        target = root / relative
+        if not target.is_file():
+            errors.append(f"active tool {tool} has invalid executable guidance target: {relative}")
+            continue
+        try:
+            text = target.read_text()
+        except UnicodeDecodeError:
+            errors.append(f"active tool {tool} guidance target is not readable text: {relative}")
+            continue
+        if filename and filename in text:
+            evidence_found = True
+        else:
+            errors.append(f"active tool {tool} is not referenced by declared executable guidance: {relative}")
+    if not evidence_found:
+        errors.append(f"active tool {tool} is not referenced by executable guidance")
 
 
 def validate_ecosystem_doctor(root: Path = ROOT) -> list[str]:
@@ -118,11 +158,24 @@ def validate_ecosystem_doctor(root: Path = ROOT) -> list[str]:
     for agent in sorted(set(manifest.get("agents", {})) - reachable_agents):
         errors.append(f"unreachable active agent {agent}")
 
-    reference_corpus = _text_reference_corpus(root)
+    for skill, contract in manifest.get("skills", {}).items():
+        claims = contract.get("reachable_from", [])
+        if not any(_skill_reachable_from(claim, skill, routes, conditions, graph_agents) for claim in claims):
+            errors.append(f"active skill {skill} has no truthful reachable_from claim")
+        for claim in claims:
+            if not _skill_reachable_from(claim, skill, routes, conditions, graph_agents):
+                errors.append(f"active skill {skill} has false reachable_from claim: {claim}")
+
+    for agent, contract in manifest.get("agents", {}).items():
+        claims = contract.get("reachable_from", [])
+        if not any(_agent_reachable_from(claim, agent, routes, conditions, sequence, conditional_edges) for claim in claims):
+            errors.append(f"active agent {agent} has no truthful reachable_from claim")
+        for claim in claims:
+            if not _agent_reachable_from(claim, agent, routes, conditions, sequence, conditional_edges):
+                errors.append(f"active agent {agent} has false reachable_from claim: {claim}")
+
     for tool, contract in manifest.get("tools", {}).items():
-        filename = Path(contract.get("path", "")).name
-        if filename and filename not in reference_corpus:
-            errors.append(f"active tool {tool} is not referenced by executable guidance")
+        _validate_tool_references(root, tool, contract, errors)
 
     graph_agent_names = set(graph_agents)
     manifest_agent_names = set(manifest.get("agents", {}))
@@ -195,7 +248,7 @@ def validate_ecosystem_doctor(root: Path = ROOT) -> list[str]:
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="Strictly validate that every public ecosystem module is real, reachable, and cross-linked")
+    parser = argparse.ArgumentParser(description="Strictly validate that every public ecosystem module is real, reachable, tested, and cross-linked")
     parser.add_argument("command", nargs="?", default="check", choices=("check",))
     parser.parse_args(argv)
     errors = validate_ecosystem_doctor(ROOT)

--- a/scripts/ecosystem_doctor.py
+++ b/scripts/ecosystem_doctor.py
@@ -19,6 +19,21 @@ def _load_json(path: Path, errors: list[str], label: str):
         return None
 
 
+def _safe_repo_path(root: Path, relative: str):
+    if not isinstance(relative, str) or not relative:
+        return None
+    supplied = Path(relative)
+    if supplied.is_absolute():
+        return None
+    root_resolved = root.resolve()
+    resolved = (root_resolved / supplied).resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        return None
+    return resolved
+
+
 def _inventory(root: Path) -> dict[str, set[str]]:
     return {
         "skills": {path.parent.name for path in (root / "skills").glob("*/SKILL.md")},
@@ -64,7 +79,10 @@ def _validate_tool_references(root: Path, tool: str, contract: dict, errors: lis
         if relative == "helper/modules.json":
             errors.append(f"active tool {tool} cannot use helper/modules.json as executable guidance")
             continue
-        target = root / relative
+        target = _safe_repo_path(root, relative)
+        if target is None:
+            errors.append(f"active tool {tool} has unsafe executable guidance path: {relative}")
+            continue
         if not target.is_file():
             errors.append(f"active tool {tool} has invalid executable guidance target: {relative}")
             continue
@@ -116,10 +134,12 @@ def validate_ecosystem_doctor(root: Path = ROOT) -> list[str]:
                 if contract.get(field) in (None, "", []):
                     errors.append(f"{module_type}:{name} missing {field}")
             relative = contract.get("path", "")
-            path = root / relative
-            if relative and not path.exists():
+            path = _safe_repo_path(root, relative)
+            if relative and path is None:
+                errors.append(f"unsafe module path for {module_type}:{name}: {relative}")
+            elif path is not None and not path.exists():
                 errors.append(f"{module_type}:{name} path does not exist: {relative}")
-            if path.exists():
+            if path is not None and path.exists():
                 text = path.read_text()
                 if len(text.strip()) < 80:
                     errors.append(f"{module_type}:{name} is too small to be a real active module")
@@ -127,7 +147,10 @@ def validate_ecosystem_doctor(root: Path = ROOT) -> list[str]:
                 if "todo: implement" in lowered or "placeholder module" in lowered:
                     errors.append(f"{module_type}:{name} is a placeholder module")
             for test_path in contract.get("tests", []):
-                if not (root / test_path).exists():
+                test = _safe_repo_path(root, test_path)
+                if test is None:
+                    errors.append(f"unsafe test path for {module_type}:{name}: {test_path}")
+                elif not test.exists():
                     errors.append(f"{module_type}:{name} test contract missing: {test_path}")
 
     routes = router_doc.get("routes", {})
@@ -226,7 +249,10 @@ def validate_ecosystem_doctor(root: Path = ROOT) -> list[str]:
         if undeclared:
             errors.append(f"research gate {gate_id} has undeclared owners: {', '.join(undeclared)}")
         for relative in gate.get("implementation_refs", []):
-            if not (root / relative).exists():
+            implementation = _safe_repo_path(root, relative)
+            if implementation is None:
+                errors.append(f"research gate {gate_id} has unsafe implementation ref: {relative}")
+            elif not implementation.exists():
                 errors.append(f"research gate {gate_id} has dead implementation reference: {relative}")
 
     helper_create_agents = routes.get("create-post", {}).get("agents", [])

--- a/scripts/ecosystem_router.py
+++ b/scripts/ecosystem_router.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 HELPER_FILES = ("router.json", "capabilities.json", "artifacts.json", "quality-gates.json")
+REQUIRED_CONDITIONS = frozenset({"arabic", "ui_mockup", "visual_reference", "official_mascot"})
 
 
 def _load_json(path: Path, errors=None):
@@ -22,6 +23,19 @@ def _load_json(path: Path, errors=None):
         if errors is not None:
             errors.append(f"invalid JSON in {path}: {exc}")
     return None
+
+
+def _resolve_asset_path(root: Path, value):
+    if not value or not isinstance(value, (str, Path)):
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = root / path
+    return path.resolve()
+
+
+def _is_svg_file(path: Path | None) -> bool:
+    return bool(path and path.is_file() and path.suffix.lower() == ".svg")
 
 
 def load_ecosystem(root: Path = ROOT) -> dict:
@@ -71,6 +85,13 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
     if router.get("default_intent") not in routes:
         errors.append("router default_intent does not resolve to a route")
 
+    conditions = router.get("conditions", {})
+    if not isinstance(conditions, dict):
+        errors.append("router conditions must be an object")
+        conditions = {}
+    for condition_id in sorted(REQUIRED_CONDITIONS - set(conditions)):
+        errors.append(f"router missing required condition {condition_id}")
+
     for intent, route in routes.items():
         workflow = route.get("workflow")
         if workflow != "focused" and workflow not in skills:
@@ -85,7 +106,10 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
             if capability not in capabilities:
                 errors.append(f"route {intent} references missing capability {capability}")
 
-    for condition, contract in router.get("conditions", {}).items():
+    for condition, contract in conditions.items():
+        if not isinstance(contract, dict):
+            errors.append(f"condition {condition} must be an object")
+            continue
         for skill in contract.get("adds_skills", []):
             if skill not in skills:
                 errors.append(f"condition {condition} references missing skill {skill}")
@@ -233,6 +257,11 @@ def route_request(request: dict, root: Path = ROOT) -> dict:
     if intent not in router["routes"]:
         raise ValueError(f"unknown routing intent: {intent}")
 
+    conditions = router.get("conditions", {})
+    missing_conditions = sorted(REQUIRED_CONDITIONS - set(conditions) if isinstance(conditions, dict) else REQUIRED_CONDITIONS)
+    if missing_conditions:
+        raise ValueError(f"router missing required conditions: {', '.join(missing_conditions)}")
+
     base = copy.deepcopy(router["routes"][intent])
     result = {
         "status": "READY",
@@ -250,33 +279,34 @@ def route_request(request: dict, root: Path = ROOT) -> dict:
 
     language = (request.get("language") or "").lower()
     if language in ("ar", "arabic") or request.get("rtl") is True:
-        result["skills"].extend(router["conditions"]["arabic"]["adds_skills"])
+        result["skills"].extend(conditions["arabic"]["adds_skills"])
 
     if request.get("ui_mockup") is True:
-        condition = router["conditions"]["ui_mockup"]
+        condition = conditions["ui_mockup"]
         result["capabilities"].extend(condition.get("adds_capabilities", []))
         result["agents"].extend(condition.get("adds_agents", []))
 
     if request.get("visual_reference") is True:
-        condition = router["conditions"]["visual_reference"]
+        condition = conditions["visual_reference"]
         result["agents"].extend(condition.get("adds_agents", []))
         result["capabilities"].extend(condition.get("adds_capabilities", []))
 
     mascot = request.get("mascot") or {}
+    svg_asset = _resolve_asset_path(root, mascot.get("svg_path"))
+    has_exact_svg = _is_svg_file(svg_asset)
     official_mascot = bool(mascot.get("official") or mascot.get("name"))
     if official_mascot:
-        condition = router["conditions"]["official_mascot"]
+        condition = conditions["official_mascot"]
         result["asset_gates"].append(condition["asset_gate"])
         result["capabilities"].extend(condition.get("adds_capabilities", []))
-        svg_path = mascot.get("svg_path")
-        if not svg_path or not Path(svg_path).exists():
+        if not has_exact_svg:
             result["status"] = "HOLD"
             result["reason"] = "exact SVG required for named or official mascot"
             return _finalize_route(result, request, ecosystem)
         result["skills"].extend(condition.get("adds_skills", []))
         result["conditional_agents"].extend(condition.get("adds_agents", []))
 
-    if intent == "mascot-animation" and not mascot.get("svg_path"):
+    if intent == "mascot-animation" and not has_exact_svg:
         result["status"] = "HOLD"
         result["reason"] = "exact SVG required for mascot animation"
         result["asset_gates"].append("exact-svg")

--- a/scripts/ecosystem_router.py
+++ b/scripts/ecosystem_router.py
@@ -7,6 +7,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HELPER_FILES = ("router.json", "capabilities.json", "artifacts.json", "quality-gates.json")
 REQUIRED_CONDITIONS = frozenset({"arabic", "ui_mockup", "visual_reference", "official_mascot"})
+CONDITION_SCHEMA = {
+    "arabic": {"adds_skills": list},
+    "ui_mockup": {"adds_capabilities": list, "adds_agents": list},
+    "visual_reference": {"adds_agents": list, "adds_capabilities": list},
+    "official_mascot": {
+        "asset_gate": str,
+        "adds_skills": list,
+        "adds_agents": list,
+        "adds_capabilities": list,
+    },
+}
 
 
 def _load_json(path: Path, errors=None):
@@ -36,6 +47,34 @@ def _resolve_asset_path(root: Path, value):
 
 def _is_svg_file(path: Path | None) -> bool:
     return bool(path and path.is_file() and path.suffix.lower() == ".svg")
+
+
+def _validate_required_conditions(router: dict) -> list[str]:
+    errors = []
+    conditions = router.get("conditions", {})
+    if not isinstance(conditions, dict):
+        return ["router conditions must be an object"]
+
+    for condition_id in sorted(REQUIRED_CONDITIONS - set(conditions)):
+        errors.append(f"router missing required condition {condition_id}")
+
+    for condition_id, required_fields in CONDITION_SCHEMA.items():
+        if condition_id not in conditions:
+            continue
+        contract = conditions[condition_id]
+        if not isinstance(contract, dict):
+            errors.append(f"condition {condition_id} must be an object")
+            continue
+        for field, expected_type in required_fields.items():
+            value = contract.get(field)
+            invalid = not isinstance(value, expected_type)
+            if expected_type is str and isinstance(value, str) and not value.strip():
+                invalid = True
+            if invalid:
+                errors.append(
+                    f"condition {condition_id} required field {field} must be {expected_type.__name__}"
+                )
+    return errors
 
 
 def load_ecosystem(root: Path = ROOT) -> dict:
@@ -75,6 +114,8 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
     if not router or not capabilities_doc or not artifacts_doc or not quality_gates_doc or not research_gates_doc:
         return errors
 
+    errors.extend(_validate_required_conditions(router))
+
     skills = {path.parent.name for path in (root / "skills").glob("*/SKILL.md")}
     agents = {path.stem for path in (root / "agents").glob("*.md")}
     capabilities = capabilities_doc.get("capabilities", {})
@@ -87,10 +128,7 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
 
     conditions = router.get("conditions", {})
     if not isinstance(conditions, dict):
-        errors.append("router conditions must be an object")
         conditions = {}
-    for condition_id in sorted(REQUIRED_CONDITIONS - set(conditions)):
-        errors.append(f"router missing required condition {condition_id}")
 
     for intent, route in routes.items():
         workflow = route.get("workflow")
@@ -108,7 +146,6 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
 
     for condition, contract in conditions.items():
         if not isinstance(contract, dict):
-            errors.append(f"condition {condition} must be an object")
             continue
         for skill in contract.get("adds_skills", []):
             if skill not in skills:
@@ -257,10 +294,10 @@ def route_request(request: dict, root: Path = ROOT) -> dict:
     if intent not in router["routes"]:
         raise ValueError(f"unknown routing intent: {intent}")
 
-    conditions = router.get("conditions", {})
-    missing_conditions = sorted(REQUIRED_CONDITIONS - set(conditions) if isinstance(conditions, dict) else REQUIRED_CONDITIONS)
-    if missing_conditions:
-        raise ValueError(f"router missing required conditions: {', '.join(missing_conditions)}")
+    condition_errors = _validate_required_conditions(router)
+    if condition_errors:
+        raise ValueError("invalid router conditions: " + "; ".join(condition_errors))
+    conditions = router["conditions"]
 
     base = copy.deepcopy(router["routes"][intent])
     result = {

--- a/scripts/ecosystem_router.py
+++ b/scripts/ecosystem_router.py
@@ -22,10 +22,12 @@ def _load_json(path: Path, errors=None):
 
 def load_ecosystem(root: Path = ROOT) -> dict:
     helper = root / "helper"
+    research = root / "research" / "capability-notes"
     return {
         "router": json.loads((helper / "router.json").read_text()),
         "capabilities": json.loads((helper / "capabilities.json").read_text()),
         "artifacts": json.loads((helper / "artifacts.json").read_text()),
+        "research_gates": json.loads((research / "gates.json").read_text()),
     }
 
 
@@ -49,12 +51,14 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
     router = _load_json(helper / "router.json", errors)
     capabilities_doc = _load_json(helper / "capabilities.json", errors)
     artifacts_doc = _load_json(helper / "artifacts.json", errors)
-    if not router or not capabilities_doc or not artifacts_doc:
+    research_gates_doc = _load_json(root / "research" / "capability-notes" / "gates.json", errors)
+    if not router or not capabilities_doc or not artifacts_doc or not research_gates_doc:
         return errors
 
     skills = {path.parent.name for path in (root / "skills").glob("*/SKILL.md")}
     agents = {path.stem for path in (root / "agents").glob("*.md")}
     capabilities = capabilities_doc.get("capabilities", {})
+    research_gates = research_gates_doc.get("gates", {})
 
     routes = router.get("routes", {})
     if router.get("default_intent") not in routes:
@@ -85,6 +89,7 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
             if capability not in capabilities:
                 errors.append(f"condition {condition} references missing capability {capability}")
 
+    referenced_research_gates = set()
     for capability, contract in capabilities.items():
         owners = contract.get("owners", [])
         if not owners:
@@ -92,6 +97,20 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
         unknown = sorted(set(owners) - agents)
         if unknown:
             errors.append(f"capability {capability} has unknown owners: {', '.join(unknown)}")
+        gate_ids = contract.get("research_gates", [])
+        local_native = contract.get("local_native") is True
+        if not gate_ids and not local_native:
+            errors.append(f"capability {capability} has neither research_gates nor local_native")
+        if gate_ids and local_native:
+            errors.append(f"capability {capability} cannot be both research-derived and local_native")
+        unknown_gates = sorted(set(gate_ids) - set(research_gates))
+        if unknown_gates:
+            errors.append(f"capability {capability} references unknown research gates: {', '.join(unknown_gates)}")
+        referenced_research_gates.update(gate_ids)
+
+    unreferenced = sorted(set(research_gates) - referenced_research_gates)
+    if unreferenced:
+        errors.append(f"research gates not connected to helper capabilities: {', '.join(unreferenced)}")
 
     allowed_participants = agents | {"parent:new-post"}
     for artifact, contract in artifacts_doc.get("artifacts", {}).items():
@@ -151,6 +170,32 @@ def _infer_intent(request: dict, router: dict) -> str:
     return router.get("default_intent", "create-post")
 
 
+def _research_gates_for(capability_ids, intent: str, request: dict, ecosystem: dict) -> list[str]:
+    capabilities = ecosystem["capabilities"].get("capabilities", {})
+    gates = ecosystem["research_gates"].get("gates", {})
+    candidates = []
+    for capability_id in capability_ids:
+        candidates.extend(capabilities.get(capability_id, {}).get("research_gates", []))
+    result = []
+    for gate_id in _dedupe(candidates):
+        gate = gates.get(gate_id, {})
+        intents = gate.get("applies_to_intents", [])
+        if intents and intent not in intents:
+            continue
+        requirement = gate.get("requires")
+        if requirement and not request.get(requirement):
+            continue
+        result.append(gate_id)
+    return result
+
+
+def _finalize_route(result: dict, request: dict, ecosystem: dict) -> dict:
+    for key in ("skills", "agents", "conditional_agents", "capabilities", "asset_gates"):
+        result[key] = _dedupe(result[key])
+    result["research_gates"] = _research_gates_for(result["capabilities"], result["intent"], request, ecosystem)
+    return result
+
+
 def route_request(request: dict, root: Path = ROOT) -> dict:
     ecosystem = load_ecosystem(root)
     router = ecosystem["router"]
@@ -169,6 +214,7 @@ def route_request(request: dict, root: Path = ROOT) -> dict:
         "conditional_agents": [],
         "capabilities": list(base.get("capabilities", [])),
         "asset_gates": [],
+        "research_gates": [],
     }
 
     language = (request.get("language") or "").lower()
@@ -190,31 +236,26 @@ def route_request(request: dict, root: Path = ROOT) -> dict:
     if official_mascot:
         condition = router["conditions"]["official_mascot"]
         result["asset_gates"].append(condition["asset_gate"])
+        result["capabilities"].extend(condition.get("adds_capabilities", []))
         svg_path = mascot.get("svg_path")
         if not svg_path or not Path(svg_path).exists():
             result["status"] = "HOLD"
             result["reason"] = "exact SVG required for named or official mascot"
-            return result
+            return _finalize_route(result, request, ecosystem)
         result["skills"].extend(condition.get("adds_skills", []))
         result["conditional_agents"].extend(condition.get("adds_agents", []))
-        result["capabilities"].extend(condition.get("adds_capabilities", []))
 
     if intent == "mascot-animation" and not mascot.get("svg_path"):
         result["status"] = "HOLD"
         result["reason"] = "exact SVG required for mascot animation"
         result["asset_gates"].append("exact-svg")
-        return result
+        return _finalize_route(result, request, ecosystem)
 
     if (request.get("output") or "").lower() in ("static", "png", "still"):
         result["agents"] = [agent for agent in result["agents"] if agent not in ("motion-director", "motion-engineer")]
         result["skills"] = [skill for skill in result["skills"] if skill != "motion"]
 
-    result["skills"] = _dedupe(result["skills"])
-    result["agents"] = _dedupe(result["agents"])
-    result["conditional_agents"] = _dedupe(result["conditional_agents"])
-    result["capabilities"] = _dedupe(result["capabilities"])
-    result["asset_gates"] = _dedupe(result["asset_gates"])
-    return result
+    return _finalize_route(result, request, ecosystem)
 
 
 def explain_route(route: dict) -> str:
@@ -226,6 +267,7 @@ def explain_route(route: dict) -> str:
         f"agents: {', '.join(route['agents']) or 'none'}",
         f"conditional agents: {', '.join(route['conditional_agents']) or 'none'}",
         f"capabilities: {', '.join(route['capabilities']) or 'none'}",
+        f"research gates: {', '.join(route['research_gates']) or 'none'}",
         f"asset gates: {', '.join(route['asset_gates']) or 'none'}",
     ]
     if route.get("reason"):

--- a/scripts/ecosystem_router.py
+++ b/scripts/ecosystem_router.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+import argparse
+import copy
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER_FILES = ("router.json", "capabilities.json", "artifacts.json")
+
+
+def _load_json(path: Path, errors=None):
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        if errors is not None:
+            errors.append(f"missing {path.relative_to(ROOT) if path.is_relative_to(ROOT) else path}")
+    except json.JSONDecodeError as exc:
+        if errors is not None:
+            errors.append(f"invalid JSON in {path}: {exc}")
+    return None
+
+
+def load_ecosystem(root: Path = ROOT) -> dict:
+    helper = root / "helper"
+    return {
+        "router": json.loads((helper / "router.json").read_text()),
+        "capabilities": json.loads((helper / "capabilities.json").read_text()),
+        "artifacts": json.loads((helper / "artifacts.json").read_text()),
+    }
+
+
+def _dedupe(values):
+    seen = set()
+    result = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def validate_ecosystem(root: Path = ROOT) -> list[str]:
+    errors = []
+    helper = root / "helper"
+    for relative in ("README.md", "GUIDE.md", *HELPER_FILES):
+        if not (helper / relative).exists():
+            errors.append(f"missing helper/{relative}")
+
+    router = _load_json(helper / "router.json", errors)
+    capabilities_doc = _load_json(helper / "capabilities.json", errors)
+    artifacts_doc = _load_json(helper / "artifacts.json", errors)
+    if not router or not capabilities_doc or not artifacts_doc:
+        return errors
+
+    skills = {path.parent.name for path in (root / "skills").glob("*/SKILL.md")}
+    agents = {path.stem for path in (root / "agents").glob("*.md")}
+    capabilities = capabilities_doc.get("capabilities", {})
+
+    routes = router.get("routes", {})
+    if router.get("default_intent") not in routes:
+        errors.append("router default_intent does not resolve to a route")
+
+    for intent, route in routes.items():
+        workflow = route.get("workflow")
+        if workflow != "focused" and workflow not in skills:
+            errors.append(f"route {intent} references missing workflow skill {workflow}")
+        for skill in route.get("skills", []):
+            if skill not in skills:
+                errors.append(f"route {intent} references missing skill {skill}")
+        for agent in route.get("agents", []):
+            if agent not in agents:
+                errors.append(f"route {intent} references missing agent {agent}")
+        for capability in route.get("capabilities", []):
+            if capability not in capabilities:
+                errors.append(f"route {intent} references missing capability {capability}")
+
+    for condition, contract in router.get("conditions", {}).items():
+        for skill in contract.get("adds_skills", []):
+            if skill not in skills:
+                errors.append(f"condition {condition} references missing skill {skill}")
+        for agent in contract.get("adds_agents", []):
+            if agent not in agents:
+                errors.append(f"condition {condition} references missing agent {agent}")
+        for capability in contract.get("adds_capabilities", []):
+            if capability not in capabilities:
+                errors.append(f"condition {condition} references missing capability {capability}")
+
+    for capability, contract in capabilities.items():
+        owners = contract.get("owners", [])
+        if not owners:
+            errors.append(f"capability {capability} has no owners")
+        unknown = sorted(set(owners) - agents)
+        if unknown:
+            errors.append(f"capability {capability} has unknown owners: {', '.join(unknown)}")
+
+    allowed_participants = agents | {"parent:new-post"}
+    for artifact, contract in artifacts_doc.get("artifacts", {}).items():
+        producer = contract.get("producer")
+        if producer not in allowed_participants:
+            errors.append(f"artifact {artifact} has unknown producer {producer}")
+        for consumer in contract.get("consumers", []):
+            if consumer not in allowed_participants:
+                errors.append(f"artifact {artifact} has unknown consumer {consumer}")
+
+    graph_path = root / "architecture" / "plugin-graph.json"
+    if graph_path.exists():
+        graph = _load_json(graph_path, errors) or {}
+        graph_caps = set(graph.get("capabilities", {}))
+        helper_caps = set(capabilities)
+        if graph_caps != helper_caps:
+            missing = sorted(helper_caps - graph_caps)
+            extra = sorted(graph_caps - helper_caps)
+            if missing:
+                errors.append(f"plugin graph missing helper capabilities: {', '.join(missing)}")
+            if extra:
+                errors.append(f"helper registry missing graph capabilities: {', '.join(extra)}")
+    return errors
+
+
+def _infer_intent(request: dict, router: dict) -> str:
+    explicit = (request.get("intent") or "").strip().lower()
+    aliases = {
+        "create": "create-post",
+        "create-post": "create-post",
+        "post": "create-post",
+        "qa": "qa",
+        "review": "qa",
+        "render": "render",
+        "render-gif": "render",
+        "design-study": "design-study",
+        "study": "design-study",
+        "mascot": "mascot-animation",
+        "mascot-animation": "mascot-animation",
+        "info-story": "info-story",
+        "info-stories": "info-story",
+    }
+    if explicit in aliases:
+        return aliases[explicit]
+
+    text = (request.get("request") or "").lower()
+    if any(token in text for token in ("qa this", "review this", "audit this", "check this finished")):
+        return "qa"
+    if "render" in text and any(token in text for token in ("html", "gif", "artboard")):
+        return "render"
+    if "design study" in text or "study this reference" in text:
+        return "design-study"
+    if "animate" in text and "mascot" in text and not any(token in text for token in ("post", "infographic")):
+        return "mascot-animation"
+    if "info-story" in text or "info story" in text:
+        return "info-story"
+    return router.get("default_intent", "create-post")
+
+
+def route_request(request: dict, root: Path = ROOT) -> dict:
+    ecosystem = load_ecosystem(root)
+    router = ecosystem["router"]
+    intent = _infer_intent(request, router)
+    if intent not in router["routes"]:
+        raise ValueError(f"unknown routing intent: {intent}")
+
+    base = copy.deepcopy(router["routes"][intent])
+    result = {
+        "status": "READY",
+        "reason": None,
+        "intent": intent,
+        "workflow": base["workflow"],
+        "skills": list(base.get("skills", [])),
+        "agents": list(base.get("agents", [])),
+        "conditional_agents": [],
+        "capabilities": list(base.get("capabilities", [])),
+        "asset_gates": [],
+    }
+
+    language = (request.get("language") or "").lower()
+    if language in ("ar", "arabic") or request.get("rtl") is True:
+        result["skills"].extend(router["conditions"]["arabic"]["adds_skills"])
+
+    if request.get("ui_mockup") is True:
+        condition = router["conditions"]["ui_mockup"]
+        result["capabilities"].extend(condition.get("adds_capabilities", []))
+        result["agents"].extend(condition.get("adds_agents", []))
+
+    if request.get("visual_reference") is True:
+        condition = router["conditions"]["visual_reference"]
+        result["agents"].extend(condition.get("adds_agents", []))
+        result["capabilities"].extend(condition.get("adds_capabilities", []))
+
+    mascot = request.get("mascot") or {}
+    official_mascot = bool(mascot.get("official") or mascot.get("name"))
+    if official_mascot:
+        condition = router["conditions"]["official_mascot"]
+        result["asset_gates"].append(condition["asset_gate"])
+        svg_path = mascot.get("svg_path")
+        if not svg_path or not Path(svg_path).exists():
+            result["status"] = "HOLD"
+            result["reason"] = "exact SVG required for named or official mascot"
+            return result
+        result["skills"].extend(condition.get("adds_skills", []))
+        result["conditional_agents"].extend(condition.get("adds_agents", []))
+        result["capabilities"].extend(condition.get("adds_capabilities", []))
+
+    if intent == "mascot-animation" and not mascot.get("svg_path"):
+        result["status"] = "HOLD"
+        result["reason"] = "exact SVG required for mascot animation"
+        result["asset_gates"].append("exact-svg")
+        return result
+
+    if (request.get("output") or "").lower() in ("static", "png", "still"):
+        result["agents"] = [agent for agent in result["agents"] if agent not in ("motion-director", "motion-engineer")]
+        result["skills"] = [skill for skill in result["skills"] if skill != "motion"]
+
+    result["skills"] = _dedupe(result["skills"])
+    result["agents"] = _dedupe(result["agents"])
+    result["conditional_agents"] = _dedupe(result["conditional_agents"])
+    result["capabilities"] = _dedupe(result["capabilities"])
+    result["asset_gates"] = _dedupe(result["asset_gates"])
+    return result
+
+
+def explain_route(route: dict) -> str:
+    lines = [
+        f"status: {route['status']}",
+        f"intent: {route['intent']}",
+        f"workflow: {route['workflow']}",
+        f"skills: {', '.join(route['skills']) or 'none'}",
+        f"agents: {', '.join(route['agents']) or 'none'}",
+        f"conditional agents: {', '.join(route['conditional_agents']) or 'none'}",
+        f"capabilities: {', '.join(route['capabilities']) or 'none'}",
+        f"asset gates: {', '.join(route['asset_gates']) or 'none'}",
+    ]
+    if route.get("reason"):
+        lines.append(f"reason: {route['reason']}")
+    return "\n".join(lines)
+
+
+def _request_from_args(args):
+    mascot = {}
+    if getattr(args, "mascot_name", None):
+        mascot["name"] = args.mascot_name
+    if getattr(args, "official_mascot", False):
+        mascot["official"] = True
+    if getattr(args, "svg_path", None):
+        mascot["svg_path"] = args.svg_path
+    request = {
+        "request": getattr(args, "request", ""),
+        "intent": getattr(args, "intent", None),
+        "language": getattr(args, "language", None),
+        "output": getattr(args, "output", None),
+        "ui_mockup": getattr(args, "ui_mockup", False),
+        "visual_reference": getattr(args, "visual_reference", False),
+    }
+    if mascot:
+        request["mascot"] = mascot
+    return request
+
+
+def _add_route_args(parser):
+    parser.add_argument("--request", required=True)
+    parser.add_argument("--intent")
+    parser.add_argument("--language")
+    parser.add_argument("--output")
+    parser.add_argument("--ui-mockup", action="store_true")
+    parser.add_argument("--visual-reference", action="store_true")
+    parser.add_argument("--mascot-name")
+    parser.add_argument("--official-mascot", action="store_true")
+    parser.add_argument("--svg-path")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Route and validate the LinkedIn infographic ecosystem")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("check")
+    route_parser = sub.add_parser("route")
+    explain_parser = sub.add_parser("explain")
+    _add_route_args(route_parser)
+    _add_route_args(explain_parser)
+    args = parser.parse_args(argv)
+
+    if args.command == "check":
+        errors = validate_ecosystem(ROOT)
+        if errors:
+            for error in errors:
+                print(f"ERROR: {error}")
+            return 1
+        print("Ecosystem helper: OK")
+        return 0
+
+    route = route_request(_request_from_args(args), ROOT)
+    if args.command == "route":
+        print(json.dumps(route, indent=2, ensure_ascii=False))
+    else:
+        print(explain_route(route))
+    return 2 if route["status"] == "HOLD" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ecosystem_router.py
+++ b/scripts/ecosystem_router.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-HELPER_FILES = ("router.json", "capabilities.json", "artifacts.json")
+HELPER_FILES = ("router.json", "capabilities.json", "artifacts.json", "quality-gates.json")
 
 
 def _load_json(path: Path, errors=None):
@@ -13,7 +13,11 @@ def _load_json(path: Path, errors=None):
         return json.loads(path.read_text())
     except FileNotFoundError:
         if errors is not None:
-            errors.append(f"missing {path.relative_to(ROOT) if path.is_relative_to(ROOT) else path}")
+            try:
+                display = path.relative_to(ROOT)
+            except ValueError:
+                display = path
+            errors.append(f"missing {display}")
     except json.JSONDecodeError as exc:
         if errors is not None:
             errors.append(f"invalid JSON in {path}: {exc}")
@@ -27,6 +31,7 @@ def load_ecosystem(root: Path = ROOT) -> dict:
         "router": json.loads((helper / "router.json").read_text()),
         "capabilities": json.loads((helper / "capabilities.json").read_text()),
         "artifacts": json.loads((helper / "artifacts.json").read_text()),
+        "quality_gates": json.loads((helper / "quality-gates.json").read_text()),
         "research_gates": json.loads((research / "gates.json").read_text()),
     }
 
@@ -51,13 +56,15 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
     router = _load_json(helper / "router.json", errors)
     capabilities_doc = _load_json(helper / "capabilities.json", errors)
     artifacts_doc = _load_json(helper / "artifacts.json", errors)
+    quality_gates_doc = _load_json(helper / "quality-gates.json", errors)
     research_gates_doc = _load_json(root / "research" / "capability-notes" / "gates.json", errors)
-    if not router or not capabilities_doc or not artifacts_doc or not research_gates_doc:
+    if not router or not capabilities_doc or not artifacts_doc or not quality_gates_doc or not research_gates_doc:
         return errors
 
     skills = {path.parent.name for path in (root / "skills").glob("*/SKILL.md")}
     agents = {path.stem for path in (root / "agents").glob("*.md")}
     capabilities = capabilities_doc.get("capabilities", {})
+    quality_gates = quality_gates_doc.get("gates", {})
     research_gates = research_gates_doc.get("gates", {})
 
     routes = router.get("routes", {})
@@ -111,6 +118,23 @@ def validate_ecosystem(root: Path = ROOT) -> list[str]:
     unreferenced = sorted(set(research_gates) - referenced_research_gates)
     if unreferenced:
         errors.append(f"research gates not connected to helper capabilities: {', '.join(unreferenced)}")
+
+    for gate_id, gate in quality_gates.items():
+        if gate.get("severity") not in {"blocking", "advisory"}:
+            errors.append(f"quality gate {gate_id} has invalid severity")
+        owners = set(gate.get("owners", []))
+        if not owners:
+            errors.append(f"quality gate {gate_id} has no owners")
+        unknown = sorted(owners - agents)
+        if unknown:
+            errors.append(f"quality gate {gate_id} has unknown owners: {', '.join(unknown)}")
+        if not gate.get("applies_to_intents"):
+            errors.append(f"quality gate {gate_id} has no applies_to_intents")
+        unknown_intents = sorted(set(gate.get("applies_to_intents", [])) - set(routes))
+        if unknown_intents:
+            errors.append(f"quality gate {gate_id} references unknown intents: {', '.join(unknown_intents)}")
+        if not gate.get("behavior"):
+            errors.append(f"quality gate {gate_id} has no behavior")
 
     allowed_participants = agents | {"parent:new-post"}
     for artifact, contract in artifacts_doc.get("artifacts", {}).items():
@@ -189,10 +213,16 @@ def _research_gates_for(capability_ids, intent: str, request: dict, ecosystem: d
     return result
 
 
+def _quality_gates_for(intent: str, ecosystem: dict) -> list[str]:
+    gates = ecosystem["quality_gates"].get("gates", {})
+    return [gate_id for gate_id, gate in gates.items() if intent in gate.get("applies_to_intents", [])]
+
+
 def _finalize_route(result: dict, request: dict, ecosystem: dict) -> dict:
     for key in ("skills", "agents", "conditional_agents", "capabilities", "asset_gates"):
         result[key] = _dedupe(result[key])
     result["research_gates"] = _research_gates_for(result["capabilities"], result["intent"], request, ecosystem)
+    result["quality_gates"] = _quality_gates_for(result["intent"], ecosystem)
     return result
 
 
@@ -215,6 +245,7 @@ def route_request(request: dict, root: Path = ROOT) -> dict:
         "capabilities": list(base.get("capabilities", [])),
         "asset_gates": [],
         "research_gates": [],
+        "quality_gates": [],
     }
 
     language = (request.get("language") or "").lower()
@@ -268,6 +299,7 @@ def explain_route(route: dict) -> str:
         f"conditional agents: {', '.join(route['conditional_agents']) or 'none'}",
         f"capabilities: {', '.join(route['capabilities']) or 'none'}",
         f"research gates: {', '.join(route['research_gates']) or 'none'}",
+        f"quality gates: {', '.join(route['quality_gates']) or 'none'}",
         f"asset gates: {', '.join(route['asset_gates']) or 'none'}",
     ]
     if route.get("reason"):

--- a/scripts/plugin_graph.py
+++ b/scripts/plugin_graph.py
@@ -37,6 +37,17 @@ def load_component_graph(root: Path = ROOT) -> dict:
     return json.loads((root / "architecture" / "plugin-graph.json").read_text())
 
 
+def _load_optional_json(path: Path, errors: list[str], label: str):
+    if not path.exists():
+        errors.append(f"missing {label}: {path}")
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid JSON in {label}: {exc}")
+        return None
+
+
 def validate_component_graph(root: Path = ROOT) -> list[str]:
     errors = []
     graph_path = root / "architecture" / "plugin-graph.json"
@@ -90,12 +101,47 @@ def validate_component_graph(root: Path = ROOT) -> list[str]:
             errors.append(f"conditional edge {name} is missing asset_gate")
 
     shipping = set(sequence) | conditional_agents
-    for capability, owners in graph.get("capabilities", {}).items():
+    graph_capabilities = graph.get("capabilities", {})
+    for capability, owners in graph_capabilities.items():
         unknown = sorted(set(owners) - graph_agents)
         if unknown:
             errors.append(f"{capability} has unknown owners: {', '.join(unknown)}")
         if not shipping.intersection(owners):
             errors.append(f"{capability} has no owner on the shipping path")
+
+    helper_dir = root / "helper"
+    helper_capabilities_doc = _load_optional_json(helper_dir / "capabilities.json", errors, "helper capabilities")
+    helper_router = _load_optional_json(helper_dir / "router.json", errors, "helper router")
+    if helper_capabilities_doc is not None:
+        helper_capabilities = helper_capabilities_doc.get("capabilities", {})
+        if set(helper_capabilities) != set(graph_capabilities):
+            missing = sorted(set(helper_capabilities) - set(graph_capabilities))
+            extra = sorted(set(graph_capabilities) - set(helper_capabilities))
+            if missing:
+                errors.append(f"plugin graph missing helper capabilities: {', '.join(missing)}")
+            if extra:
+                errors.append(f"helper registry missing graph capabilities: {', '.join(extra)}")
+        for capability in sorted(set(helper_capabilities) & set(graph_capabilities)):
+            helper_owners = set(helper_capabilities[capability].get("owners", []))
+            graph_owners = set(graph_capabilities[capability])
+            if helper_owners != graph_owners:
+                errors.append(
+                    f"helper capability {capability} owner drift: "
+                    f"helper={sorted(helper_owners)} graph={sorted(graph_owners)}"
+                )
+
+    if helper_router is not None:
+        create_route = helper_router.get("routes", {}).get("create-post", {})
+        helper_agents = create_route.get("agents", [])
+        if helper_agents != sequence:
+            errors.append("helper create-post agent order does not match plugin graph new-post sequence")
+        mascot_condition = helper_router.get("conditions", {}).get("official_mascot", {})
+        mascot_edge = workflow.get("conditional", {}).get("mascot", {})
+        helper_mascot_agents = mascot_condition.get("adds_agents", [])
+        if helper_mascot_agents != ([mascot_edge.get("agent")] if mascot_edge.get("agent") else []):
+            errors.append("helper official_mascot agent does not match plugin graph mascot edge")
+        if mascot_condition.get("asset_gate") != mascot_edge.get("asset_gate"):
+            errors.append("helper official_mascot asset gate does not match plugin graph mascot edge")
     return errors
 
 

--- a/scripts/research_gates.py
+++ b/scripts/research_gates.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_GATE_FIELDS = ("sources", "stage", "severity", "owners", "local_behavior", "implementation_refs")
+VALID_SEVERITIES = {"blocking", "advisory"}
+
+
+def _load(path: Path, errors: list[str], label: str):
+    if not path.exists():
+        errors.append(f"missing {label}: {path}")
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid JSON in {label}: {exc}")
+        return None
+
+
+def load_research_gates(root: Path = ROOT) -> dict:
+    base = root / "research" / "capability-notes"
+    return {
+        "sources": json.loads((base / "sources.json").read_text()),
+        "gates": json.loads((base / "gates.json").read_text()),
+    }
+
+
+def validate_research_gates(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    base = root / "research" / "capability-notes"
+    sources_doc = _load(base / "sources.json", errors, "research sources")
+    gates_doc = _load(base / "gates.json", errors, "research gates")
+    capabilities_doc = _load(root / "helper" / "capabilities.json", errors, "helper capabilities")
+    graph = _load(root / "architecture" / "plugin-graph.json", errors, "plugin graph")
+    if not all((sources_doc, gates_doc, capabilities_doc, graph)):
+        return errors
+
+    source_items = sources_doc.get("sources", [])
+    source_names = {item.get("name") for item in source_items if item.get("name")}
+    for item in source_items:
+        name = item.get("name", "<unknown>")
+        commit = item.get("commit", "")
+        if not re.fullmatch(r"[0-9a-f]{40}", commit):
+            errors.append(f"research source {name} has invalid commit SHA")
+        if item.get("license") != "MIT":
+            errors.append(f"research source {name} is not recorded as MIT")
+        repository = item.get("repository", "")
+        if not repository.startswith("https://github.com/"):
+            errors.append(f"research source {name} has invalid repository URL")
+
+    graph_agents = set(graph.get("agents", {}))
+    workflow = graph.get("workflows", {}).get("new-post", {})
+    shipping_agents = set(workflow.get("sequence", [])) | {
+        edge.get("agent") for edge in workflow.get("conditional", {}).values() if edge.get("agent")
+    }
+
+    gates = gates_doc.get("gates", {})
+    known_gate_ids = set(gates)
+    referenced_gate_ids: set[str] = set()
+
+    for gate_id, gate in gates.items():
+        for field in REQUIRED_GATE_FIELDS:
+            value = gate.get(field)
+            if value in (None, "", []):
+                errors.append(f"research gate {gate_id} missing {field}")
+        if gate.get("severity") not in VALID_SEVERITIES:
+            errors.append(f"research gate {gate_id} has invalid severity {gate.get('severity')!r}")
+        unknown_sources = sorted(set(gate.get("sources", [])) - source_names)
+        if unknown_sources:
+            errors.append(f"research gate {gate_id} references unknown sources: {', '.join(unknown_sources)}")
+        owners = set(gate.get("owners", []))
+        unknown_owners = sorted(owners - graph_agents)
+        if unknown_owners:
+            errors.append(f"research gate {gate_id} references unknown owners: {', '.join(unknown_owners)}")
+        if owners and not owners.intersection(shipping_agents):
+            errors.append(f"research gate {gate_id} has no owner on the shipping path")
+        for relative in gate.get("implementation_refs", []):
+            if not (root / relative).exists():
+                errors.append(f"research gate {gate_id} implementation ref missing: {relative}")
+        intents = gate.get("applies_to_intents", [])
+        if not intents:
+            errors.append(f"research gate {gate_id} has no applies_to_intents")
+
+    capabilities = capabilities_doc.get("capabilities", {})
+    for capability, contract in capabilities.items():
+        research_gates = contract.get("research_gates", [])
+        local_native = contract.get("local_native") is True
+        if not research_gates and not local_native:
+            errors.append(f"helper capability {capability} has neither research_gates nor local_native")
+        if research_gates and local_native:
+            errors.append(f"helper capability {capability} cannot be both research-derived and local_native")
+        unknown = sorted(set(research_gates) - known_gate_ids)
+        if unknown:
+            errors.append(f"helper capability {capability} references unknown research gates: {', '.join(unknown)}")
+        referenced_gate_ids.update(research_gates)
+
+        capability_owners = set(contract.get("owners", []))
+        for gate_id in research_gates:
+            gate_owners = set(gates.get(gate_id, {}).get("owners", []))
+            if gate_owners and capability_owners and not gate_owners.intersection(capability_owners):
+                errors.append(f"helper capability {capability} has no shared owner with research gate {gate_id}")
+
+    unreferenced = sorted(known_gate_ids - referenced_gate_ids)
+    if unreferenced:
+        errors.append(f"unreferenced research gates: {', '.join(unreferenced)}")
+    return errors
+
+
+def gates_for_capabilities(capability_ids, intent: str, request: dict, root: Path = ROOT) -> list[str]:
+    data = load_research_gates(root)
+    gates = data["gates"].get("gates", {})
+    capabilities = json.loads((root / "helper" / "capabilities.json").read_text()).get("capabilities", {})
+    gate_ids = []
+    for capability_id in capability_ids:
+        for gate_id in capabilities.get(capability_id, {}).get("research_gates", []):
+            if gate_id not in gate_ids:
+                gate_ids.append(gate_id)
+
+    result = []
+    for gate_id in gate_ids:
+        gate = gates.get(gate_id, {})
+        intents = gate.get("applies_to_intents", [])
+        if intents and intent not in intents:
+            continue
+        requirement = gate.get("requires")
+        if requirement and not request.get(requirement):
+            continue
+        result.append(gate_id)
+    return result
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Validate research-derived runtime capability gates")
+    parser.add_argument("command", nargs="?", default="check", choices=("check",))
+    parser.parse_args(argv)
+    errors = validate_research_gates(ROOT)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Research gates: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research_gates.py
+++ b/scripts/research_gates.py
@@ -20,6 +20,21 @@ def _load(path: Path, errors: list[str], label: str):
         return None
 
 
+def _safe_repo_path(root: Path, relative: str):
+    if not isinstance(relative, str) or not relative:
+        return None
+    supplied = Path(relative)
+    if supplied.is_absolute():
+        return None
+    root_resolved = root.resolve()
+    resolved = (root_resolved / supplied).resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        return None
+    return resolved
+
+
 def load_research_gates(root: Path = ROOT) -> dict:
     base = root / "research" / "capability-notes"
     return {
@@ -78,7 +93,10 @@ def validate_research_gates(root: Path = ROOT) -> list[str]:
         if owners and not owners.intersection(shipping_agents):
             errors.append(f"research gate {gate_id} has no owner on the shipping path")
         for relative in gate.get("implementation_refs", []):
-            if not (root / relative).exists():
+            implementation = _safe_repo_path(root, relative)
+            if implementation is None:
+                errors.append(f"research gate {gate_id} has unsafe implementation ref: {relative}")
+            elif not implementation.exists():
                 errors.append(f"research gate {gate_id} implementation ref missing: {relative}")
         intents = gate.get("applies_to_intents", [])
         if not intents:

--- a/scripts/validate_marketplace.py
+++ b/scripts/validate_marketplace.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_PLUGIN_VERSION = "3.0.0"
 
 
 def _load_json(path: Path, errors: list[str]):
@@ -48,10 +49,10 @@ def validate_marketplace(root: Path = ROOT) -> list[str]:
         errors.append("root plugin must use strict mode")
     if entry.get("version") != plugin.get("version"):
         errors.append("marketplace plugin version does not match plugin.json")
-    if plugin.get("version") != "2.2.0":
-        errors.append("plugin release version must be 2.2.0")
+    if plugin.get("version") != EXPECTED_PLUGIN_VERSION:
+        errors.append(f"plugin release version must be {EXPECTED_PLUGIN_VERSION}")
 
-    for relative in ("skills", "agents", "hooks/hooks.json"):
+    for relative in ("skills", "agents", "hooks/hooks.json", "helper"):
         if not (root / relative).exists():
             errors.append(f"missing standard plugin component {relative}")
     hooks = _load_json(root / "hooks" / "hooks.json", errors)

--- a/skills/arabic/SKILL.md
+++ b/skills/arabic/SKILL.md
@@ -1,42 +1,57 @@
 ---
 name: arabic
-description: >-
-  Produce the Arabic or bilingual version of a LinkedIn infographic and caption. Use for any
-  Arabic or mixed Arabic-English post, artboard, or caption, and whenever a layout needs to
-  mirror to RTL. Trigger on "النسخة العربية", "اعملي نسخة بالعربي", "RTL version", "bilingual
-  post", or an Arabic brief for a visual. Covers layout mirroring, the numeral system, the
-  Arabic type scale, bidi isolation for LTR technical terms, the font stack, and how Arabic
-  caption rhythm differs from English.
+description: Produce Arabic or bilingual LinkedIn infographic copy and layout with native RTL reading order, bidi-safe technical terms, Arabic-aware typography, and evidence-safe hooks.
 ---
 
 # Arabic and bilingual output
 
-**This is not a translation job.** Running the English artboard through a translator and
-flipping `direction: rtl` produces something that reads as a machine artifact to any native
-reader, and the type will be visibly too small.
+## Purpose
 
-Four things change, and all four are structural:
+Adapt an approved infographic story and caption for Arabic or mixed Arabic-English use without treating the work as word-for-word translation. Preserve meaning, evidence, hierarchy, and native reading behavior.
 
-1. **The layout mirrors.** Reading order runs right to left, so the eyebrow, headline, number
-   badges, and dotted leaders all move, and any sequential highlight runs the other way.
-2. **The typographic scale changes.** Arabic needs roughly 12% more leading and one size step
-   up for the same optical weight. An Arabic headline set at the English size looks thin and
-   cramped.
-3. **The numeral system is a decision.** Pick one and hold it across the whole artboard.
-4. **English technical terms stay LTR inside RTL runs.** `Claude`, `ChatGPT`, `MCP`, `CTR`,
-   version strings, and commands need bidi isolation or the punctuation around them jumps to
-   the wrong side.
+Read `helper/GUIDE.md` first. Arabic/RTL is a conditional route that changes copy, typography, reading order, motion direction, and alignment decisions.
 
-## Caption rhythm
+## Use when
 
-Arabic LinkedIn captions carry longer lines than English ones and break at different points.
-The truncation cut still applies but lands at a different character count, so line 1 has to be
-measured rather than assumed.
+Use for Arabic briefs, Arabic captions, bilingual posts, RTL artboards, or any story that mixes Arabic with LTR technical terms such as product names, commands, acronyms, or version strings.
 
-The ban list applies identically in Arabic: no `ده مش X، ده Y`, no `مش مجرد X`, no
-`هذا ليس X، بل Y`, no em dashes.
+## Inputs
 
-## Full reference
+- approved source/evidence and story direction
+- Arabic source copy or approved meaning to adapt
+- product/brand spellings that must remain exact
+- selected Story House and layout when already resolved
+- numeral preference when the brief requires one
+- static or animated output mode
 
-`references/arabic-rtl.md` has the font stack, the bidi isolation markers, the mirrored
-spacing scale, and the caption rhythm differences. Read it before producing any Arabic output.
+## Outputs
+
+Return Arabic/bilingual copy, RTL layout instructions, bidi-isolation notes for LTR technical terms, numeral decision, typography adjustments, and any evidence/meaning issue to the parent workflow.
+
+## Procedure
+
+1. Read `references/arabic-rtl.md` in full.
+2. Preserve the source meaning and protected facts before rewriting for Arabic rhythm.
+3. Mirror reading order where sequence or hierarchy depends on direction. Do not mechanically mirror product UI or diagrams whose native direction is part of the evidence.
+4. Use Arabic-aware type sizing and leading. Arabic usually needs more vertical breathing room and may need a larger optical size than the English equivalent.
+5. Pick one numeral convention and hold it across the artifact unless the evidence itself contains a different literal number format.
+6. Isolate English product names, commands, acronyms, version strings, URLs, and code so punctuation does not jump in RTL runs.
+7. Apply `hooked-design-copy` to the Arabic hero/opening when the slot is attention-bearing. Use natural Arabic framing, not literal translation of an English hook.
+8. Preserve `center-first` as the default composition, but Arabic/RTL reading flow is an explicit alignment exception when centered treatment reduces comprehension.
+9. Recheck the mobile truncation cut and feed-width typography after adaptation.
+
+## HOLD conditions
+
+Return a HOLD when a protected product/brand spelling is unknown, a factual hook cannot be preserved truthfully in Arabic, a bilingual UI state would require inventing untranslated product behavior, or the chosen numeral/terminology convention is genuinely ambiguous and materially affects the artifact.
+
+## Related components
+
+- routing authority: `helper/GUIDE.md`
+- caption rules: `skills/caption/SKILL.md`
+- design copy hooks: `skills/info-stories/references/hook-driven-design-copy.md`
+- Arabic reference: `references/arabic-rtl.md`
+- full parent workflow: `skills/new-post/SKILL.md`
+
+## Research gates
+
+When active in the route, apply `prose-specificity`, `voice-preservation`, and `evidence-traceability`. Arabic adaptation may change rhythm and phrasing, but it may not erase specific facts or create unsupported emphasis.

--- a/skills/artboard/SKILL.md
+++ b/skills/artboard/SKILL.md
@@ -1,84 +1,67 @@
 ---
 name: artboard
-description: >-
-  Choose a visual layout and build the 1080x1350 still. Use when picking a visual archetype for
-  an infographic, laying out cards, panels, nodes, or a route, choosing colours, type, or
-  spacing for a LinkedIn visual, or building the HTML artboard before any animation. Covers 13
-  layout archetypes, the House 0 default palette with its nine section hues, offline-safe font
-  stacks, the type scale, and the mandatory attribution footer.
+description: Choose and execute the static 1080x1350 infographic composition, including hierarchy, Story House tokens, center-first alignment, UI surfaces, contrast, and feed-scale legibility before motion.
 ---
 
 # Artboard
 
-The still is the approval gate. Build it, show it, get a yes, then animate.
+## Purpose
 
-## Pick the layout from the shape of the content
+Build or evaluate the approved static infographic composition before animation. The still is the visual approval gate and the base artifact consumed by motion and render workers.
 
-| Content shape | Archetype |
-|---|---|
-| A hierarchy of files or modules | Directory Map |
-| A linear process with stages | Pipeline Stages |
-| A cyclical process with no start | Orbit Cycle |
-| Many inputs converging on one output | Flow Map + Verdict |
-| A flat catalogue of third-party tools | Logo Grid |
-| N independent items of equal weight | Trading Card Grid |
-| A branching dependency graph | Node Tree |
-| One product or integration announcement | Terminal Card |
-| Dense reference material meant to be saved | Cheat Sheet Poster |
-| A benchmark, spec, or timeline | Spec Sheet |
-| A sequential how-to | Annotated Blueprint |
-| A sequence made friendly, with a character | Character Flowchart |
-| A catalogue you can *show* running | Specimen Grid |
+Read `helper/GUIDE.md` before choosing structure. When Info-stories is active, the resolved Story House, Visual Style, Story Archetype, creative concept, and layout spec are authoritative inputs.
 
-Caption archetype and visual archetype are chosen independently.
-`references/visual-archetypes.md` has the structural spec, what to animate, and the failure
-mode for each, plus a table for choosing between adjacent ones.
+## Use when
 
-## Colour: House 0 is the default
+Use for selecting a static visual archetype, executing cards/panels/routes/UI mockups, applying typography and spacing, building `build/post.html`, or checking whether a still is ready for motion.
 
-Warm paper ground, nine desaturated section hues in four tiers each, one terracotta carrying
-every active state. Build in it unless the content is genuinely dark-technical (House 2 or 3)
-or the brief names a brand palette, and say which house you switched to and why.
+## Inputs
 
-Drop-in token sheet: `${CLAUDE_PLUGIN_ROOT}/assets/house0-tokens.css`.
-Rendered swatches: `${CLAUDE_PLUGIN_ROOT}/assets/house0-swatches.html`.
+- selected creative concept when present
+- `build/story-brief.json`
+- `build/palette-check.json`
+- `build/artboard-copy.json`
+- `build/layout-spec.json`
+- optional caption, UI evidence, exact mascot-zone requirement, and brand assets
 
-Tier discipline is what keeps it calm. `bar` for header strips, `wash` for panel bodies, `mid`
-for filled badges with white text, `ink` for label text. Never a `mid` on a background larger
-than 60px, never an `ink` as a fill. Full rules in `references/design-systems.md`.
+## Outputs
 
-Section hues are **static identity**. The accent is **state**. The moment a section hue
-animates, the reader loses the ability to tell "this is panel four" from "this is the panel
-being pointed at".
+Return or support generation of `build/post.html`, `build/still.png`, structural/fidelity notes, visual default compliance, and any blocking render/layout finding to the parent workflow.
 
-## Hard constraints
+## Procedure
 
-1. Exactly one `#artboard` element, `width:1080px; height:1350px`. The capture script
-   screenshots that element, not the viewport.
-2. Fonts are system-safe or base64-embedded in the same file. A webfont that loads over the
-   network renders as a fallback in some frames and not others, and the GIF flickers.
-3. Nothing in the outer 48px margin may ever move. That band holds the title and the footer.
-4. **The attribution footer is mandatory.** Avatar, name, one URL. These images get reposted
-   stripped of the caption, and the footer is the only thing that survives.
-5. Anything load-bearing stays at or above 22px in artboard units, which is about 7px at
-   LinkedIn's 350px feed width.
-6. Text must reach **4.5:1 contrast** and use **500 weight or heavier**. Use each house's
-   `--accent-deep` for accent-coloured text, never the raw accent token. See
-   `references/design-systems.md#contrast-floor-every-house` for the calculation and token
-   rules.
-
-## Templates
-
-`${CLAUDE_PLUGIN_ROOT}/assets/` holds `template-flow-map.html`, `template-orbit-cycle.html`,
-`template-directory-map.html`, `template-specimen-grid.html`, and `template-mascot-flow.html`.
-Start from one rather than from an empty file.
-
-## Check the still
+1. Read `references/visual-archetypes.md` and `references/design-systems.md`.
+2. Choose or execute structure from the content shape. Existing archetypes include Directory Map, Pipeline Stages, Orbit Cycle, Flow Map + Verdict, Logo Grid, Trading Card Grid, Node Tree, Terminal Card, Cheat Sheet Poster, Spec Sheet, Annotated Blueprint, Character Flowchart, and Specimen Grid.
+3. When Info-stories is active, use the resolved Story House token block. Do not silently replace it with legacy House 0. Legacy work without a story brief may still use the existing House 0 fallback.
+4. Apply the plugin-local palette default `creative-attractive-restrained`. Keep the palette memorable and harmonious, with a clear accent and enough personality to feel designed. Avoid exaggerated saturation, unnecessary neon, and competing accents unless the approved brief explicitly requires them.
+5. Apply `center-first` composition to the primary visual anchor and major zones. Use a documented alignment exception only for content that benefits from it, including tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL reading flow, or reference-DNA fidelity.
+6. Build macro zones first, then hierarchy, cards/connectors/UI, then attribution. One zone gets one reading job.
+7. For UI stories, read `skills/info-stories/references/ui-mockup-rules.md`. Preserve evidence-qualified product states and feed-width legibility. Concept UI must remain identifiable when it could be mistaken for real product evidence.
+8. Keep exactly one `#artboard` at `1080x1350`, system-safe or embedded fonts, mandatory attribution, and load-bearing text at or above the existing feed-scale floor.
+9. Enforce text contrast of at least 4.5:1 and the existing state-pair floor. Use the resolved semantic tokens rather than arbitrary one-off colors.
+10. Run the static checks:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py build/post.html --out build/still.png
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py build/post.html --mobile
 ```
 
-The mobile downscale is the one to judge legibility on. Micro labels below 22px are
-unreadable in feed by design; every flag is a judgement call, not an automatic failure.
+11. Inspect the rendered still at feed width. Confirm visual anchor, alignment decision, structural fingerprint, footer clearance, UI readability, and restrained palette character.
+
+## HOLD conditions
+
+Return a HOLD when contrast fails, the selected Story House/style combination is incompatible, the layout needs unsupported factual/product UI, a required asset is missing, center-first is overridden without a defensible reason, or the still is unreadable at feed width.
+
+## Related components
+
+- routing authority: `helper/GUIDE.md`
+- local quality gates: `helper/quality-gates.json`
+- design defaults: `skills/info-stories/references/design-taste-gates.md`
+- UI fidelity: `skills/info-stories/references/ui-mockup-rules.md`
+- structural check: `tools/fingerprint_check.py`
+- contrast check: `tools/contrast_check.py`
+- worker: `agents/artboard-builder.md`
+
+## Research gates
+
+Apply `structural-originality` and `contrast-discipline` on every Info-stories artboard. Apply `reference-dna` when a visual reference drives the layout. Evidence-bearing UI also inherits `evidence-traceability`.

--- a/skills/caption/SKILL.md
+++ b/skills/caption/SKILL.md
@@ -1,61 +1,58 @@
 ---
 name: caption
-description: >-
-  Write or edit the caption for a LinkedIn post. Use when drafting a LinkedIn caption, a hook,
-  an opening line, a CTA, a comment gate, or a first comment, and when rewriting a caption that
-  sounds AI-written. Covers seven caption archetypes, the mobile truncation cut, the hook and
-  CTA libraries, and the hard ban on denial-then-reveal contrast and em dashes in English and
-  Arabic. Trigger on "اكتبلي كابشن", "hook للبوست", "caption for my post", or any request to
-  improve LinkedIn post copy.
+description: Write or edit evidence-safe LinkedIn captions, opening hooks, CTAs, and first comments using one caption archetype, mobile truncation discipline, and the repository anti-slop rules.
 ---
 
 # Caption
 
-The caption is 90% of the work. It decides what the visual has to carry, so it gets written
-before the artboard.
+## Purpose
 
-## Pick one archetype and stay in it
+Write or evaluate the post caption and opening hook without weakening evidence or turning the copy into generic marketing language. Attention-bearing copy should earn the click; literal information should remain literal when clarity is the job.
 
-| Archetype | Use when | Signature move |
-|---|---|---|
-| **A. Numbered Inventory** | N discrete items of equal weight | "My 9 X." then 9 one-line entries |
-| **B. Result Case Study** | you have a real before/after metric | the metric appears three times |
-| **C. Bundle Manifest** | gating a free resource | `▫️` list plus a comment keyword |
-| **D. Setup Walkthrough** | the value is a procedure | numbered clicks, an oddly specific time claim |
-| **E. Operating Story** | you made a real decision at your company | first person, cost admitted, no CTA at all |
-| **F. Belief Correction** | you have a POV and nothing to sell | 3 to 8 word lines, aphoristic close |
-| **G. Catalogue Tease** | giving away a large set the visual can show | "That is 5 of 42." |
+Read `helper/GUIDE.md` first. For Info-stories, also read `skills/info-stories/references/hook-driven-design-copy.md`.
 
-Blending archetypes is the most common failure. A manifest with a case study bolted on reads
-as a pitch deck.
+## Use when
 
-## The four rules that carry most of the quality
+Use for a new caption, hook, opening line, CTA, first comment, caption rewrite, or caption QA. Use the `caption-writer` worker inside the full parent workflow.
 
-1. **Line 1 survives the truncation cut.** LinkedIn shows roughly 140 characters on mobile.
-   Keep line 1 under 55 characters and make it worth the click on its own.
-2. **One idea per line, blank line between almost every line.** These captions are 90%
-   whitespace by area. When a block hits three lines, break it.
-3. **Specific numbers and specific product names.** Categories are invisible; names are proof.
-   Replace every generic noun with the actual name or delete the line.
-4. **One CTA, at the end.** Comment keyword, repost, newsletter, or question. Pick one.
+## Inputs
 
-## Hard bans
+- approved facts/evidence
+- audience and one primary takeaway
+- selected creative concept and story brief when available
+- CTA or explicitly CTA-free intent
+- language and any brand/voice constraints
 
-Never write the denial-then-reveal contrast in any language:
-`This is not X, this is Y` / `Not just X, but Y` / `ده مش X، ده Y` / `مش مجرد X` /
-`هذا ليس X، بل Y`. State the thing directly instead.
+## Outputs
 
-No em dashes. Use a period and a line break. No buzzword list
-(unlock, leverage, seamless, transform, empower, robust, and the rest).
+Return finished caption copy, first-comment copy when applicable, selected caption archetype, hook mechanism, and any unsupported claim that prevents a safe final version.
 
-## Full reference
+## Procedure
 
-`references/caption-patterns.md` has the line-by-line skeleton for each archetype, the hook
-library grouped by mechanism, the CTA table, the bullet-glyph vocabulary, and the complete
-ban list with the self-check to run before output.
+1. Read `references/caption-patterns.md` and the active helper gates.
+2. Pick one caption archetype and stay in it: Numbered Inventory, Result Case Study, Bundle Manifest, Setup Walkthrough, Operating Story, Belief Correction, or Catalogue Tease.
+3. Apply `hooked-design-copy` to line 1. Use specificity, supported tension, concrete outcome, recognizable problem, useful surprise, or strong framing. A portable generic opening fails.
+4. Keep line 1 compact enough to survive the mobile truncation cut; under roughly 55 characters is a strong default when the language allows it.
+5. Keep one idea per line and use deliberate whitespace. Do not let a short-form caption collapse into dense paragraphs.
+6. Use specific names and numbers only when evidence supports them. Unsupported precision is removed, not approximated.
+7. Use one CTA at the end unless the chosen archetype intentionally has none.
+8. Run anti-slop checks. Reject denial-then-reveal constructions, generic puffery, faux insight, repetitive recap, and buzzword substitution. No em dashes.
+9. Preserve useful voice and concrete mechanisms. Do not make every line clever; one strong opening and a clear progression are enough.
+10. For Arabic/bilingual output, use the `arabic` skill before finalizing rhythm, bidi, and truncation behavior.
 
-## Self-check before returning a caption
+## HOLD conditions
 
-Read every line. If a line reduces to "not X, but Y", delete it and write the positive
-statement. If a line contains a banned word, rewrite the line rather than swapping synonyms.
-If line 1 exceeds 60 characters, cut it.
+Return a HOLD when the requested hook, result, price, metric, testimonial, product claim, or CTA premise cannot be supported from the available evidence and cannot be rewritten truthfully without changing the approved idea.
+
+## Related components
+
+- routing authority: `helper/GUIDE.md`
+- local hook gate: `helper/quality-gates.json`
+- design-copy reference: `skills/info-stories/references/hook-driven-design-copy.md`
+- detailed patterns: `references/caption-patterns.md`
+- worker: `agents/caption-writer.md`
+- copy compression: `agents/copy-compressor.md`
+
+## Research gates
+
+Apply `prose-specificity` and `voice-preservation` to all visible prose. Apply `evidence-traceability` whenever the caption contains numbers, product behavior, proof, or other checkable factual claims.

--- a/skills/info-stories/SKILL.md
+++ b/skills/info-stories/SKILL.md
@@ -1,74 +1,74 @@
 ---
 name: info-stories
-description: Use when turning source material, a topic, a screenshot, an interface, or an approved caption into a structured LinkedIn infographic story and choosing its palette, visual grammar, narrative shape, or motion direction.
+description: Resolve the infographic story contract across Story House, Visual Style, Story Archetype, Motion Patterns, creative concept, UI story behavior, and evidence-safe design choices before HTML production.
 ---
 
 # Info-stories
 
-Info-stories resolves four independent choices before HTML is built: **Story House**, **Visual Style**, **Story Archetype**, and **Motion Pattern**. It is a composition layer over the existing artboard, motion, render, mascot, Arabic, and QA skills.
+## Purpose
 
-## Use the registry
+Turn source material into a structured infographic story before HTML is built. Info-stories sits above the existing artboard, caption, motion, mascot, Arabic, render, and QA skills and keeps composition decisions deterministic and inspectable.
 
-`catalog.json` contains the stable base registry. Optional first-party families live in `extensions/*.json`. `scripts/info_stories.py` merges them deterministically by extension filename and exposes one catalog to every agent and tool.
+Read `helper/GUIDE.md` first. The merged registry returned by `scripts/info_stories.py::load_catalog()` is authoritative.
 
-Validate the merged registry before a build:
+## Use when
+
+Use when choosing the narrative shape, visual grammar, Story House, motion behavior, UI mockup story, reference-informed direction, or deterministic story brief for a LinkedIn infographic.
+
+## Inputs
+
+- evidence-safe source material
+- selected `build/creative-concepts.json` direction when available
+- optional `build/design-study.json`
+- audience, takeaway, CTA, language, and output mode
+- explicit user choices for any registry axis
+- optional UI, brand, mascot, or reference constraints
+
+## Outputs
+
+Return or support creation of `build/story-brief.json` with Story House, Visual Style, Story Archetype, Motion Patterns, design dials, execution bridge, structural fingerprint inputs, and rationale for every resolved axis.
+
+## Procedure
+
+1. Validate the merged registry:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/info_stories.py check
 ```
 
-Inspect options with `list` and `show`. Use `scaffold` to emit a deterministic story brief after choices are resolved.
+2. Base options live in `catalog.json`; first-party extension families live in `extensions/*.json`. They are merged deterministically by filename.
+3. When a complete workflow is running, consume the selected concept from `creative-director` before resolving the story. Preserve its visual hook, copy hook, and aha mechanic unless evidence or compatibility gates require a change.
+4. Resolve Story Archetype from the narrative job using `references/story-archetypes.md`.
+5. Resolve Visual Style from information topology and density using `references/visual-styles.md`.
+6. Resolve Story House from tone, brand constraints, and contrast using `references/palette-houses.md`.
+7. Resolve Motion Patterns from what motion must communicate using `references/motion-patterns.md`.
+8. Check combinations against `references/composition-matrix.md` and the merged registry. Explicit user choices win unless they violate a hard compatibility, contrast, evidence, or render constraint.
+9. Apply `creative-attractive-restrained` as the palette character default and `center-first` as the composition default. Alignment exceptions require a real comprehension/fidelity reason.
+10. Apply `hooked-design-copy` and `creative-payoff`. Attention-bearing copy needs a real hook, and the story should contain a useful visual payoff or aha mechanism rather than a generic headline-plus-cards treatment.
+11. UI Mockup Stories are first-class. Use `UI Storyboard` or `Interface Cutaway` with `references/ui-mockup-rules.md`. Dedicated archetypes include `Screen to Outcome`, `Inside the Interface`, and `State Change Story`; dedicated motion includes `Cursor Focus` and `State Transition`.
+12. When visual references exist, `design-study` uses `references/study-protocol.md` to extract reusable design DNA without cloning distinctive work.
+13. A named official mascot uses the exact user-supplied/task-attached SVG and the mascot path; missing SVG holds that path.
 
-## Resolution order
+## HOLD conditions
 
-1. Story Archetype from the content's narrative job. Read `references/story-archetypes.md`.
-2. Visual Style from information topology and density. Read `references/visual-styles.md`.
-3. Story House from tone, brand constraints, and contrast. Read `references/palette-houses.md`.
-4. Motion Patterns from what motion must communicate. Read `references/motion-patterns.md`.
-5. Check the combination against `references/composition-matrix.md` and the merged registry.
+Return a HOLD when a requested registry choice is unknown or incompatible, contrast fails, UI evidence is insufficient for a real-product story, a creative payoff depends on unsupported facts, a named official mascot lacks its exact SVG, or a visual reference cannot be used without copying distinctive work.
 
-Explicit user choices win unless they violate a hard contrast, compatibility, evidence, or render constraint. Unknown choices fail with valid alternatives instead of silently substituting a default.
+Unknown choices should fail with valid alternatives rather than silently substituting a default.
 
-## UI Mockup Stories
+## Related components
 
-UI mockups are first-class story surfaces. Use `UI Storyboard` for a sequence of two to four screens/states and `Interface Cutaway` for one dominant interface with annotated internal regions. The dedicated archetypes are `Screen to Outcome`, `Inside the Interface`, and `State Change Story`.
+- routing authority: `helper/GUIDE.md`
+- local quality gates: `helper/quality-gates.json`
+- creative copy: `references/hook-driven-design-copy.md`
+- design defaults: `references/design-taste-gates.md`
+- UI mockups: `references/ui-mockup-rules.md`
+- reference study: `references/study-protocol.md`
+- verification: `references/verification-loop.md`
+- executable graph: `architecture/plugin-graph.json`
+- deterministic tools: `scripts/info_stories.py`, `tools/story_scaffold.py`, `tools/composition_check.py`, `tools/palette_preview.py`, `tools/contrast_check.py`, `tools/fingerprint_check.py`, `tools/copy_slop_check.py`
 
-Read `references/ui-mockup-rules.md`. A UI mockup may simplify a documented product flow or use clearly fictional concept data, but it must not invent real product claims, features, metrics, integrations, or customer proof. Core controls and labels must remain readable at feed width. `Cursor Focus` and `State Transition` are the dedicated restrained motion patterns.
+Capability owners include `creative-director`, `evidence-checker`, `story-architect`, `palette-curator`, `copy-compressor`, `layout-composer`, `caption-writer`, `artboard-builder`, `motion-director`, `mascot-animator`, `motion-engineer`, `render-qa`, `post-critic`, and `story-verifier` through the parent workflow.
 
-## Reference study
+## Research gates
 
-When the direction comes from screenshots, GIFs, previous designs, or a public reference, `design-study` owns design-DNA diagnosis using `references/study-protocol.md`. The diagnosis maps reusable principles into local choices and never grants permission to copy source wording or distinctive assets.
-
-## Capability ownership
-
-The parent workflow coordinates focused workers and passes artifacts between them. Workers do not assume hidden peer delegation.
-
-- `evidence-checker` owns claim provenance and blocked proof slots.
-- `story-architect` owns the four-axis story contract.
-- `palette-curator` owns Story House tokens and contrast verdicts.
-- `copy-compressor` owns slot-sized visible copy and anti-slop compression.
-- `layout-composer` owns information topology, design-taste gates, and structural fingerprints.
-- `caption-writer` owns caption archetype and caption-specific copy rules.
-- `artboard-builder` owns static execution of the approved layout.
-- `motion-director` owns motion intent and pattern selection.
-- `mascot-animator` owns exact-SVG mascot inspection, identity preservation, and the approved mascot motion component when the mascot path is active.
-- `motion-engineer` owns final seekable animation integration.
-- `render-qa` owns deterministic render evidence.
-- `post-critic` owns adversarial copy, visual, motion, and fingerprint review.
-- `story-verifier` owns evidence-backed final acceptance and the bounded repair loop.
-
-The executable graph is tracked in `architecture/plugin-graph.json` and checked by `scripts/plugin_graph.py`.
-
-## Hard constraints
-
-- Keep one 1080x1350 artboard and the existing attribution footer contract.
-- Text pairs declared by a Story House must meet 4.5:1 contrast.
-- Use at most two motion patterns; every motion needs a reading, hierarchy, sequence, or state reason.
-- Frame 0 remains a complete still.
-- Never invent metrics, testimonials, proof, product facts, or source claims.
-- A palette swap is not a new visual style. Structural choices must change when the story needs a different visual grammar.
-- A named official mascot uses the exact user-supplied SVG. Missing SVG means hold the mascot path, not substitute an asset.
-
-## Independent verification
-
-Before delivery, `story-verifier` uses `references/verification-loop.md`, reads artifacts directly, records evidence against stable criteria, and permits at most two targeted fix attempts before escalation.
+Use `design-dials`, `structural-originality`, and `contrast-discipline` for normal story composition. Add `reference-dna` when visual references are supplied, `evidence-traceability` for product/proof claims, `prose-specificity` and `voice-preservation` for visible copy, and `bounded-verification` before delivery.

--- a/skills/info-stories/references/design-taste-gates.md
+++ b/skills/info-stories/references/design-taste-gates.md
@@ -2,6 +2,15 @@
 
 Taste is checked against the story job, not against a generic website aesthetic. These gates are adapted for fixed 1080x1350 LinkedIn artboards.
 
+## Plugin-local visual defaults
+
+These defaults are local product choices, not claims imported from the research sources.
+
+- Palette character: `creative-attractive-restrained`. Prefer memorable, harmonious color combinations with a clear accent and enough personality to feel designed. Avoid exaggerated saturation, unnecessary neon, or multiple competing accents unless the brief explicitly requires them.
+- Composition alignment: `center-first`. Center the primary infographic content, visual anchor, and major story zones by default so the page reads as one deliberate composition rather than a loose document layout.
+- An alignment exception is allowed when the content structure requires it, including tables, UI mockups, code or terminal surfaces, timelines, Arabic/RTL reading flow, or a documented reference-DNA decision.
+- An exception must improve comprehension or fidelity, not merely introduce asymmetry for decoration.
+
 ## Pre-emit critique
 
 Score 1-5 before production on six axes: **Purpose, Hierarchy, Execution, Specificity, Restraint, Variety**. Any score below 3 sends the composition back for one targeted revision.
@@ -23,11 +32,13 @@ When a previous brief is supplied, change at least two structural axes. Changing
 
 - One visual anchor must dominate in two seconds at feed scale
 - Every zone has one reading job
+- Start center-first, then use a documented alignment exception only when the content benefits
 - Card count follows content count; do not create empty decorative cells
 - Repetition is allowed when it improves comparison, but the full page must not become one repeated card template
 - Shape choices follow a rule; mixed radii need an explicit role distinction
 - Section hues, supporting colours, and accent roles stay token-driven
 - No arbitrary colour values or type families appear halfway through a build
+- Keep palette character creative-attractive-restrained and avoid exaggerated saturation unless specifically briefed
 - A dense story earns density through hierarchy, not smaller text
 - Real screenshots stay real screenshots; a diagrammatic terminal must be labelled and styled as an illustration rather than presented as captured UI
 - Do not fabricate proof bars, metrics, logos, or testimonials because the selected style has a slot for them

--- a/skills/info-stories/references/hook-driven-design-copy.md
+++ b/skills/info-stories/references/hook-driven-design-copy.md
@@ -1,0 +1,50 @@
+# Hook-driven design copy
+
+Design copy carries attention and progression. It should not read like a neutral report when the slot is responsible for getting the reader into the story.
+
+## Hero headline
+
+The hero headline must earn attention with at least one real mechanism:
+
+- specificity: a concrete actor, mechanism, number, product, or constraint
+- useful tension: a real conflict or tradeoff already supported by the source
+- outcome: a concrete result the reader can understand
+- recognizable problem: language the intended reader would actually use
+- useful surprise: an unexpected relationship or sequence that the visual can prove
+- strong framing: a concise way to name the job, pattern, or decision
+
+A hero headline fails when it is portable: if the same sentence could move unchanged to another product, category, or infographic, it is probably generic.
+
+## Section openers
+
+Section openers may use micro-hooks when they create progression. They should tell the reader why the next block matters, what changes, what to notice, or what consequence follows.
+
+Do not force hooks into literal labels. Table headers, commands, UI controls, file names, product names, diagram node labels, and short badges stay literal when clarity is the job.
+
+## Evidence safety
+
+Do not invent stakes, urgency, scarcity, proof, metrics, product behavior, user quotes, social proof, or numbers to make a hook stronger. Every factual hook inherits the evidence requirements of the source material.
+
+Protect the user's specific facts and language. A strong factual phrase is not improved by replacing it with generic marketing vocabulary.
+
+## Visual hook and copy hook
+
+The strongest infographic openings usually pair one copy hook with one visual hook. Examples of useful visual hook mechanics include:
+
+- reveal the hidden relationship after the headline names the problem
+- contrast two states the source actually supports
+- show a transformation from raw input to finished output
+- expose the missing step in a process
+- turn a dense stack into one readable hierarchy
+- make a UI state change answer the headline
+- use a mascot gesture to point at the exact payoff without becoming decoration
+
+The hook must lead into the story. It cannot be disconnected bait.
+
+## Restraint
+
+One strong hook is better than every label trying to sound clever. Keep the rest of the page specific, direct, and easy to scan.
+
+## Gate
+
+`hooked-design-copy` is blocking for complete post creation and Info-story composition. The `creative-director`, `copy-compressor`, `caption-writer`, and `post-critic` own the gate at different stages.

--- a/skills/mascots/SKILL.md
+++ b/skills/mascots/SKILL.md
@@ -1,60 +1,47 @@
 ---
 name: mascots
-description: >-
-  Use when an infographic contains a mascot or character, especially when the user names an
-  official mascot, supplies an SVG, wants a mascot to guide reading order, or needs character
-  motion that stays inside the infographic motion budget.
+description: Use an exact supplied mascot SVG as a story element, choose a communication role and creative motion direction, preserve identity, and keep character motion inside the infographic budget.
 ---
 
-# Mascots for Infographics
+# Mascots for infographics
 
-A mascot is a communication element, not filler. It must have one clear job in the story and it must preserve the identity of the user's asset.
+## Purpose
 
-## Hard gate: exact official mascot
+Use a mascot as a communication element rather than decoration. The mascot should guide reading, reveal a state, confirm a payoff, or provide a small contextual reaction while preserving the exact identity of the supplied asset.
 
-When the user names a specific official mascot or says to use a mascot exactly:
+Read `helper/GUIDE.md` first. `mascot-identity` is a plugin-local capability and the exact-SVG asset gate is mandatory for named or official mascots.
 
-1. Require the exact SVG from the user unless it is already attached to the current task.
-2. Treat that SVG as the identity source.
-3. Never redraw, approximate, substitute, generate a lookalike, or silently use a different mascot.
-4. Preserve recognizable silhouette, colours, marks, face details, and proportions.
-5. If the SVG structure cannot support the requested articulation, explain the rig limitation and propose safe motion that still uses the original asset.
+## Use when
 
-The parent workflow owns this intake gate because the focused mascot worker should receive a validated asset, not ask the user for one itself.
+Use when the user names an official mascot, supplies a mascot SVG, asks for mascot motion, wants a character to guide reading order, or needs a mascot component inside an Info-story.
 
-Validate the request before planning motion:
+## Inputs
+
+- `build/mascot-request.json`
+- exact user-supplied or task-attached SVG for named/official mascots
+- approved still/layout zone
+- selected creative concept and mascot communication job
+- motion direction and output track
+
+## Outputs
+
+Return validated mascot role, chosen creative direction, inspection/identity notes, motion budget, rig constraints, and a mascot motion contract for downstream motion/render verification.
+
+## Procedure
+
+1. For a named or official mascot, require the **exact SVG** before any production. Treat it as the identity source. Never redraw, approximate, substitute, generate a lookalike, or silently use a different mascot.
+2. If the exact SVG is missing, return `HOLD: exact SVG required`. In the main conversational context, ask the user to upload the SVG; inside a worker, return the HOLD to the parent workflow.
+3. Validate the request:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mascot_contract.py check build/mascot-request.json
 ```
 
-## Roles
-
-| Role | Count | Motion budget | Job |
-|---|---:|---:|---|
-| Pointer | exactly 1 | route travel | carries reading order |
-| Payoff | 0 or 1 | one short reaction | confirms the final state |
-| Idle | 0 to 6 | 3px target, 4px cap | quiet presence in a panel/footer |
-
-A mascot pointer replaces an abstract pointer. Do not create two simultaneous reading orders.
-
-## Creative direction
-
-Read `skills/svg-mascot-animator/references/creative-directions.md`. Good starting directions include Guide the Eye, Curious Peek, Inspect and React, Carry and Place, Reveal Assistant, Status Confirmation, Route Follow, Card-to-Card Handoff, Calm Idle Breathing, and Contextual Micro-Reaction.
-
-A direction is valid only when it states:
-
-- what the motion communicates
-- which existing mascot parts may move
-- which support elements may be added outside the mascot
-- how the loop resets
-- what competing primitive it replaces
-
-## Seek-safe infographic motion
-
-Use one artboard clock. Frame 0 stays complete. Motion in the outer 48px margin is prohibited. Use baked CSS/SMIL/seekable motion for deterministic frame capture. Do not use runtime `requestAnimationFrame` animation in a rendered LinkedIn GIF.
-
-Generate physics/timing rather than nudging arbitrary keyframes:
+4. Pick one communication role. Pointer carries reading order, Payoff confirms the final state, and Idle provides quiet presence. A mascot pointer replaces another pointer primitive rather than adding a competing route.
+5. Read `skills/svg-mascot-animator/references/creative-directions.md`. Adapt a direction such as Guide the Eye, Curious Peek, Inspect and React, Carry and Place, Reveal Assistant, Status Confirmation, Route Follow, Card-to-Card Handoff, Calm Idle Breathing, or Contextual Micro-Reaction.
+6. The direction must state what the motion communicates, which existing SVG parts may move, which support elements may be added outside the identity, how the loop resets, and what competing primitive it replaces.
+7. Preserve frame 0, the outer 48px safe zone, one artboard clock, and deterministic seekable timing for rendered infographic output.
+8. Generate timing/physics from the existing tools rather than hand-nudging arbitrary keyframes:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py budget --mascot 64 --travel 1 --idles 4
@@ -63,22 +50,23 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py idle --loop 6000 --id amb -
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/bake_mascot.py payoff --loop 6000 --id win --at .89 --rise 18 --zeta .30
 ```
 
-Never hand-edit baked timing output. Change the parameters and regenerate.
+9. UI mockup stories may use a mascot only when it does not cover story-critical controls or imply a product assistant that does not actually exist.
+10. Verify identity, purpose, frame-zero readability, loop reset, motion budget, and accessibility before returning the component.
 
-## Structural fit
+## HOLD conditions
 
-Mascots work best in route, process, annotated, and state-change stories. Dense catalogs and reference sheets usually need no moving character. UI Mockup Stories may use a mascot as a guide, assistant, or state reaction only if it does not cover core controls or imitate a product assistant that does not actually exist.
+Return a HOLD when the exact SVG is missing, the SVG cannot support the requested articulation without identity-changing redraw, required brand details are ambiguous, or the requested mascot behavior would fabricate product behavior or compete with the approved reading order.
 
-## Verification
+## Related components
 
-Before shipment confirm:
+- routing authority: `helper/GUIDE.md`
+- exact-SVG worker: `agents/mascot-animator.md`
+- animator skill: `skills/svg-mascot-animator/SKILL.md`
+- creative directions: `skills/svg-mascot-animator/references/creative-directions.md`
+- detailed doctrine: `references/mascots.md`
+- request validator: `scripts/mascot_contract.py`
+- motion baker: `scripts/bake_mascot.py`
 
-- the exact supplied SVG remains recognizably unchanged
-- the role is singular and clear
-- the selected creative direction has a story purpose
-- frame 0 is complete
-- the motion budget is respected
-- the mascot does not compete with UI, copy, or route highlights
-- reduced-motion and accessibility requirements from the SVG animator contract are satisfied
+## Research gates
 
-Full infographic mascot doctrine and failure modes remain in `references/mascots.md`.
+Mascot identity itself is local-native and has no upstream provenance requirement. When the mascot is embedded in a complete Info-story, still respect active `design-dials`, `structural-originality`, `evidence-traceability`, and `bounded-verification` gates from the parent route.

--- a/skills/motion/SKILL.md
+++ b/skills/motion/SKILL.md
@@ -1,65 +1,67 @@
 ---
 name: motion
-description: >-
-  Write the animation for a 1080x1350 artboard so it loops seamlessly and captures
-  deterministically. Use when adding motion to an infographic, writing keyframes, staggering a
-  sequence, animating a path, diagnosing a visible loop point, or fixing a GIF that came back
-  oversized, blank, or jittery. Covers ten seekable motion primitives, the one-loop-clock rule,
-  the reverse-delay trap, motion budgeting by changed pixels, and a symptom-to-cause debugging
-  table.
+description: Design and implement deterministic seekable infographic motion that communicates reading order, state, reveal, hierarchy, or route direction while preserving a complete first frame and clean loop.
 ---
 
 # Motion
 
-Animations are **seeked**, not recorded. `capture_frames.py` pauses
-`document.getAnimations()`, sets `currentTime` per frame, and calls `svg.setCurrentTime()` for
-SMIL. That gives pixel-identical frames and a mathematically exact loop close. Real-time screen
-recording produces the wobble that reads as amateur.
+## Purpose
 
-## Three rules that decide whether it works
+Add meaning-driven motion to an already approved still. Motion should clarify sequence, hierarchy, route, state change, reveal, or the selected creative payoff. It is not a substitute for weak structure.
 
-**One loop clock.** Define `--loop` once and derive everything from it. A sub-animation that
-genuinely needs to be faster gets an integer division: `calc(var(--loop) / 4)`. Never `1.3s`
-next to `4.8s`. Legal divisors: 1, 2, 3, 4, 5, 6, 8, 10, 12.
+Read `helper/GUIDE.md` first. Rendered infographic animation is seeked frame-by-frame, not screen-recorded in real time.
 
-**Frame 0 equals frame N.** The value at `0%` and `100%` must be identical.
-`build_gif.py` prints the seam delta; anything larger than the biggest normal frame-to-frame
-change means something does not close.
+## Use when
 
-**Motion budget is changed pixels, not area.** A dense dark grid animating 85% of its canvas
-can encode cheaper than four boxes and four dots on a light textured ground. Judge on
-`build_gif.py`'s `motion:` line. Under 2% is healthy. Never animate `filter: blur()`, large
-`box-shadow` spread, or `backdrop-filter`: they rewrite every pixel underneath and defeat
-rectangle diffing.
+Use when choosing or implementing Motion Patterns, writing keyframes, animating routes or state changes, integrating mascot motion, debugging a loop, or diagnosing an oversized/jittery GIF caused by animation behavior.
 
-## The primitives
+## Inputs
 
-Sequential Highlight, Path Particles, Path Draw-On, Orbit, Staggered Reveal, Bar Growth,
-Typewriter, Glow Pulse, Ambient Micro-Loops, and Mascot Pointer.
+- approved `build/still.png` and `build/post.html`
+- selected creative concept and aha mechanic when present
+- `build/story-brief.json`
+- `build/layout-spec.json`
+- `build/motion-direction.json` when produced by the motion director
+- optional mascot motion contract
+- target duration/fps from verified timing options
 
-**Use exactly two per artboard.** That is what the reference set does and it is the right
-number. A mascot does not add a third: Mascot Pointer replaces Path Particles, and the
-highlight it drives is still Sequential Highlight.
+## Outputs
 
-`references/animation-recipes.md` has the code for each, the composition table pairing
-primitives to archetypes, the timing table of loop/fps combinations verified to close, and the
-symptom-to-cause debugging table. Read it before writing any animation CSS.
+Return or support the animated `build/post.html`, resolved Motion Patterns, timing rationale, loop/motion-budget notes, and any HOLD that prevents deterministic capture.
 
-## The trap that costs the most renders
+## Procedure
 
-A negative `animation-delay` pushes an animation **forward** in its cycle. To have element `i`
-of `N` active at `t = (i-1) x loop / N`, the delays run in **reverse**:
-`0, -loop x 3/4, -loop x 2/4, -loop x 1/4` for four elements. Writing the intuitive
-`0, -1/4, -2/4, -3/4` produces the order 1 → 4 → 3 → 2, which looks almost right in a thumbnail
-and is obviously wrong once anyone watches it.
-
-Verify by capturing four frames at `t = 0, loop/4, loop/2, 3xloop/4` and checking the order.
-
-## Render
+1. Read `references/animation-recipes.md` and active helper gates.
+2. Use one loop clock. Define `--loop` once and derive sub-animation durations with integer divisions. Do not mix arbitrary unrelated durations.
+3. Frame 0 must be a complete readable still and the animation state at 0% and 100% must close.
+4. Use at most two meaning-driven motion patterns for the infographic. A Mascot Pointer replaces another pointer primitive rather than adding a third competing route.
+5. Available primitives include Sequential Highlight, Path Particles, Path Draw-On, Orbit, Staggered Reveal, Bar Growth, Typewriter, Glow Pulse, Ambient Micro-Loops, and Mascot Pointer.
+6. Tie motion to the selected concept's useful payoff. A reveal, state transition, route, or comparison can support `creative-payoff`; decorative movement that does not change understanding should stay static.
+7. Keep changed pixels under control. Large blur, backdrop-filter, large shadow spread, and full-canvas decorative motion are poor choices for GIF encoding.
+8. Respect the reverse-delay rule for sequential animation. Verify order by capturing quarter-cycle frames instead of trusting intuition.
+9. Keep the outer 48px safe zone static and preserve reduced-motion behavior where the delivery context supports it.
+10. Render with verified timing rows:
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/render.sh build/post.html build/post.gif --duration 6.0 --fps 12.5
 ```
 
-Pick duration and fps from the timing table rather than inventing numbers. Each verified row
-divides cleanly and closes.
+11. Read seam and changed-pixel evidence before approving the motion.
+
+## HOLD conditions
+
+Return a HOLD when the still is not approved, frame 0 is incomplete, the loop cannot close deterministically, motion contradicts the approved reading order, the requested effect exceeds the motion budget, or a mascot path lacks a validated exact-SVG component.
+
+## Related components
+
+- routing authority: `helper/GUIDE.md`
+- local quality gates: `helper/quality-gates.json`
+- motion recipes: `references/animation-recipes.md`
+- motion planner: `agents/motion-director.md`
+- implementation worker: `agents/motion-engineer.md`
+- mascot skill: `skills/mascots/SKILL.md`
+- render skill: `skills/render/SKILL.md`
+
+## Research gates
+
+Apply `design-dials` when resolving motion intensity and `bounded-verification` when the animated result reaches render/acceptance. `structural-originality` remains relevant when motion behavior is part of the story fingerprint.

--- a/skills/new-post/SKILL.md
+++ b/skills/new-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-post
-description: Run the full post pipeline end to end, from topic to a delivered GIF or static infographic plus caption and first comment.
+description: Run the complete evidence-to-delivery workflow for a static or animated LinkedIn infographic, including creative concepting, story architecture, production, critique, and independent verification.
 disable-model-invocation: true
 argument-hint: "[topic or URL] [optional: --arabic] [optional: --mascot]"
 ---
@@ -9,85 +9,163 @@ argument-hint: "[topic or URL] [optional: --arabic] [optional: --mascot]"
 
 Topic: **$ARGUMENTS**
 
-The parent workflow owns orchestration. Workers return artifacts to this workflow; do not ask one worker to coordinate its peers.
+## Purpose
 
-## 0. Mascot asset gate
+Run the canonical parent workflow for a complete LinkedIn infographic. The workflow owns routing, user approvals, HOLD resolution, targeted repair loops, and final delivery. Workers return bounded artifacts here and never coordinate peer workers directly.
 
-If `--mascot` is present or the user names a specific mascot, identify whether the request refers to an official or exact character. For a named or official mascot, require the **exact SVG** from the user unless that SVG is already task-attached. Do not redraw, approximate, substitute, or generate a lookalike. If the exact SVG is missing, ask the user to attach it and stop the mascot path until it is available.
+Read `helper/GUIDE.md` before execution. Treat `helper/router.json`, `helper/capabilities.json`, `helper/quality-gates.json`, `helper/artifacts.json`, `research/capability-notes/gates.json`, and `architecture/plugin-graph.json` as machine-readable contracts.
 
-Record `build/mascot-request.json` with requested name, SVG path, source classification (`user-supplied` or `task-attached`), and `allow_substitute: false`. Validate it with `scripts/mascot_contract.py check` before continuing any mascot planning.
+## Use when
 
-## 1. Reference diagnosis
+Use this workflow when the user wants a complete new infographic or a substantial redesign that should proceed from source/evidence through concept, copy, artboard, optional motion, QA, and delivery.
 
-If the user supplied screenshots, GIFs, previous designs, or visual references, delegate to `design-study` and save the structured result as `build/design-study.json`. If there is no visual reference, record that this stage is not applicable and continue.
+Use focused skills instead when the request is only a render, only QA, only mascot animation, or only a design study.
 
-## 2. Evidence inventory
+## Inputs
 
-Delegate to `evidence-checker` with the source material and all claims, numbers, product names, proof slots, and logos likely to appear. Save `build/evidence.json`. Unsupported proof is blocked before copy or layout work begins. A source with no external factual claims still gets a short evidence record saying so.
+- topic, source material, URL, files, or user-provided facts
+- intended audience and one primary takeaway when they cannot be inferred safely
+- desired CTA when applicable
+- language and static/animated output preference
+- optional visual references
+- optional brand/UI assets
+- exact SVG when a named or official mascot is requested
 
-## 3. Story contract
+## Outputs
 
-Delegate to `story-architect` with the topic, one takeaway, CTA, language, output mode, `build/design-study.json` when present, and `build/evidence.json`. Save the deterministic result as `build/story-brief.json`.
+The parent workflow may produce:
 
-State the four Info-stories choices and one reason per choice. If the user explicitly chose an axis, preserve it unless a hard compatibility or contrast rule fails.
+- `build/design-study.json`
+- `build/evidence.json`
+- `build/creative-concepts.json`
+- `build/story-brief.json`
+- `build/palette-check.json`
+- `build/artboard-copy.json`
+- `build/layout-spec.json`
+- `build/caption.md`
+- `build/first-comment.md`
+- `build/post.html`
+- `build/still.png`
+- `build/motion-direction.json` for animated output
+- `build/mascot/motion-contract.json` when a mascot is active
+- `build/render-report.json`
+- `build/critic-report.json`
+- `build/verification-report.json`
+- final static/GIF artifact plus resolved story and validation summary
 
-## 4. Palette contract
+## Procedure
 
-Delegate to `palette-curator` with `build/story-brief.json` and any brand colours. Save the complete verified token block and contrast result as `build/palette-check.json`. A failing text or state pair holds the build.
+### 0. Route and asset gates
 
-## 5. Artboard copy
+Resolve the request through the helper. Apply local quality gates and research gates before production.
 
-Delegate to `copy-compressor` with the source, evidence record, Story Archetype, and target story beats. Save slot-keyed copy and protected facts as `build/artboard-copy.json`. Keep intentional short labels; remove generic filler and unsupported claims.
+If the user names a specific or official mascot, require the exact user-supplied or task-attached SVG. Record `build/mascot-request.json` and validate it with `scripts/mascot_contract.py check`. Never redraw, approximate, substitute, or silently generate a lookalike.
 
-## 6. Static layout specification
+If Arabic/RTL is active, load the `arabic` skill before copy or layout work.
 
-Delegate to `layout-composer` with the story brief, palette check, artboard copy, optional design study, and mascot placement requirement when present. Save `build/layout-spec.json`, including zone order, visual anchor, hierarchy, structural fingerprint, and asset requirements.
+### 1. Reference diagnosis
 
-## 7. Caption
+When visual references exist, delegate to `design-study` and save `build/design-study.json`. Activate `reference-dna`. Study reusable structure, hierarchy, rhythm, density, and motion grammar without cloning distinctive work.
 
-Delegate to `caption-writer` with the approved facts, one takeaway, CTA, and narrative context. Save the caption as `build/caption.md` and first-comment text as `build/first-comment.md`.
+### 2. Evidence inventory
 
-Show the caption and the resolved story direction. Get approval before building the still.
+Delegate to `evidence-checker`. Save `build/evidence.json` with protected claims, metrics, product states, logos, proof, and unsupported slots. Unsupported proof is blocked before creative/copy/layout production.
 
-## 8. Still construction
+### 3. Creative concept directions
 
-Delegate to `artboard-builder` with `build/story-brief.json`, `build/palette-check.json`, `build/artboard-copy.json`, `build/layout-spec.json`, and the approved caption. It returns `build/post.html` and `build/still.png` after static checks.
+Delegate to `creative-director` with the evidence record, optional design study, audience, language, output mode, and approved constraints. Save `build/creative-concepts.json`.
 
-Show the still. This is the visual approval gate. Get approval before motion.
+Require at least three meaningfully different directions. Every direction contains a visual hook, copy hook, aha mechanic, story shape, recommended style/archetype/motion behavior, evidence dependencies, risk notes, and why it earns attention. At least one direction must contain a useful visual payoff or aha moment through a reveal, relationship, comparison, transformation, state change, or interaction. Spectacle without a story job does not count.
 
-## 9. Motion direction
+Apply `hooked-design-copy` and `creative-payoff`. The parent workflow selects or approves one direction before story architecture.
 
-For animated output, delegate to `motion-director` with the approved still, layout spec, story brief, and mascot role when applicable. Save `build/motion-direction.json`. Static output records this stage as skipped.
+### 4. Story contract
 
-## 10. Mascot animation component
+Delegate to `story-architect` with the selected concept, evidence, optional design study, one takeaway, CTA, language, and output mode. Save `build/story-brief.json` with Story House, Visual Style, Story Archetype, Motion Patterns, design dials, and execution bridge.
 
-When the mascot path is active, delegate to `mascot-animator` with the validated exact SVG request, approved still, layout spec, selected mascot role, and motion direction. Save its inspection and identity-preservation evidence under `build/mascot/` and pass the resulting motion contract forward. The supplied SVG remains the identity source and must not be replaced.
+### 5. Palette contract
 
-## 11. Motion implementation
+Delegate to `palette-curator`. Save `build/palette-check.json`.
 
-For animated output, delegate to `motion-engineer` with the approved still, story brief, motion-direction artifact, and validated mascot component when present. It returns the animated `build/post.html`. Static output skips this stage.
+The plugin default is `creative-attractive-restrained`: use an engaging, memorable, harmonious palette without exaggerated saturation, unnecessary neon, or competing accents unless the approved brief explicitly calls for them. Text/state contrast floors remain blocking.
 
-## 12. Render mechanics and gates
+### 6. Artboard copy
 
-Delegate to `render-qa`. Save its gate-by-gate evidence as `build/render-report.json`. A `HOLD` returns control to this parent workflow for a targeted fix and re-run.
+Delegate to `copy-compressor` with evidence, selected concept, story brief, and target slots. Save `build/artboard-copy.json`. The hero and attention-bearing story openers must use evidence-safe hooks; literal labels remain literal where clarity wins.
 
-## 13. Adversarial review
+### 7. Static layout specification
 
-Delegate to `post-critic` with the rendered artifact, caption, evidence record, structural fingerprint, mascot identity notes when present, and render report. Save `build/critic-report.json`. Resolve every must-fix item or record why it is not applicable before independent verification.
+Delegate to `layout-composer`. Save `build/layout-spec.json` with zone order, proportions, visual anchor, component counts, structural fingerprint, assets, alignment mode, and any exception reason.
 
-## 14. Independent acceptance
+Use `center-first` for the primary visual anchor and major story zones. A non-centered alignment requires a recorded comprehension/fidelity reason such as tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or reference-DNA fidelity.
 
-Delegate to `story-verifier` with the artifact paths, story brief, evidence record, render report, critic report, and explicit acceptance criteria. Save `build/verification-report.json`. `FAIL:fixable` may trigger a targeted fix and re-check. Maximum two targeted fix attempts; a third unresolved failure escalates.
+### 8. Caption
 
-## 15. Deliver
+Delegate to `caption-writer`. Save `build/caption.md` and `build/first-comment.md`. The opening hook must be specific and evidence-safe. Show the caption and selected story direction for approval before still construction when interactive approval is available.
 
-Deliver, in this order:
+### 9. Still construction
 
-1. GIF or static artifact
-2. caption
-3. first-comment text
-4. resolved Story House, Visual Style, Story Archetype, and Motion Patterns
-5. render numbers when applicable
-6. final verification verdict
+Delegate to `artboard-builder` with the approved story, palette, copy, layout, and caption artifacts. It returns `build/post.html` and `build/still.png` after static checks. Show the still as the visual approval gate when interaction is available.
 
-If `--arabic` is present, apply `linkedin-animated-infographics:arabic` before copy/layout production.
+### 10. Motion direction
+
+For animated output, delegate to `motion-director` with the approved still, selected concept, story brief, layout spec, and mascot role when applicable. Save `build/motion-direction.json`. Static output records this stage as skipped.
+
+### 11. Mascot component when active
+
+After still construction and before motion implementation, delegate the validated exact SVG to `mascot-animator`. Save identity and rig evidence plus `build/mascot/motion-contract.json`. The supplied SVG remains the identity source.
+
+### 12. Motion implementation
+
+For animated output, delegate to `motion-engineer` with the approved still, story brief, motion direction, and mascot contract when present. It returns the animated `build/post.html`. Static output skips this stage.
+
+### 13. Render mechanics and QA
+
+Delegate to `render-qa`. Save `build/render-report.json`. A render HOLD returns control to this parent workflow for a targeted fix and re-run.
+
+### 14. Adversarial review
+
+Delegate to `post-critic` with the artifact, caption, evidence, selected concept, layout, mascot identity notes when present, and render report. Save `build/critic-report.json`.
+
+The critic must explicitly evaluate `hooked-design-copy`, `creative-payoff`, `restrained-palette`, and `center-first-composition` in addition to applicable research gates.
+
+### 15. Independent acceptance
+
+Delegate to `story-verifier`. Save `build/verification-report.json`. The verifier reads artifacts directly. `FAIL:fixable` may trigger a targeted fix and re-check. Maximum two targeted repair attempts; a third unresolved failure escalates.
+
+### 16. Deliver
+
+Deliver the final artifact, caption, first comment, resolved Info-stories choices, selected creative concept, render numbers when applicable, active gate summary, and final verification verdict.
+
+## HOLD conditions
+
+Stop and return a precise HOLD when any blocking requirement is unresolved, including:
+
+- missing exact SVG for a named or official mascot
+- unsupported factual proof, metric, product state, logo, or claim
+- hook or aha concept that depends on invented evidence
+- failing contrast or Story House compatibility
+- unresolved blocking local quality gate
+- unresolved blocking research gate
+- render evidence unavailable when required
+- third unresolved verification failure after two targeted repair attempts
+
+Do not fill missing inputs with plausible content.
+
+## Related components
+
+- helper: `helper/GUIDE.md`
+- router: `helper/router.json`
+- local gates: `helper/quality-gates.json`
+- artifacts: `helper/artifacts.json`
+- executable graph: `architecture/plugin-graph.json`
+- creative copy reference: `skills/info-stories/references/hook-driven-design-copy.md`
+- design defaults: `skills/info-stories/references/design-taste-gates.md`
+- focused QA: `qa-post`
+- focused render: `render-gif`
+
+## Research gates
+
+Complete post creation may activate `prose-specificity`, `voice-preservation`, `design-dials`, `structural-originality`, `reference-dna`, `contrast-discipline`, `evidence-traceability`, and `bounded-verification` according to `research/capability-notes/gates.json`.
+
+The two final safety gates are `evidence-traceability` and `bounded-verification`; they remain active even when the chosen creative direction is intentionally simple.

--- a/skills/post/SKILL.md
+++ b/skills/post/SKILL.md
@@ -1,77 +1,66 @@
 ---
 name: post
-description: >-
-  Router for building a LinkedIn post as a caption plus a 1080x1350 static or looping
-  infographic. Use when the user wants a LinkedIn post, animated infographic, GIF, system map,
-  stack map, workflow diagram, cheat sheet, or wants source material turned into a LinkedIn
-  visual. Start here even when the immediate ask is only a hook, visual direction, or motion.
+description: Route LinkedIn infographic requests to the correct complete or focused workflow using the repository helper, capability gates, creative defaults, and artifact contracts.
 ---
 
 # LinkedIn Animated Infographics
 
-The core format is a complete static infographic with a small, deliberate motion footprint when animation adds meaning. Motion acts as a reading, route, hierarchy, or state signal. It does not compensate for weak information architecture.
+## Purpose
 
-## Pipeline
+Act as the lightweight **routing entrypoint** for the plugin. Do not duplicate the complete workflow here. Read `helper/GUIDE.md`, classify the request, inspect the route, then invoke the correct workflow or focused skill.
 
-```text
-topic -> Info-stories brief -> caption -> still -> motion -> render -> independent QA -> publish
-```
+## Use when
 
-Load only the skill needed for the current stage.
+Start here for a LinkedIn infographic, post, GIF, cheat sheet, workflow visual, stack map, UI story, design direction, hook, mascot request, render request, or QA request when the correct specialist path is not already explicit.
 
-| Stage | Skill | Job |
-|---|---|---|
-| Composition | `linkedin-animated-infographics:info-stories` | resolve Story Archetype, Visual Style, Story House, Motion Patterns, and design dials |
-| Caption | `linkedin-animated-infographics:caption` | write or edit the caption and enforce copy rules |
-| Layout | `linkedin-animated-infographics:artboard` | execute the approved static composition |
-| Motion | `linkedin-animated-infographics:motion` | implement seekable animation and loop rules |
-| Mascots | `linkedin-animated-infographics:mascots` | add an optional character within the motion budget |
-| Render | `linkedin-animated-infographics:render` | capture frames, assemble the GIF, and run render gates |
-| Arabic | `linkedin-animated-infographics:arabic` | apply Arabic and bilingual layout behavior |
+## Inputs
 
-Three workflow skills run common end-to-end tasks: `linkedin-animated-infographics:new-post`, `linkedin-animated-infographics:render-gif`, and `linkedin-animated-infographics:qa-post`.
+- user request and source material
+- optional intent override
+- language/output mode
+- optional visual references, UI mockup flag, brand assets, or mascot requirement
 
-## Agents
+## Outputs
 
-| Agent | Give it |
-|---|---|
-| `design-study` | supplied visual references when their design DNA should inform a new direction |
-| `story-architect` | topic, takeaway, CTA, explicit choices, and optional study report |
-| `copy-compressor` | source material and target story slots when the artboard copy is too dense |
-| `evidence-checker` | claims, names, metrics, and proof that must survive into the visual |
-| `layout-composer` | approved story brief and compressed content blocks |
-| `artboard-builder` | approved static layout spec and story brief |
-| `motion-director` | approved still and story brief when output is animated |
-| `motion-engineer` | approved still plus resolved Motion Patterns |
-| `render-qa` | built artboard for render diagnostics |
-| `story-verifier` | final artifact plus acceptance criteria and direct evidence |
+Return a resolved route containing workflow, skills, agents, capabilities, asset gates, research gates, and local quality gates. For creation requests, hand control to the `new-post` parent workflow.
 
-## Non-negotiables
+## Procedure
 
-1. Exactly one `#artboard` element at `width:1080px; height:1350px`.
-2. All animation is seekable CSS, WAAPI, or SMIL, shares one `--loop` or an integer division, and keeps frame 0 complete.
-3. Fonts are system-safe or base64-embedded. Never `@import` a network font.
-4. When Info-stories is active, colour comes from the resolved **Story House** token block. Do not silently replace it with House 0 or invent one-off colours. Legacy posts without a story brief may keep the existing House 0 default.
-5. Declared text pairs meet 4.5:1 contrast and declared state pairs meet 3:1.
-6. Nothing moves in the outer 48px margin.
-7. A mascot replaces another pointer primitive rather than becoming a third competing motion.
-8. No fabricated metrics, proof, testimonials, product facts, or source claims.
-
-## Working method
-
-1. Ask only what cannot be inferred: the one takeaway and CTA.
-2. If references are supplied, study them before choosing a direction.
-3. Resolve and approve the Info-stories brief before production.
-4. Write the caption and compress artboard copy without weakening facts.
-5. Build and approve the still before motion.
-6. Add zero to two meaning-driven Motion Patterns.
-7. Render, run existing QA, then run independent story verification.
-8. Deliver the artifact, caption, first comment, resolved four-axis selection, and render numbers when applicable.
-
-## Setup
+1. Read `helper/GUIDE.md`.
+2. Resolve the request through the deterministic helper when structured routing is useful:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh
+python3 ${CLAUDE_PLUGIN_ROOT}/tools/route_request.py --request "<request>"
 ```
 
-The registry and validation tools run on plain Python 3. Browser rendering additionally needs the Playwright browser and its operating-system libraries.
+3. Use the route intent:
+   - `create-post` → `new-post`
+   - `qa` → `qa-post`
+   - `render` → `render-gif`
+   - `design-study` → focused `design-study` worker/Info-stories references
+   - `mascot-animation` → `mascots` + `svg-mascot-animator`
+   - `info-story` → focused Info-stories composition path
+4. Apply conditional gates before production: Arabic/RTL, UI fidelity, visual-reference diagnosis, and exact official mascot SVG.
+5. For complete creation, require the `creative-director` concept stage before `story-architect`. The concept should provide evidence-safe visual/copy hooks and a useful aha mechanic rather than a generic topic restatement.
+6. Keep plugin-local defaults active: `creative-attractive-restrained` palettes and `center-first` composition with documented exceptions.
+7. Do not silently bypass `post-critic` or `story-verifier` on complete shipping paths.
+
+## HOLD conditions
+
+Return a HOLD when the helper reports a blocking asset or gate, especially a missing exact mascot SVG, unsupported evidence, incompatible Story House/Style choice, or a render/verification blocker. Do not invent a route around a blocking gate.
+
+## Related components
+
+- routing authority: `helper/GUIDE.md`
+- router registry: `helper/router.json`
+- capability registry: `helper/capabilities.json`
+- local quality gates: `helper/quality-gates.json`
+- artifact contracts: `helper/artifacts.json`
+- research gates: `research/capability-notes/gates.json`
+- complete workflow: `skills/new-post/SKILL.md`
+- focused QA: `skills/qa-post/SKILL.md`
+- focused render: `skills/render-gif/SKILL.md`
+
+## Research gates
+
+The post router does not reinterpret research rules. It passes through the gate IDs returned by the helper, including `prose-specificity`, `voice-preservation`, `design-dials`, `structural-originality`, `reference-dna`, `contrast-discipline`, `evidence-traceability`, and `bounded-verification` where applicable.

--- a/skills/post/SKILL.md
+++ b/skills/post/SKILL.md
@@ -39,11 +39,12 @@ python3 ${CLAUDE_PLUGIN_ROOT}/tools/route_request.py --request "<request>"
    - `render` → `render-gif`
    - `design-study` → focused `design-study` worker/Info-stories references
    - `mascot-animation` → `mascots` + `svg-mascot-animator`
-   - `info-story` → focused Info-stories composition path
-4. Apply conditional gates before production: Arabic/RTL, UI fidelity, visual-reference diagnosis, and exact official mascot SVG.
-5. For complete creation, require the `creative-director` concept stage before `story-architect`. The concept should provide evidence-safe visual/copy hooks and a useful aha mechanic rather than a generic topic restatement.
-6. Keep plugin-local defaults active: `creative-attractive-restrained` palettes and `center-first` composition with documented exceptions.
-7. Do not silently bypass `post-critic` or `story-verifier` on complete shipping paths.
+   - `info-story` → focused `linkedin-animated-infographics:info-stories` composition path
+4. When Info-stories is active, the resolved Story House from the merged registry is authoritative. Do not silently replace it with legacy House 0; House 0 is only a legacy fallback when there is no resolved story brief.
+5. Apply conditional gates before production: Arabic/RTL, UI fidelity, visual-reference diagnosis, and exact official mascot SVG.
+6. For complete creation, require the `creative-director` concept stage before `story-architect`. The concept should provide evidence-safe visual/copy hooks and a useful aha mechanic rather than a generic topic restatement.
+7. Keep plugin-local defaults active: `creative-attractive-restrained` palettes and `center-first` composition with documented exceptions.
+8. Do not silently bypass `post-critic` or `story-verifier` on complete shipping paths.
 
 ## HOLD conditions
 
@@ -57,6 +58,7 @@ Return a HOLD when the helper reports a blocking asset or gate, especially a mis
 - local quality gates: `helper/quality-gates.json`
 - artifact contracts: `helper/artifacts.json`
 - research gates: `research/capability-notes/gates.json`
+- Info-stories skill: `linkedin-animated-infographics:info-stories`
 - complete workflow: `skills/new-post/SKILL.md`
 - focused QA: `skills/qa-post/SKILL.md`
 - focused render: `skills/render-gif/SKILL.md`

--- a/skills/qa-post/SKILL.md
+++ b/skills/qa-post/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qa-post
-description: Run every quality gate against a built post before it ships, red-team the post, and independently verify acceptance evidence.
+description: Run deterministic render checks, local creative gates, adversarial critique, and independent evidence-backed acceptance against a built infographic before shipment.
 disable-model-invocation: true
 argument-hint: "[path/to/artboard.html] [optional: path/to/caption.md]"
 ---
@@ -9,9 +9,31 @@ argument-hint: "[path/to/artboard.html] [optional: path/to/caption.md]"
 
 Arguments: **$ARGUMENTS**
 
-This workflow reports evidence. It does not silently edit the artifact.
+## Purpose
 
-## 1. Deterministic render gates
+Act as the focused **parent workflow** for QA. Report evidence and route targeted fixes; do not silently edit the artifact or let the producing worker grade its own result.
+
+Read `helper/GUIDE.md` before checking the artifact.
+
+## Use when
+
+Use for a finished or nearly finished artboard/GIF that needs shipping acceptance, regression review, visual/caption red-teaming, or verification after a targeted fix.
+
+## Inputs
+
+- artboard HTML and rendered static/GIF evidence
+- optional caption and first comment
+- story brief, selected creative concept, evidence table, and layout spec when available
+- optional mascot identity/motion contract
+- explicit acceptance criteria when supplied
+
+## Outputs
+
+Return `build/render-report.json`, `build/critic-report.json`, `build/verification-report.json`, and one final verdict: `SHIP` or `HOLD: <the one thing to fix first>`.
+
+## Procedure
+
+1. Run deterministic render checks:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py <path> --out /tmp/qa-still.png
@@ -19,20 +41,27 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/check_render.py <path> --mobile
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/lint_artboard.sh <path>
 ```
 
-Walk `linkedin-animated-infographics:render` and `references/qa-gates.md` in full. Open frame 0 and the 350px preview. For GIFs, include seam, motion, duration, and file-size evidence.
+2. Walk the `render` skill and `references/qa-gates.md`. Inspect frame 0 and feed-width output. For GIFs, capture seam, changed-pixel motion, duration, and file-size evidence.
+3. If a caption exists, apply the `caption` skill and `hooked-design-copy`. Check truncation, one archetype, factual support, CTA discipline, and anti-slop findings.
+4. Delegate adversarial review to `post-critic`. It must evaluate `creative-payoff`, `restrained-palette`, `center-first-composition`, UI fidelity, mascot identity when present, motion meaning, and evidence safety.
+5. Any must-fix item produces a HOLD until corrected or proven not applicable.
+6. Delegate independent acceptance to `story-verifier`. The verifier reads the actual artifacts and evidence, not a worker summary.
+7. Respect the maximum-two targeted fix attempts before escalation.
 
-## 2. Caption checks
+## HOLD conditions
 
-Use `linkedin-animated-infographics:caption` when a caption is supplied. Check the truncation cut, one archetype, factual support, exactly one CTA, anti-slop rules, and banned constructions.
+Return HOLD for a failed render gate, unsupported factual claim, generic/unsupported hero hook, missing promised creative payoff, excessive or unjustified palette treatment, invalid alignment exception, UI/mascot fidelity failure, or independent verifier failure.
 
-## 3. Adversarial review
+## Related components
 
-Delegate to `post-critic` with the artifact, caption, render evidence, story brief if present, and evidence record if present. Report must-fix, improvement, and leave-alone findings. Any must-fix item produces `HOLD` until resolved or explicitly shown not applicable.
+- routing authority: `helper/GUIDE.md`
+- local quality gates: `helper/quality-gates.json`
+- render skill: `skills/render/SKILL.md`
+- caption skill: `skills/caption/SKILL.md`
+- adversarial worker: `agents/post-critic.md`
+- independent verifier: `agents/story-verifier.md`
+- verification reference: `skills/info-stories/references/verification-loop.md`
 
-## 4. Independent verification
+## Research gates
 
-When an Info-stories brief or acceptance criteria exist, delegate to `story-verifier` with direct artifact paths, render evidence, post-critic findings, and criteria. Do not substitute a worker summary for artifact evidence. Respect the maximum-two-fix-attempt rule.
-
-## Verdict
-
-End with one line: `SHIP` or `HOLD: <the one thing to fix first>`.
+QA enforces applicable `prose-specificity`, `voice-preservation`, `structural-originality`, `contrast-discipline`, and `evidence-traceability` gates. `bounded-verification` is always active for final acceptance and prevents unbounded repair loops.

--- a/skills/render-gif/SKILL.md
+++ b/skills/render-gif/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: render-gif
-description: Render an existing artboard HTML file to a looping GIF and report the three numbers that matter.
+description: Render an existing infographic artboard HTML to a deterministic looping GIF, then report motion, seam, and file-size evidence without changing the approved design.
 disable-model-invocation: true
 argument-hint: "[path/to/artboard.html] [--duration 6.0] [--fps 12.5]"
 ---
@@ -9,24 +9,57 @@ argument-hint: "[path/to/artboard.html] [--duration 6.0] [--fps 12.5]"
 
 Arguments: **$ARGUMENTS**
 
-1. If no path was given, look for `build/*.html` and ask which one.
-2. Lint before spending the render:
+## Purpose
+
+Provide a **focused workflow** for rendering an already approved artboard. This workflow does not redesign copy, layout, palette, or motion direction; it turns the existing artifact into deterministic GIF evidence.
+
+Read `helper/GUIDE.md` first.
+
+## Use when
+
+Use when the user already has artboard HTML and wants the GIF output, wants a render rerun after a targeted fix, or needs the three core render measurements without running the entire new-post workflow.
+
+## Inputs
+
+- path to approved artboard HTML
+- optional duration/fps override
+- desired output path and file-size budget
+
+## Outputs
+
+Return the rendered GIF plus motion percentage/verdict, seam result, file size, and any HOLD that prevents a trustworthy render.
+
+## Procedure
+
+1. If no path is supplied, locate candidate `build/*.html` artifacts and ask/select rather than guessing.
+2. Lint before rendering:
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/lint_artboard.sh <path>
 ```
 
-3. Pick duration and fps from the timing table in `linkedin-animated-infographics:motion` if they were not
-   given. Do not invent numbers; each verified row divides cleanly and closes.
-
+3. If duration/fps are not supplied, use a verified timing row from the `motion` skill. Do not invent arbitrary timings that cannot close cleanly.
 4. Render:
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/render.sh <path> <out.gif> --duration <d> --fps <f>
 ```
 
-5. Report exactly three things and nothing else: the `motion:` percentage with its verdict, the
-   seam result, and the file size. If the seam does not close, name the likely cause from the
-   debugging table rather than guessing.
+5. Inspect `motion:`, seam, and file size. If the seam fails, use the motion debugging reference to identify the likely cause instead of guessing.
+6. Return the GIF and concise render evidence. Do not add a design postamble that implies unperformed QA.
 
-6. Present the GIF with `present_files`. No postamble.
+## HOLD conditions
+
+Return a HOLD when lint fails, browser capture is unavailable, frame 0 is invalid, the loop seam fails, output exceeds the accepted budget after controlled fallback, or the render evidence cannot be produced reliably.
+
+## Related components
+
+- routing authority: `helper/GUIDE.md`
+- domain render skill: `skills/render/SKILL.md`
+- motion skill: `skills/motion/SKILL.md`
+- render worker: `agents/render-qa.md`
+- full QA workflow: `skills/qa-post/SKILL.md`
+
+## Research gates
+
+`bounded-verification` applies to render failure/re-check behavior. The workflow reports evidence and does not silently mutate the artifact to force a PASS.

--- a/skills/render/SKILL.md
+++ b/skills/render/SKILL.md
@@ -1,65 +1,68 @@
 ---
 name: render
-description: >-
-  Capture frames, assemble the GIF, run the quality gates, and publish. Use when rendering an
-  artboard to a GIF, when a render fails or comes back oversized, blank, or jittery, when
-  checking a post against the QA gates before export, or when asking how to upload and post it
-  on LinkedIn. Covers the headless-Chrome capture pipeline, two-pass palette GIF assembly with
-  size budgeting, every QA gate, and the upload and first-comment mechanics.
+description: Capture deterministic infographic frames, assemble GIF output, measure motion/seam/file size, and run the render acceptance gates before shipment.
 ---
 
 # Render and ship
 
-## One command
+## Purpose
+
+Convert an approved static/animated artboard into deterministic render evidence and final GIF output. Rendering is an acceptance stage, not a place to redesign the story.
+
+Read `helper/GUIDE.md` first. Render evidence feeds `post-critic` and `story-verifier` through `build/render-report.json`.
+
+## Use when
+
+Use when capturing frames, building a GIF, diagnosing blank/jittery/oversized output, measuring seam or changed pixels, running render QA, or preparing a final LinkedIn image GIF.
+
+## Inputs
+
+- approved `build/post.html`
+- duration/fps from verified motion timing when animated
+- output file-size budget
+- expected frame-zero state and safe-zone constraints
+
+## Outputs
+
+Return GIF/static render output plus `build/render-report.json` containing frame-zero, mobile legibility, motion percentage, seam result, duration/fps, file size, and any blocking render finding.
+
+## Procedure
+
+1. Use the one-command path when possible:
 
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/render.sh build/post.html build/post.gif --duration 6.0 --fps 12.5
 ```
 
-That wraps two steps you can also run separately:
+2. The underlying deterministic stages are:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/capture_frames.py build/post.html --out build/frames \
-        --duration 6.0 --fps 12.5 --selector "#artboard"
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_gif.py build/frames --out build/post.gif \
-        --fps 12.5 --max-mb 5 --colors 128
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/capture_frames.py build/post.html --out build/frames --duration 6.0 --fps 12.5 --selector "#artboard"
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/build_gif.py build/frames --out build/post.gif --fps 12.5 --max-mb 5 --colors 128
 ```
 
-`build_gif.py` runs a two-pass ffmpeg palette and then steps down colours, then fps, then
-scale until the file fits the budget, printing every attempt so you can see the trade it made.
+3. Read `references/qa-gates.md` and `references/production-pipeline.md`.
+4. Inspect three core measurements: mean changed-pixel `motion:`, loop seam relative to normal frame deltas, and file size.
+5. Treat frame 0 as a complete poster frame. It must remain readable before autoplay.
+6. Inspect the 350px feed downscale honestly. Render success without feed-scale legibility is not acceptance.
+7. Keep the outer 48px safe zone free of motion and account for known SVG `<defs>` false positives when diagnosing geometry.
+8. If encoding exceeds the budget, prefer the existing controlled color/fps/scale fallback rather than arbitrary re-authoring.
+9. For publishing guidance, read `references/publishing-playbook.md`: LinkedIn GIF output is uploaded as an image; links normally belong in the first comment when the post strategy calls for them.
 
-## Read three numbers from the output
+## HOLD conditions
 
-- **`motion:`** the mean share of pixels changing per frame. Under 2% is healthy. Over 5% means
-  something full-bleed is animating; find it.
-- **`loop:`** the seam delta against the biggest normal frame-to-frame change. If the seam is
-  no larger than any other frame boundary, the loop closes.
-- **file size.** Keep under 5 MB and under 8 seconds or LinkedIn converts it.
+Return a HOLD when capture fails, frame 0 is incomplete, the seam does not close, changed-pixel motion indicates unintended full-canvas animation, feed-scale output is unreadable, safe-zone rules fail, or output cannot fit the accepted file budget without unacceptable degradation.
 
-## Gates before export
+## Related components
 
-Run `references/qa-gates.md`. The four that catch the most failures:
+- routing authority: `helper/GUIDE.md`
+- focused render workflow: `skills/render-gif/SKILL.md`
+- motion skill: `skills/motion/SKILL.md`
+- QA gates: `references/qa-gates.md`
+- production setup: `references/production-pipeline.md`
+- render worker: `agents/render-qa.md`
+- independent verifier: `agents/story-verifier.md`
 
-- **First-frame integrity.** LinkedIn shows a static poster frame before playback. Frame 0 must
-  be a complete, readable infographic on its own.
-- **Mobile legibility.** `check_render.py --mobile` produces the 350px downscale. Look at it
-  honestly.
-- **Loop close.** Frame 0 and the last frame indistinguishable from any other frame boundary.
-- **Safe zone.** Nothing animated in the outer 48px. Note the known false positive for animated
-  groups inside `<defs>`, which report a zero-size rect at the origin.
+## Research gates
 
-## Publishing
-
-Two things people get wrong, both in `references/publishing-playbook.md`:
-
-- Upload the GIF as an **image**, not a document or a video. LinkedIn autoplays image GIFs.
-- Put links in the **first comment**, not the caption, and say so in the caption.
-
-## Environment
-
-`references/production-pipeline.md` covers renderer setup, troubleshooting, and the HyperFrames
-interop path for when the deliverable is a video rather than a post.
-
-```bash
-bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh
-```
+`bounded-verification` governs how render failures enter the repair/re-check loop. `contrast-discipline` remains relevant to rendered evidence, and `evidence-traceability` applies when the final artifact contains factual proof that must be checked visually.

--- a/skills/svg-mascot-animator/SKILL.md
+++ b/skills/svg-mascot-animator/SKILL.md
@@ -1,113 +1,80 @@
 ---
 name: svg-mascot-animator
-description: >-
-  Animate an exact SVG mascot, logo, icon, or character with professional physics-driven motion.
-  Use whenever the user supplies an SVG for animation, names an official mascot that must be used
-  exactly, requests believable mascot motion, or wants static/baked or runtime SVG animation.
+description: Animate an exact SVG mascot, logo, icon, or character with identity-preserving, rig-aware, professional motion for deterministic or runtime delivery tracks.
 license: MIT
 ---
 
 # SVG Mascot Animator
 
-The input SVG is the identity source. Animation adds behavior around that source; it does not redesign the character.
+## Purpose
 
-## Identity and asset gate
+Animate the exact supplied SVG while preserving identity-critical geometry, colors, marks, proportions, and recognizable details. Animation adds behavior around the user's asset; it does not redesign the mascot.
 
-For a named or official mascot:
+Read `helper/GUIDE.md` first. For named or official mascots, the exact-SVG gate is mandatory.
 
-- require the exact user-supplied or task-attached SVG before animation begins
-- never substitute a generated mascot or a visually similar asset
-- keep an untouched copy of the source SVG
-- preserve recognizable silhouette, proportions, brand colours, face details, marks, and distinctive geometry
+## Use when
 
-If the exact SVG is missing and this skill is running in the main conversational context, ask the user to upload the exact SVG and do not start mascot production. If this skill is running inside a focused subagent, return `HOLD: exact SVG required` to the parent workflow instead of contacting the user or inventing an asset.
+Use when the user supplies an SVG for animation, names an official mascot that must be used exactly, requests believable mascot motion, or needs a mascot component for an Info-story or interactive web context.
 
-Run the request contract before inspection:
+## Inputs
+
+- exact user-supplied/task-attached SVG when identity must be preserved
+- validated `build/mascot-request.json` when used in the infographic workflow
+- approved communication job and creative direction
+- output track: deterministic baked/static or runtime interactive
+- approved layout/motion constraints when embedded in an infographic
+
+## Outputs
+
+Return animated asset/component, inspection report, chosen creative direction, physics/timing rationale, identity-preservation notes, rig limitations, and the motion contract/evidence needed by downstream motion, render, critique, and verification workers.
+
+## Procedure
+
+1. For a named or official mascot, require the **exact SVG** before animation begins. Keep an untouched copy of the source.
+2. If the exact SVG is missing in the main conversational context, ask the user to upload it and stop. Inside a worker, return `HOLD: exact SVG required` to the parent workflow.
+3. Validate the request contract:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mascot_contract.py check build/mascot-request.json
 ```
 
-## Inspect before promising motion
+4. Inspect the SVG before promising articulation:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/inspect_svg.py <path-to-svg>
 ```
 
-Record viewBox, bounds, IDs, groups, transforms, clips, paths, and addressable parts. A single-path mascot cannot articulate limbs or eyes independently. Use body-level transforms, external support elements, or ask the user whether an articulated derivative is acceptable. Never split identity-critical geometry silently.
-
-## Choose the delivery track
-
-**Deterministic static/baked track** is the default for LinkedIn GIFs, README assets, and anything captured frame by frame. Use self-contained SVG/CSS/SMIL with no runtime JavaScript.
-
-**Runtime track** uses Anime.js when the final environment genuinely supports interaction. Use it for interactive web contexts, then bake an equivalent deterministic version if the same motion must appear in a rendered infographic.
-
-Install and inspect the local Anime.js surface when runtime work is required:
-
-```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/setup.sh
-node ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/bake.mjs list
-```
-
-## Creative direction before keyframes
-
-Read `references/creative-directions.md`. Start from a communication job, then adapt the motion to the supplied rig. The starter set includes Guide the Eye, Curious Peek, Inspect and React, Carry and Place, Reveal Assistant, Status Confirmation, Route Follow, Card-to-Card Handoff, Calm Idle Breathing, and Contextual Micro-Reaction.
-
-Creative work is encouraged, but each new direction must define:
-
-1. communication purpose
-2. exact existing SVG parts allowed to move
-3. optional non-identity support elements
-4. loop/reset behavior
-5. motion budget
-
-Do not reuse the same bounce or float treatment for every mascot.
-
-## Rig rules
-
-Normalize pivots once, then separate transform concerns into nested groups: position, vertical motion, rotation, scale. Prefer transforms on existing groups and paths. Read `references/rigging.md` before changing transform structure.
-
-If articulation exists, secondary parts may lag the primary motion by a small amount. If it does not exist, do not fake limb movement by deforming identity-critical geometry.
-
-## Physical motion rules
-
-Read `references/physics.md` and `references/animejs.md` before implementation. Use real motion relationships rather than decorative easing:
-
-- projectile paths for hops and transfers
-- damped springs for short landing/payoff reactions
-- pendulum timing for genuine swings
-- linear sampling for physical paths
-- contact shadow derived from subject height
-- squash/stretch tied to velocity and contact
-- anticipation before committed movement
-- follow-through only on addressable secondary parts
-
-Keep contact frames short. Keep ambient motion small. Long constant bouncing, random blinking, large rotations, and unmotivated floating are failures.
-
-## Story-aware support elements
-
-You may add a small contact shadow, pointer dot, cursor, route line, card, badge, or lightweight prop when it helps the story and the user did not forbid it. These elements must remain visually separate from the mascot identity and should be removable without changing the official asset.
-
-## Accessibility and asset contract
-
-Read `references/contract.md`. Both delivery tracks require accessible labeling, ID/keyframe namespacing, reduced-motion behavior, collision-safe IDs, and no accidental external dependencies. Brand colours remain brand colours.
-
-For static assets:
-
-- zero JavaScript
-- zero web fonts or network dependencies
-- self-contained styles/animation
-- deterministic seekable timing
-
-## Verification
+Record viewBox, bounds, IDs, groups, transforms, clips, paths, and addressable parts. Do not silently split identity-critical geometry to fake articulation.
+5. Choose the delivery track. Deterministic self-contained SVG/CSS/SMIL is the default for LinkedIn GIFs and frame capture. Runtime Anime.js is valid only when the target environment genuinely supports interaction.
+6. Read `references/creative-directions.md`, `references/rigging.md`, `references/physics.md`, `references/animejs.md`, and `references/contract.md` as needed.
+7. Define the motion job before keyframes. Specify communication purpose, exact existing SVG parts allowed to move, optional non-identity support elements, loop/reset behavior, and motion budget.
+8. Use believable relationships such as projectile paths, damped landing reactions, pendulum timing for genuine swings, contact shadows derived from height, velocity-linked squash/stretch, anticipation, and follow-through only on addressable parts.
+9. Avoid constant bouncing, random blinking, large rotations, unmotivated floating, or deformation that changes the mascot's identity.
+10. Support elements such as route lines, cursors, cards, badges, or contact shadows must remain visually separate from the identity source and removable without changing the official mascot.
+11. Verify the output:
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/check_asset.py <output.svg>
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/svg-mascot-animator/scripts/check_asset.py --runtime <scene.html>
 ```
 
-Also compare the animated output with the untouched source. Confirm identity preservation, motion purpose, loop closure, frame-zero readability when used in an infographic, and reduced-motion behavior.
+12. Compare the result with the untouched source and confirm identity, purpose, loop closure, frame-zero readability when used in an infographic, reduced-motion behavior, accessible labeling, namespaced IDs/keyframes, and zero accidental network dependencies for baked assets.
 
-## Output
+## HOLD conditions
 
-Return the animated asset/component, inspection report, chosen creative direction, physics/timing rationale, identity-preservation notes, and any rig limitation. For Info-stories, return these to the parent workflow so `motion-engineer`, `render-qa`, `post-critic`, and `story-verifier` can consume the same evidence.
+Return a HOLD when the exact SVG is missing, the requested articulation is impossible without identity-changing redraw, required brand details are ambiguous, the runtime track is requested in an environment that cannot support it, or the requested motion would violate the infographic's approved reading order or evidence boundary.
+
+## Related components
+
+- routing authority: `helper/GUIDE.md`
+- infographic mascot skill: `skills/mascots/SKILL.md`
+- focused worker: `agents/mascot-animator.md`
+- request validator: `scripts/mascot_contract.py`
+- creative directions: `references/creative-directions.md`
+- rigging: `references/rigging.md`
+- physics: `references/physics.md`
+- asset contract: `references/contract.md`
+
+## Research gates
+
+Mascot identity/rigging is a local-native capability. When embedded in the complete infographic route, inherit applicable `design-dials`, `structural-originality`, `evidence-traceability`, and `bounded-verification` gates from the parent workflow.

--- a/skills/svg-mascot-animator/SKILL.md
+++ b/skills/svg-mascot-animator/SKILL.md
@@ -31,7 +31,7 @@ Return animated asset/component, inspection report, chosen creative direction, p
 ## Procedure
 
 1. For a named or official mascot, require the **exact SVG** before animation begins. Keep an untouched copy of the source.
-2. If the exact SVG is missing in the main conversational context, ask the user to upload it and stop. Inside a worker, return `HOLD: exact SVG required` to the parent workflow.
+2. If the exact SVG is missing in the main conversational context, **ask the user to upload the exact SVG** and stop. Inside a worker, return `HOLD: exact SVG required` to the parent workflow.
 3. Validate the request contract:
 
 ```bash

--- a/tests/test_agent_contracts.py
+++ b/tests/test_agent_contracts.py
@@ -1,0 +1,107 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AGENT_ROOT = ROOT / "agents"
+GRAPH = json.loads((ROOT / "architecture" / "plugin-graph.json").read_text())
+ARTIFACTS = json.loads((ROOT / "helper" / "artifacts.json").read_text())["artifacts"]
+RESEARCH = json.loads((ROOT / "research" / "capability-notes" / "gates.json").read_text())["gates"]
+QUALITY = json.loads((ROOT / "helper" / "quality-gates.json").read_text())["gates"]
+
+REQUIRED_SECTIONS = (
+    "Role",
+    "Inputs",
+    "Method",
+    "HOLD conditions",
+    "Quality gates",
+    "Research gates",
+    "Outputs",
+)
+
+
+class AgentContractTests(unittest.TestCase):
+    def test_every_agent_has_v3_worker_sections(self):
+        agents = sorted(AGENT_ROOT.glob("*.md"))
+        self.assertGreaterEqual(len(agents), 15)
+        failures = []
+        for path in agents:
+            text = path.read_text()
+            for section in REQUIRED_SECTIONS:
+                if not re.search(rf"^## {re.escape(section)}\s*$", text, re.MULTILINE):
+                    failures.append(f"{path.stem}: missing {section}")
+        self.assertEqual([], failures)
+
+    def test_every_agent_points_to_helper_and_parent_contract(self):
+        failures = []
+        for path in sorted(AGENT_ROOT.glob("*.md")):
+            text = path.read_text().lower()
+            if "helper/guide.md" not in text:
+                failures.append(f"{path.stem}: missing helper")
+            if "parent workflow" not in text:
+                failures.append(f"{path.stem}: missing parent workflow")
+        self.assertEqual([], failures)
+
+    def test_frontmatter_name_matches_filename(self):
+        failures = []
+        for path in sorted(AGENT_ROOT.glob("*.md")):
+            text = path.read_text()
+            match = re.search(r"^name:\s*([^\n]+)$", text, re.MULTILINE)
+            if not match or match.group(1).strip() != path.stem:
+                failures.append(path.name)
+        self.assertEqual([], failures)
+
+    def test_graph_skill_preloads_remain_declared(self):
+        failures = []
+        for agent, contract in GRAPH["agents"].items():
+            text = (AGENT_ROOT / f"{agent}.md").read_text()
+            for skill in contract.get("required_skills", []):
+                if f"  - {skill}" not in text:
+                    failures.append(f"{agent}: missing preload {skill}")
+        self.assertEqual([], failures)
+
+    def test_research_gate_owners_name_the_gate(self):
+        failures = []
+        for gate_id, gate in RESEARCH.items():
+            for owner in gate["owners"]:
+                text = (AGENT_ROOT / f"{owner}.md").read_text()
+                if f"`{gate_id}`" not in text:
+                    failures.append(f"{owner}: missing research gate {gate_id}")
+        self.assertEqual([], failures)
+
+    def test_local_quality_gate_owners_name_the_gate(self):
+        failures = []
+        for gate_id, gate in QUALITY.items():
+            for owner in gate["owners"]:
+                text = (AGENT_ROOT / f"{owner}.md").read_text()
+                if f"`{gate_id}`" not in text:
+                    failures.append(f"{owner}: missing quality gate {gate_id}")
+        self.assertEqual([], failures)
+
+    def test_artifact_producers_name_their_output(self):
+        by_producer = {}
+        for artifact, contract in ARTIFACTS.items():
+            producer = contract.get("producer")
+            if producer and not producer.startswith("parent:"):
+                by_producer.setdefault(producer, []).append(artifact)
+        failures = []
+        for producer, artifacts in by_producer.items():
+            text = (AGENT_ROOT / f"{producer}.md").read_text()
+            if not any(artifact in text for artifact in artifacts):
+                failures.append(f"{producer}: no declared produced artifact")
+        self.assertEqual([], failures)
+
+    def test_no_worker_claims_peer_orchestration(self):
+        banned = ("delegate to another agent", "handoff the approved brief to", "coordinate the other agents")
+        failures = []
+        for path in sorted(AGENT_ROOT.glob("*.md")):
+            text = path.read_text().lower()
+            for phrase in banned:
+                if phrase in text:
+                    failures.append(f"{path.stem}: {phrase}")
+        self.assertEqual([], failures)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_creative_runtime.py
+++ b/tests/test_creative_runtime.py
@@ -1,0 +1,112 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+QUALITY = ROOT / "helper" / "quality-gates.json"
+ROUTER = ROOT / "helper" / "router.json"
+CAPABILITIES = ROOT / "helper" / "capabilities.json"
+ARTIFACTS = ROOT / "helper" / "artifacts.json"
+GRAPH = ROOT / "architecture" / "plugin-graph.json"
+CREATIVE_AGENT = ROOT / "agents" / "creative-director.md"
+HOOK_DOC = ROOT / "skills" / "info-stories" / "references" / "hook-driven-design-copy.md"
+
+EXPECTED_QUALITY_GATES = {
+    "hooked-design-copy",
+    "creative-payoff",
+    "restrained-palette",
+    "center-first-composition",
+}
+
+
+class CreativeRuntimeTests(unittest.TestCase):
+    def test_local_quality_gate_registry_exists(self):
+        self.assertTrue(QUALITY.exists(), "missing helper/quality-gates.json")
+        gates = json.loads(QUALITY.read_text())["gates"]
+        self.assertEqual(EXPECTED_QUALITY_GATES, set(gates))
+
+    def test_local_quality_gates_have_runtime_contracts(self):
+        self.assertTrue(QUALITY.exists())
+        failures = []
+        for gate_id, gate in json.loads(QUALITY.read_text())["gates"].items():
+            for field in ("stage", "severity", "owners", "behavior", "applies_to_intents"):
+                if gate.get(field) in (None, "", []):
+                    failures.append(f"{gate_id}: missing {field}")
+            if gate.get("severity") not in ("blocking", "advisory"):
+                failures.append(f"{gate_id}: invalid severity")
+        self.assertEqual([], failures)
+
+    def test_creative_director_is_a_real_shipping_agent(self):
+        self.assertTrue(CREATIVE_AGENT.exists(), "missing agents/creative-director.md")
+        graph = json.loads(GRAPH.read_text())
+        self.assertIn("creative-director", graph["agents"])
+        sequence = graph["workflows"]["new-post"]["sequence"]
+        self.assertLess(sequence.index("evidence-checker"), sequence.index("creative-director"))
+        self.assertLess(sequence.index("creative-director"), sequence.index("story-architect"))
+
+    def test_create_route_includes_creative_director_and_quality_gates(self):
+        router = json.loads(ROUTER.read_text())
+        route = router["routes"]["create-post"]
+        self.assertIn("creative-director", route["agents"])
+        self.assertIn("creative-direction", route["capabilities"])
+        self.assertIn("hook-design-copy", route["capabilities"])
+
+    def test_info_story_route_keeps_creative_concepting_available(self):
+        router = json.loads(ROUTER.read_text())
+        route = router["routes"]["info-story"]
+        self.assertIn("creative-director", route["agents"])
+        self.assertIn("creative-direction", route["capabilities"])
+
+    def test_creative_capabilities_are_local_native_and_owned(self):
+        capabilities = json.loads(CAPABILITIES.read_text())["capabilities"]
+        for capability in ("creative-direction", "hook-design-copy"):
+            contract = capabilities[capability]
+            self.assertTrue(contract.get("local_native"), capability)
+            self.assertIn("creative-director", contract["owners"])
+
+    def test_creative_concepts_artifact_is_declared(self):
+        artifacts = json.loads(ARTIFACTS.read_text())["artifacts"]
+        contract = artifacts["build/creative-concepts.json"]
+        self.assertEqual("creative-director", contract["producer"])
+        for consumer in ("story-architect", "copy-compressor", "layout-composer", "motion-director"):
+            self.assertIn(consumer, contract["consumers"])
+        for field in (
+            "concept_name", "visual_hook", "copy_hook", "aha_mechanic", "story_shape",
+            "recommended_visual_style", "recommended_story_archetype",
+            "recommended_motion_behavior", "evidence_dependencies", "risk_notes",
+            "why_it_earns_attention",
+        ):
+            self.assertIn(field, contract["required_fields"])
+
+    def test_creative_agent_requires_three_directions_and_evidence_safety(self):
+        self.assertTrue(CREATIVE_AGENT.exists())
+        text = CREATIVE_AGENT.read_text().lower()
+        self.assertRegex(text, r"at least\s+three|minimum\s+three")
+        for needle in ("visual hook", "copy hook", "aha", "evidence", "parent workflow", "do not invent"):
+            self.assertIn(needle, text)
+
+    def test_hook_driven_design_copy_reference_exists(self):
+        self.assertTrue(HOOK_DOC.exists())
+        text = HOOK_DOC.read_text().lower()
+        for needle in ("hero headline", "specificity", "portable", "do not invent", "literal labels"):
+            self.assertIn(needle, text)
+
+    def test_hook_gate_is_wired_into_copy_owners(self):
+        for agent in ("creative-director", "copy-compressor", "caption-writer", "post-critic"):
+            text = (ROOT / "agents" / f"{agent}.md").read_text().lower()
+            self.assertIn("hooked-design-copy", text, agent)
+
+    def test_creative_payoff_is_not_spectacle(self):
+        self.assertTrue(QUALITY.exists())
+        behavior = json.loads(QUALITY.read_text())["gates"]["creative-payoff"]["behavior"].lower()
+        for needle in ("useful visual payoff", "not spectacle", "reveal", "relationship"):
+            self.assertIn(needle, behavior)
+
+    def test_complete_route_exposes_local_quality_gates(self):
+        script = (ROOT / "scripts" / "ecosystem_router.py").read_text()
+        self.assertIn('"quality_gates"', script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -1,0 +1,102 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = {
+    "ecosystem": ROOT / "docs" / "ecosystem.md",
+    "routing": ROOT / "docs" / "routing.md",
+    "agents": ROOT / "docs" / "agents.md",
+    "skills": ROOT / "docs" / "skills.md",
+    "research": ROOT / "docs" / "research.md",
+    "marketplace": ROOT / "docs" / "marketplace.md",
+    "development": ROOT / "docs" / "development.md",
+}
+README = ROOT / "README.md"
+
+
+class DocsContractTests(unittest.TestCase):
+    def test_required_v3_docs_exist(self):
+        failures = [name for name, path in DOCS.items() if not path.exists()]
+        self.assertEqual([], failures)
+
+    def test_readme_is_a_concise_gateway_to_focused_docs(self):
+        text = README.read_text()
+        for relative in (
+            "docs/ecosystem.md", "docs/routing.md", "docs/agents.md", "docs/skills.md",
+            "docs/research.md", "docs/marketplace.md", "docs/development.md",
+        ):
+            self.assertIn(relative, text)
+        self.assertIn("helper/GUIDE.md", text)
+        self.assertIn("creative-director", text)
+        self.assertIn("ecosystem_doctor.py", text)
+
+    def test_agent_doc_covers_every_active_agent(self):
+        self.assertTrue(DOCS["agents"].exists())
+        text = DOCS["agents"].read_text()
+        manifest = json.loads((ROOT / "helper" / "modules.json").read_text())["modules"]["agents"]
+        for name in manifest:
+            self.assertIn(f"`{name}`", text, name)
+
+    def test_skill_doc_covers_every_active_skill(self):
+        self.assertTrue(DOCS["skills"].exists())
+        text = DOCS["skills"].read_text()
+        manifest = json.loads((ROOT / "helper" / "modules.json").read_text())["modules"]["skills"]
+        for name in manifest:
+            self.assertIn(f"`{name}`", text, name)
+
+    def test_research_doc_covers_every_active_gate_and_source(self):
+        self.assertTrue(DOCS["research"].exists())
+        text = DOCS["research"].read_text()
+        gates = json.loads((ROOT / "research" / "capability-notes" / "gates.json").read_text())["gates"]
+        sources = json.loads((ROOT / "research" / "capability-notes" / "sources.json").read_text())["sources"]
+        for gate_id in gates:
+            self.assertIn(f"`{gate_id}`", text, gate_id)
+        for source in sources:
+            self.assertIn(source["name"], text, source["name"])
+
+    def test_marketplace_doc_has_real_install_and_validation_commands(self):
+        self.assertTrue(DOCS["marketplace"].exists())
+        text = DOCS["marketplace"].read_text()
+        for needle in (
+            "/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics",
+            "/plugin install linkedin-animated-infographics@mamdouh-creative-tools",
+            "claude plugin validate .",
+            "python3 scripts/validate_marketplace.py",
+        ):
+            self.assertIn(needle, text)
+
+    def test_development_doc_names_all_strict_validators(self):
+        self.assertTrue(DOCS["development"].exists())
+        text = DOCS["development"].read_text()
+        for command in (
+            "python3 scripts/ecosystem_router.py check",
+            "python3 scripts/research_gates.py check",
+            "python3 scripts/plugin_graph.py check",
+            "python3 scripts/ecosystem_doctor.py check",
+            "python3 scripts/validate_marketplace.py",
+        ):
+            self.assertIn(command, text)
+
+    def test_docs_local_markdown_links_resolve(self):
+        missing = []
+        files = [README, *DOCS.values()]
+        for path in files:
+            if not path.exists():
+                continue
+            text = path.read_text()
+            for target in re.findall(r"\[[^\]]+\]\(([^)]+)\)", text):
+                if target.startswith(("http://", "https://", "#", "mailto:")):
+                    continue
+                clean = target.split("#", 1)[0]
+                if not clean:
+                    continue
+                resolved = (path.parent / clean).resolve()
+                if not resolved.exists():
+                    missing.append(f"{path.relative_to(ROOT)} -> {target}")
+        self.assertEqual([], missing)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ecosystem_doctor.py
+++ b/tests/test_ecosystem_doctor.py
@@ -98,6 +98,54 @@ class EcosystemDoctorTests(unittest.TestCase):
                 errors,
             )
 
+    def test_doctor_rejects_module_path_that_escapes_repository(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            copy_repo_fixture(root)
+            outside = root.parent / "outside.md"
+            outside.write_text("outside repository file that must never satisfy a module contract")
+            manifest_path = root / "helper" / "modules.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["modules"]["skills"]["post"]["path"] = "../outside.md"
+            manifest_path.write_text(json.dumps(manifest))
+            errors = module.validate_ecosystem_doctor(root)
+            self.assertTrue(any("unsafe module path" in error.lower() and "post" in error for error in errors), errors)
+
+    def test_doctor_rejects_test_path_that_escapes_repository(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            copy_repo_fixture(root)
+            outside = root.parent / "outside_test.py"
+            outside.write_text("# outside test")
+            manifest_path = root / "helper" / "modules.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["modules"]["agents"]["creative-director"]["tests"] = ["../outside_test.py"]
+            manifest_path.write_text(json.dumps(manifest))
+            errors = module.validate_ecosystem_doctor(root)
+            self.assertTrue(any("unsafe test path" in error.lower() and "creative-director" in error for error in errors), errors)
+
+    def test_doctor_rejects_tool_guidance_path_that_escapes_repository(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            copy_repo_fixture(root)
+            outside = root.parent / "outside-guide.md"
+            outside.write_text("route_request.py is mentioned outside the repository")
+            manifest_path = root / "helper" / "modules.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["modules"]["tools"]["route_request"]["reachable_from"] = ["../outside-guide.md"]
+            manifest_path.write_text(json.dumps(manifest))
+            errors = module.validate_ecosystem_doctor(root)
+            self.assertTrue(any("unsafe executable guidance path" in error.lower() and "route_request" in error for error in errors), errors)
+
     def test_doctor_rejects_unreachable_agent(self):
         module = load_module()
         self.assertIsNotNone(module)

--- a/tests/test_ecosystem_doctor.py
+++ b/tests/test_ecosystem_doctor.py
@@ -19,6 +19,13 @@ def load_module():
     return module
 
 
+def copy_repo_fixture(root: Path):
+    for relative in ("helper", "skills", "agents", "tools", "architecture", "research", "scripts", "tests"):
+        source = ROOT / relative
+        if source.exists():
+            shutil.copytree(source, root / relative)
+
+
 class EcosystemDoctorTests(unittest.TestCase):
     def test_manifest_and_strict_doctor_exist(self):
         self.assertTrue(MANIFEST.exists(), "missing helper/modules.json")
@@ -63,23 +70,40 @@ class EcosystemDoctorTests(unittest.TestCase):
         self.assertIsNotNone(module)
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            for relative in ("helper", "skills", "agents", "tools", "architecture", "research", "scripts", "tests"):
-                source = ROOT / relative
-                if source.exists():
-                    shutil.copytree(source, root / relative)
+            copy_repo_fixture(root)
             (root / "tools" / "fake_public_tool.py").write_text("def main():\n    return 0\n")
             errors = module.validate_ecosystem_doctor(root)
             self.assertTrue(any("undeclared public tool" in error.lower() for error in errors), errors)
+
+    def test_doctor_rejects_declared_tool_referenced_only_by_manifest(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_repo_fixture(root)
+            tool_path = root / "tools" / "fake_declared_tool.py"
+            tool_path.write_text("#!/usr/bin/env python3\n\ndef main():\n    print('real enough for the fixture')\n    return 0\n")
+            manifest_path = root / "helper" / "modules.json"
+            manifest = json.loads(manifest_path.read_text())
+            manifest["modules"]["tools"]["fake_declared_tool"] = {
+                "path": "tools/fake_declared_tool.py",
+                "role": "Fixture tool that is deliberately unused",
+                "tests": ["tests/test_ecosystem_doctor.py"],
+                "reachable_from": ["helper/modules.json"],
+            }
+            manifest_path.write_text(json.dumps(manifest))
+            errors = module.validate_ecosystem_doctor(root)
+            self.assertTrue(
+                any("fake_declared_tool" in error and "executable guidance" in error.lower() for error in errors),
+                errors,
+            )
 
     def test_doctor_rejects_unreachable_agent(self):
         module = load_module()
         self.assertIsNotNone(module)
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            for relative in ("helper", "skills", "agents", "tools", "architecture", "research", "scripts", "tests"):
-                source = ROOT / relative
-                if source.exists():
-                    shutil.copytree(source, root / relative)
+            copy_repo_fixture(root)
             graph_path = root / "architecture" / "plugin-graph.json"
             graph = json.loads(graph_path.read_text())
             graph["workflows"]["new-post"]["sequence"].remove("creative-director")

--- a/tests/test_ecosystem_doctor.py
+++ b/tests/test_ecosystem_doctor.py
@@ -1,0 +1,117 @@
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "helper" / "modules.json"
+SCRIPT = ROOT / "scripts" / "ecosystem_doctor.py"
+
+
+def load_module():
+    if not SCRIPT.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("ecosystem_doctor", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class EcosystemDoctorTests(unittest.TestCase):
+    def test_manifest_and_strict_doctor_exist(self):
+        self.assertTrue(MANIFEST.exists(), "missing helper/modules.json")
+        self.assertTrue(SCRIPT.exists(), "missing scripts/ecosystem_doctor.py")
+
+    def test_manifest_matches_public_filesystem_inventory(self):
+        self.assertTrue(MANIFEST.exists())
+        modules = json.loads(MANIFEST.read_text())["modules"]
+        expected = {
+            "skills": {path.parent.name for path in (ROOT / "skills").glob("*/SKILL.md")},
+            "agents": {path.stem for path in (ROOT / "agents").glob("*.md")},
+            "tools": {path.stem for path in (ROOT / "tools").glob("*.py")},
+        }
+        self.assertEqual(expected["skills"], set(modules["skills"]))
+        self.assertEqual(expected["agents"], set(modules["agents"]))
+        self.assertEqual(expected["tools"], set(modules["tools"]))
+
+    def test_every_manifest_entry_has_real_contract(self):
+        self.assertTrue(MANIFEST.exists())
+        modules = json.loads(MANIFEST.read_text())["modules"]
+        failures = []
+        for module_type, entries in modules.items():
+            for name, contract in entries.items():
+                for field in ("path", "role", "tests", "reachable_from"):
+                    if contract.get(field) in (None, "", []):
+                        failures.append(f"{module_type}:{name}: missing {field}")
+                path = ROOT / contract.get("path", "")
+                if not path.exists():
+                    failures.append(f"{module_type}:{name}: missing path")
+                for test_path in contract.get("tests", []):
+                    if not (ROOT / test_path).exists():
+                        failures.append(f"{module_type}:{name}: missing test {test_path}")
+        self.assertEqual([], failures)
+
+    def test_doctor_reports_clean_repository(self):
+        module = load_module()
+        self.assertIsNotNone(module, "strict doctor implementation missing")
+        self.assertEqual([], module.validate_ecosystem_doctor(ROOT))
+
+    def test_doctor_rejects_undeclared_public_tool(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for relative in ("helper", "skills", "agents", "tools", "architecture", "research", "scripts", "tests"):
+                source = ROOT / relative
+                if source.exists():
+                    shutil.copytree(source, root / relative)
+            (root / "tools" / "fake_public_tool.py").write_text("def main():\n    return 0\n")
+            errors = module.validate_ecosystem_doctor(root)
+            self.assertTrue(any("undeclared public tool" in error.lower() for error in errors), errors)
+
+    def test_doctor_rejects_unreachable_agent(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for relative in ("helper", "skills", "agents", "tools", "architecture", "research", "scripts", "tests"):
+                source = ROOT / relative
+                if source.exists():
+                    shutil.copytree(source, root / relative)
+            graph_path = root / "architecture" / "plugin-graph.json"
+            graph = json.loads(graph_path.read_text())
+            graph["workflows"]["new-post"]["sequence"].remove("creative-director")
+            graph_path.write_text(json.dumps(graph))
+            router_path = root / "helper" / "router.json"
+            router = json.loads(router_path.read_text())
+            for route in router["routes"].values():
+                route["agents"] = [agent for agent in route.get("agents", []) if agent != "creative-director"]
+            router_path.write_text(json.dumps(router))
+            errors = module.validate_ecosystem_doctor(root)
+            self.assertTrue(any("unreachable active agent creative-director" in error.lower() for error in errors), errors)
+
+    def test_doctor_requires_critical_shipping_workers(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        errors = module.validate_ecosystem_doctor(ROOT)
+        self.assertFalse(any("critical shipping worker" in error.lower() for error in errors), errors)
+
+    def test_active_modules_are_not_placeholder_stubs(self):
+        self.assertTrue(MANIFEST.exists())
+        modules = json.loads(MANIFEST.read_text())["modules"]
+        failures = []
+        for entries in modules.values():
+            for name, contract in entries.items():
+                text = (ROOT / contract["path"]).read_text()
+                if len(text.strip()) < 80:
+                    failures.append(f"{name}: too small")
+                lowered = text.lower()
+                if "todo: implement" in lowered or "placeholder module" in lowered:
+                    failures.append(f"{name}: placeholder")
+        self.assertEqual([], failures)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ecosystem_router.py
+++ b/tests/test_ecosystem_router.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "helper"
+SCRIPT = ROOT / "scripts" / "ecosystem_router.py"
+
+
+def load_module():
+    if not SCRIPT.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("ecosystem_router", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class EcosystemRouterTests(unittest.TestCase):
+    def test_helper_contract_files_exist(self):
+        for relative in ("README.md", "GUIDE.md", "router.json", "capabilities.json", "artifacts.json"):
+            self.assertTrue((HELPER / relative).exists(), relative)
+        self.assertTrue(SCRIPT.exists(), "missing scripts/ecosystem_router.py")
+        self.assertTrue((ROOT / "tools" / "route_request.py").exists(), "missing public route_request tool")
+
+    def test_registry_validator_is_clean(self):
+        module = load_module()
+        self.assertIsNotNone(module, "ecosystem router implementation missing")
+        self.assertEqual([], module.validate_ecosystem(ROOT))
+
+    def test_full_post_route_uses_canonical_workflow(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        route = module.route_request({"request": "Create an animated LinkedIn infographic", "output": "gif"}, ROOT)
+        self.assertEqual("create-post", route["intent"])
+        self.assertEqual("new-post", route["workflow"])
+        self.assertIn("story-architect", route["agents"])
+        self.assertIn("render-qa", route["agents"])
+        self.assertIn("story-verifier", route["agents"])
+
+    def test_named_mascot_without_svg_holds(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        route = module.route_request({"request": "Create a post with the official Acme mascot", "mascot": {"name": "Acme", "official": True}}, ROOT)
+        self.assertEqual("HOLD", route["status"])
+        self.assertIn("exact SVG", route["reason"])
+
+    def test_named_mascot_with_exact_svg_routes_mascot_agent(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            svg = Path(tmp) / "official.svg"
+            svg.write_text('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M0 0h10v10H0z"/></svg>')
+            route = module.route_request({"request": "Create a post with the official Acme mascot", "mascot": {"name": "Acme", "official": True, "svg_path": str(svg)}}, ROOT)
+            self.assertEqual("READY", route["status"])
+            self.assertIn("mascot-animator", route["conditional_agents"])
+
+    def test_arabic_request_adds_arabic_skill(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        route = module.route_request({"request": "اعمل انفوجرافيك عربي", "language": "ar"}, ROOT)
+        self.assertIn("arabic", route["skills"])
+
+    def test_ui_mockup_request_requires_evidence_capability(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        route = module.route_request({"request": "Create a UI mockup story for our product", "ui_mockup": True}, ROOT)
+        self.assertIn("ui-mockup-fidelity", route["capabilities"])
+        self.assertIn("evidence-checker", route["agents"])
+
+    def test_focused_qa_routes_to_qa_workflow(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        route = module.route_request({"request": "QA this finished infographic", "intent": "qa"}, ROOT)
+        self.assertEqual("qa-post", route["workflow"])
+        self.assertIn("post-critic", route["agents"])
+        self.assertIn("story-verifier", route["agents"])
+
+    def test_helper_guide_names_machine_readable_authority(self):
+        guide = HELPER / "GUIDE.md"
+        self.assertTrue(guide.exists())
+        text = guide.read_text()
+        for needle in ("router.json", "capabilities.json", "artifacts.json", "parent workflow", "HOLD"):
+            self.assertIn(needle, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ecosystem_router.py
+++ b/tests/test_ecosystem_router.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import os
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,6 +9,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "helper"
 SCRIPT = ROOT / "scripts" / "ecosystem_router.py"
+REQUIRED_CONDITIONS = {"arabic", "ui_mockup", "visual_reference", "official_mascot"}
 
 
 def load_module():
@@ -18,9 +21,14 @@ def load_module():
     return module
 
 
+def copy_router_fixture(root: Path):
+    for relative in ("helper", "research", "skills", "agents", "architecture"):
+        shutil.copytree(ROOT / relative, root / relative)
+
+
 class EcosystemRouterTests(unittest.TestCase):
     def test_helper_contract_files_exist(self):
-        for relative in ("README.md", "GUIDE.md", "router.json", "capabilities.json", "artifacts.json"):
+        for relative in ("README.md", "GUIDE.md", "router.json", "capabilities.json", "artifacts.json", "quality-gates.json"):
             self.assertTrue((HELPER / relative).exists(), relative)
         self.assertTrue(SCRIPT.exists(), "missing scripts/ecosystem_router.py")
         self.assertTrue((ROOT / "tools" / "route_request.py").exists(), "missing public route_request tool")
@@ -30,12 +38,31 @@ class EcosystemRouterTests(unittest.TestCase):
         self.assertIsNotNone(module, "ecosystem router implementation missing")
         self.assertEqual([], module.validate_ecosystem(ROOT))
 
+    def test_validator_requires_all_runtime_condition_ids(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        for condition_id in sorted(REQUIRED_CONDITIONS):
+            with self.subTest(condition=condition_id), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp) / "repo"
+                root.mkdir()
+                copy_router_fixture(root)
+                router_path = root / "helper" / "router.json"
+                router = json.loads(router_path.read_text())
+                router["conditions"].pop(condition_id)
+                router_path.write_text(json.dumps(router))
+                errors = module.validate_ecosystem(root)
+                self.assertTrue(
+                    any("required condition" in error.lower() and condition_id in error for error in errors),
+                    errors,
+                )
+
     def test_full_post_route_uses_canonical_workflow(self):
         module = load_module()
         self.assertIsNotNone(module)
         route = module.route_request({"request": "Create an animated LinkedIn infographic", "output": "gif"}, ROOT)
         self.assertEqual("create-post", route["intent"])
         self.assertEqual("new-post", route["workflow"])
+        self.assertIn("creative-director", route["agents"])
         self.assertIn("story-architect", route["agents"])
         self.assertIn("render-qa", route["agents"])
         self.assertIn("story-verifier", route["agents"])
@@ -47,7 +74,7 @@ class EcosystemRouterTests(unittest.TestCase):
         self.assertEqual("HOLD", route["status"])
         self.assertIn("exact SVG", route["reason"])
 
-    def test_named_mascot_with_exact_svg_routes_mascot_agent(self):
+    def test_named_mascot_with_exact_absolute_svg_routes_mascot_agent(self):
         module = load_module()
         self.assertIsNotNone(module)
         with tempfile.TemporaryDirectory() as tmp:
@@ -56,6 +83,44 @@ class EcosystemRouterTests(unittest.TestCase):
             route = module.route_request({"request": "Create a post with the official Acme mascot", "mascot": {"name": "Acme", "official": True, "svg_path": str(svg)}}, ROOT)
             self.assertEqual("READY", route["status"])
             self.assertIn("mascot-animator", route["conditional_agents"])
+
+    def test_repo_relative_mascot_svg_is_resolved_against_router_root_not_cwd(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            root = base / "repo"
+            root.mkdir()
+            copy_router_fixture(root)
+            asset = root / "fixtures" / "official.svg"
+            asset.parent.mkdir()
+            asset.write_text('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M0 0h10v10H0z"/></svg>')
+            elsewhere = base / "elsewhere"
+            elsewhere.mkdir()
+            previous = Path.cwd()
+            try:
+                os.chdir(elsewhere)
+                route = module.route_request(
+                    {
+                        "request": "Create a post with the official Acme mascot",
+                        "mascot": {"name": "Acme", "official": True, "svg_path": "fixtures/official.svg"},
+                    },
+                    root,
+                )
+            finally:
+                os.chdir(previous)
+            self.assertEqual("READY", route["status"])
+            self.assertIn("mascot-animator", route["conditional_agents"])
+
+    def test_focused_mascot_route_holds_when_svg_path_string_does_not_exist(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        route = module.route_request(
+            {"request": "Animate this mascot", "intent": "mascot-animation", "mascot": {"svg_path": "missing.svg"}},
+            ROOT,
+        )
+        self.assertEqual("HOLD", route["status"])
+        self.assertIn("exact SVG", route["reason"])
 
     def test_arabic_request_adds_arabic_skill(self):
         module = load_module()

--- a/tests/test_ecosystem_router.py
+++ b/tests/test_ecosystem_router.py
@@ -26,6 +26,13 @@ def copy_router_fixture(root: Path):
         shutil.copytree(ROOT / relative, root / relative)
 
 
+def mutate_router_fixture(root: Path, mutator):
+    router_path = root / "helper" / "router.json"
+    router = json.loads(router_path.read_text())
+    mutator(router)
+    router_path.write_text(json.dumps(router))
+
+
 class EcosystemRouterTests(unittest.TestCase):
     def test_helper_contract_files_exist(self):
         for relative in ("README.md", "GUIDE.md", "router.json", "capabilities.json", "artifacts.json", "quality-gates.json"):
@@ -46,15 +53,52 @@ class EcosystemRouterTests(unittest.TestCase):
                 root = Path(tmp) / "repo"
                 root.mkdir()
                 copy_router_fixture(root)
-                router_path = root / "helper" / "router.json"
-                router = json.loads(router_path.read_text())
-                router["conditions"].pop(condition_id)
-                router_path.write_text(json.dumps(router))
+                mutate_router_fixture(root, lambda router, key=condition_id: router["conditions"].pop(key))
                 errors = module.validate_ecosystem(root)
                 self.assertTrue(
                     any("required condition" in error.lower() and condition_id in error for error in errors),
                     errors,
                 )
+
+    def test_validator_requires_runtime_condition_schema(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        cases = (
+            ("arabic", "adds_skills", None),
+            ("ui_mockup", "adds_agents", "not-a-list"),
+            ("visual_reference", "adds_capabilities", None),
+            ("official_mascot", "asset_gate", 42),
+            ("official_mascot", "adds_skills", None),
+        )
+        for condition_id, field, bad_value in cases:
+            with self.subTest(condition=condition_id, field=field), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp) / "repo"
+                root.mkdir()
+                copy_router_fixture(root)
+
+                def break_field(router, key=condition_id, field_name=field, value=bad_value):
+                    if value is None:
+                        router["conditions"][key].pop(field_name, None)
+                    else:
+                        router["conditions"][key][field_name] = value
+
+                mutate_router_fixture(root, break_field)
+                errors = module.validate_ecosystem(root)
+                self.assertTrue(
+                    any(condition_id in error and field in error and "required field" in error.lower() for error in errors),
+                    errors,
+                )
+
+    def test_route_request_fails_fast_with_value_error_for_malformed_required_condition(self):
+        module = load_module()
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            copy_router_fixture(root)
+            mutate_router_fixture(root, lambda router: router["conditions"]["arabic"].pop("adds_skills"))
+            with self.assertRaisesRegex(ValueError, "arabic.*adds_skills"):
+                module.route_request({"request": "اعمل انفوجرافيك عربي", "language": "ar"}, root)
 
     def test_full_post_route_uses_canonical_workflow(self):
         module = load_module()

--- a/tests/test_info_stories.py
+++ b/tests/test_info_stories.py
@@ -121,7 +121,7 @@ class InfoStoriesRegistryTests(unittest.TestCase):
         artboard=(ROOT/"agents/artboard-builder.md").read_text().lower(); motion=(ROOT/"agents/motion-engineer.md").read_text().lower(); self.assertIn("story brief",artboard); self.assertIn("story house",artboard); self.assertIn("motion pattern",motion); self.assertIn("story brief",motion)
 
     def test_plugin_version_and_readme_publish_info_stories(self):
-        plugin=json.loads((ROOT/".claude-plugin/plugin.json").read_text()); self.assertEqual("2.2.0",plugin["version"]); self.assertIn("info-stories",plugin["keywords"])
+        plugin=json.loads((ROOT/".claude-plugin/plugin.json").read_text()); self.assertEqual("3.0.0",plugin["version"]); self.assertIn("info-stories",plugin["keywords"])
         readme=(ROOT/"README.md").read_text().lower()
         for needle in ["info-stories","story house","scripts/info_stories.py","tools/palette_preview.py","tools/story_scaffold.py","tools/composition_check.py","tools/copy_slop_check.py"]: self.assertIn(needle,readme)
 

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -32,20 +32,21 @@ class MarketplaceTests(unittest.TestCase):
         self.assertEqual("./", entry["source"])
         self.assertIs(True, entry["strict"])
 
-    def test_marketplace_and_plugin_versions_match(self):
+    def test_marketplace_and_plugin_versions_match_v3_release(self):
         market = json.loads(MARKETPLACE.read_text())["plugins"][0]
         plugin = json.loads(PLUGIN.read_text())
-        self.assertEqual("2.2.0", plugin["version"])
+        self.assertEqual("3.0.0", plugin["version"])
         self.assertEqual(plugin["version"], market["version"])
 
     def test_standard_component_directories_exist(self):
-        for relative in ("skills", "agents", "hooks/hooks.json"):
+        for relative in ("skills", "agents", "hooks/hooks.json", "helper"):
             self.assertTrue((ROOT / relative).exists(), relative)
 
     def test_readme_documents_marketplace_install(self):
         text = README.read_text()
         self.assertIn("/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics", text)
         self.assertIn("/plugin install linkedin-animated-infographics@mamdouh-creative-tools", text)
+        self.assertIn("3.0.0", text)
 
     def test_local_marketplace_validator_is_clean(self):
         module = load_validator()

--- a/tests/test_plugin_graph.py
+++ b/tests/test_plugin_graph.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -15,6 +17,11 @@ def load_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def copy_graph_fixture(destination: Path):
+    for relative in ("architecture", "agents", "skills", "helper"):
+        shutil.copytree(ROOT / relative, destination / relative)
 
 
 class PluginGraphTests(unittest.TestCase):
@@ -78,6 +85,31 @@ class PluginGraphTests(unittest.TestCase):
         text = (ROOT / "skills" / "qa-post" / "SKILL.md").read_text()
         self.assertIn("post-critic", text)
         self.assertIn("story-verifier", text)
+
+    def test_validator_detects_helper_capability_owner_drift(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_graph_fixture(root)
+            capabilities_path = root / "helper" / "capabilities.json"
+            capabilities = json.loads(capabilities_path.read_text())
+            capabilities["capabilities"]["anti-slop"]["owners"] = ["story-verifier"]
+            capabilities_path.write_text(json.dumps(capabilities))
+            errors = module.validate_component_graph(root)
+            self.assertTrue(any("helper capability anti-slop" in error.lower() for error in errors), errors)
+
+    def test_validator_detects_helper_workflow_order_drift(self):
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_graph_fixture(root)
+            router_path = root / "helper" / "router.json"
+            router = json.loads(router_path.read_text())
+            agents = router["routes"]["create-post"]["agents"]
+            router["routes"]["create-post"]["agents"] = list(reversed(agents))
+            router_path.write_text(json.dumps(router))
+            errors = module.validate_component_graph(root)
+            self.assertTrue(any("helper create-post agent order" in error.lower() for error in errors), errors)
 
 
 class WorkerCoordinationTests(unittest.TestCase):

--- a/tests/test_plugin_graph.py
+++ b/tests/test_plugin_graph.py
@@ -38,10 +38,16 @@ class PluginGraphTests(unittest.TestCase):
         graph = json.loads(GRAPH.read_text())
         sequence = graph["workflows"]["new-post"]["sequence"]
         required = {
-            "story-architect", "palette-curator", "copy-compressor", "layout-composer",
-            "caption-writer", "artboard-builder", "render-qa", "post-critic", "story-verifier",
+            "creative-director", "story-architect", "palette-curator", "copy-compressor",
+            "layout-composer", "caption-writer", "artboard-builder", "render-qa",
+            "post-critic", "story-verifier",
         }
         self.assertTrue(required.issubset(sequence))
+
+    def test_creative_director_runs_between_evidence_and_story(self):
+        sequence = json.loads(GRAPH.read_text())["workflows"]["new-post"]["sequence"]
+        self.assertLess(sequence.index("evidence-checker"), sequence.index("creative-director"))
+        self.assertLess(sequence.index("creative-director"), sequence.index("story-architect"))
 
     def test_conditional_mascot_edge_is_explicit(self):
         edge = json.loads(GRAPH.read_text())["workflows"]["new-post"]["conditional"]["mascot"]
@@ -63,8 +69,8 @@ class PluginGraphTests(unittest.TestCase):
     def test_capability_families_have_shipping_owners(self):
         graph = json.loads(GRAPH.read_text())
         expected = {
-            "anti-slop", "design-taste", "structural-fingerprint", "evidence",
-            "verification-loop", "mascot-identity", "ui-mockup-fidelity",
+            "anti-slop", "creative-direction", "design-taste", "evidence", "hook-design-copy",
+            "mascot-identity", "structural-fingerprint", "ui-mockup-fidelity", "verification-loop",
         }
         self.assertEqual(expected, set(graph["capabilities"]))
         workflow = graph["workflows"]["new-post"]
@@ -114,7 +120,7 @@ class PluginGraphTests(unittest.TestCase):
 
 class WorkerCoordinationTests(unittest.TestCase):
     def test_planning_workers_return_to_parent_orchestrator(self):
-        for name in ("story-architect", "layout-composer", "motion-director"):
+        for name in ("creative-director", "story-architect", "layout-composer", "motion-director"):
             text = (ROOT / "agents" / f"{name}.md").read_text()
             self.assertIn("parent workflow", text.lower(), name)
             self.assertNotIn("Handoff the approved brief to", text, name)

--- a/tests/test_repository_guidance.py
+++ b/tests/test_repository_guidance.py
@@ -1,0 +1,51 @@
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDANCE = [
+    ROOT / "AGENTS.md",
+    ROOT / "CLAUDE.md",
+    ROOT / ".codex" / "AGENTS.md",
+    ROOT / ".agents" / "skills" / "linkedin-animated-infographics" / "SKILL.md",
+    ROOT / ".claude" / "skills" / "linkedin-animated-infographics" / "SKILL.md",
+]
+
+
+class RepositoryGuidanceTests(unittest.TestCase):
+    def test_root_guidance_files_exist(self):
+        self.assertTrue((ROOT / "AGENTS.md").exists())
+        self.assertTrue((ROOT / "CLAUDE.md").exists())
+
+    def test_all_guidance_points_to_same_authority(self):
+        failures = []
+        for path in GUIDANCE:
+            self.assertTrue(path.exists(), str(path))
+            text = path.read_text()
+            for needle in (
+                "helper/GUIDE.md",
+                "research/capability-notes/gates.json",
+                "helper/quality-gates.json",
+                "helper/modules.json",
+                "scripts/ecosystem_doctor.py",
+            ):
+                if needle not in text:
+                    failures.append(f"{path.relative_to(ROOT)}: missing {needle}")
+        self.assertEqual([], failures)
+
+    def test_guidance_names_creative_and_exact_asset_rules(self):
+        for path in (ROOT / "AGENTS.md", ROOT / "CLAUDE.md"):
+            text = path.read_text().lower()
+            self.assertIn("creative-director", text)
+            self.assertIn("hooked-design-copy", text)
+            self.assertIn("creative-attractive-restrained", text)
+            self.assertIn("center-first", text)
+            self.assertIn("exact svg", text)
+
+    def test_guidance_does_not_claim_catalog_json_alone_is_authority(self):
+        banned = "catalog.json is the source of truth"
+        for path in GUIDANCE:
+            self.assertNotIn(banned, path.read_text().lower(), str(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_research_gates.py
+++ b/tests/test_research_gates.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -29,6 +31,13 @@ def load_module(path: Path, name: str):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def copy_research_fixture(root: Path):
+    for relative in ("research", "helper", "architecture", "agents", "skills", "tools"):
+        source = ROOT / relative
+        if source.exists():
+            shutil.copytree(source, root / relative)
 
 
 class ResearchGateTests(unittest.TestCase):
@@ -115,6 +124,36 @@ class ResearchGateTests(unittest.TestCase):
         module = load_module(SCRIPT, "research_gates")
         self.assertIsNotNone(module, "research gate validator missing")
         self.assertEqual([], module.validate_research_gates(ROOT))
+
+    def test_validator_rejects_implementation_ref_that_escapes_repository(self):
+        module = load_module(SCRIPT, "research_gates")
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            copy_research_fixture(root)
+            outside = root.parent / "outside.md"
+            outside.write_text("outside implementation reference")
+            gates_path = root / "research" / "capability-notes" / "gates.json"
+            gates = json.loads(gates_path.read_text())
+            gates["gates"]["reference-dna"]["implementation_refs"] = ["../outside.md"]
+            gates_path.write_text(json.dumps(gates))
+            errors = module.validate_research_gates(root)
+            self.assertTrue(any("unsafe implementation ref" in error.lower() and "reference-dna" in error for error in errors), errors)
+
+    def test_validator_rejects_absolute_implementation_ref(self):
+        module = load_module(SCRIPT, "research_gates")
+        self.assertIsNotNone(module)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            copy_research_fixture(root)
+            gates_path = root / "research" / "capability-notes" / "gates.json"
+            gates = json.loads(gates_path.read_text())
+            gates["gates"]["reference-dna"]["implementation_refs"] = ["/etc/passwd"]
+            gates_path.write_text(json.dumps(gates))
+            errors = module.validate_research_gates(root)
+            self.assertTrue(any("unsafe implementation ref" in error.lower() and "reference-dna" in error for error in errors), errors)
 
     def test_router_returns_research_gates_for_create_route(self):
         module = load_module(ROUTER_SCRIPT, "ecosystem_router")

--- a/tests/test_research_gates.py
+++ b/tests/test_research_gates.py
@@ -1,0 +1,139 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GATES = ROOT / "research" / "capability-notes" / "gates.json"
+SOURCES = ROOT / "research" / "capability-notes" / "sources.json"
+SCRIPT = ROOT / "scripts" / "research_gates.py"
+CAPABILITIES = ROOT / "helper" / "capabilities.json"
+ROUTER_SCRIPT = ROOT / "scripts" / "ecosystem_router.py"
+
+EXPECTED_GATES = {
+    "prose-specificity",
+    "voice-preservation",
+    "design-dials",
+    "structural-originality",
+    "reference-dna",
+    "contrast-discipline",
+    "evidence-traceability",
+    "bounded-verification",
+}
+
+
+def load_module(path: Path, name: str):
+    if not path.exists():
+        return None
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ResearchGateTests(unittest.TestCase):
+    def test_gate_registry_and_validator_exist(self):
+        self.assertTrue(GATES.exists(), "missing research/capability-notes/gates.json")
+        self.assertTrue(SCRIPT.exists(), "missing scripts/research_gates.py")
+
+    def test_expected_research_gates_are_first_class(self):
+        self.assertTrue(GATES.exists())
+        gates = json.loads(GATES.read_text())["gates"]
+        self.assertEqual(EXPECTED_GATES, set(gates))
+
+    def test_each_gate_has_complete_runtime_contract(self):
+        self.assertTrue(GATES.exists())
+        gates = json.loads(GATES.read_text())["gates"]
+        failures = []
+        for gate_id, gate in gates.items():
+            for field in ("sources", "stage", "severity", "owners", "local_behavior", "implementation_refs"):
+                value = gate.get(field)
+                if value in (None, "", []):
+                    failures.append(f"{gate_id}: missing {field}")
+            if gate.get("severity") not in ("blocking", "advisory"):
+                failures.append(f"{gate_id}: invalid severity")
+        self.assertEqual([], failures)
+
+    def test_gate_sources_exist_in_provenance_snapshot(self):
+        self.assertTrue(GATES.exists())
+        source_names = {item["name"] for item in json.loads(SOURCES.read_text())["sources"]}
+        failures = []
+        for gate_id, gate in json.loads(GATES.read_text())["gates"].items():
+            missing = sorted(set(gate["sources"]) - source_names)
+            if missing:
+                failures.append(f"{gate_id}: unknown sources {missing}")
+        self.assertEqual([], failures)
+
+    def test_gate_implementation_refs_exist(self):
+        self.assertTrue(GATES.exists())
+        failures = []
+        for gate_id, gate in json.loads(GATES.read_text())["gates"].items():
+            for relative in gate["implementation_refs"]:
+                if not (ROOT / relative).exists():
+                    failures.append(f"{gate_id}: missing {relative}")
+        self.assertEqual([], failures)
+
+    def test_gate_owners_are_real_shipping_agents(self):
+        self.assertTrue(GATES.exists())
+        graph = json.loads((ROOT / "architecture" / "plugin-graph.json").read_text())
+        agents = set(graph["agents"])
+        workflow = graph["workflows"]["new-post"]
+        shipping = set(workflow["sequence"]) | {
+            edge["agent"] for edge in workflow.get("conditional", {}).values()
+        }
+        failures = []
+        for gate_id, gate in json.loads(GATES.read_text())["gates"].items():
+            owners = set(gate["owners"])
+            unknown = sorted(owners - agents)
+            if unknown:
+                failures.append(f"{gate_id}: unknown owners {unknown}")
+            if not owners & shipping:
+                failures.append(f"{gate_id}: no shipping owner")
+        self.assertEqual([], failures)
+
+    def test_helper_capabilities_reference_known_research_gates(self):
+        self.assertTrue(GATES.exists())
+        known = set(json.loads(GATES.read_text())["gates"])
+        capabilities = json.loads(CAPABILITIES.read_text())["capabilities"]
+        failures = []
+        referenced = set()
+        for capability, contract in capabilities.items():
+            gates = contract.get("research_gates", [])
+            if not gates:
+                failures.append(f"{capability}: no research_gates")
+            unknown = sorted(set(gates) - known)
+            if unknown:
+                failures.append(f"{capability}: unknown gates {unknown}")
+            referenced.update(gates)
+        self.assertEqual([], failures)
+        self.assertEqual(EXPECTED_GATES, referenced)
+
+    def test_validator_reports_no_errors(self):
+        module = load_module(SCRIPT, "research_gates")
+        self.assertIsNotNone(module, "research gate validator missing")
+        self.assertEqual([], module.validate_research_gates(ROOT))
+
+    def test_router_returns_research_gates_for_create_route(self):
+        module = load_module(ROUTER_SCRIPT, "ecosystem_router")
+        route = module.route_request({"request": "Create an animated LinkedIn infographic"}, ROOT)
+        self.assertIn("research_gates", route)
+        self.assertIn("prose-specificity", route["research_gates"])
+        self.assertIn("design-dials", route["research_gates"])
+        self.assertIn("evidence-traceability", route["research_gates"])
+        self.assertIn("bounded-verification", route["research_gates"])
+
+    def test_reference_route_activates_reference_dna_gate(self):
+        module = load_module(ROUTER_SCRIPT, "ecosystem_router")
+        route = module.route_request(
+            {"request": "Study this reference and build a post", "visual_reference": True}, ROOT
+        )
+        self.assertIn("reference-dna", route["research_gates"])
+
+    def test_adoption_matrix_names_runtime_gate_ids(self):
+        text = (ROOT / "research" / "capability-notes" / "adoption-matrix.md").read_text()
+        for gate_id in EXPECTED_GATES:
+            self.assertIn(f"`{gate_id}`", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_research_gates.py
+++ b/tests/test_research_gates.py
@@ -91,7 +91,7 @@ class ResearchGateTests(unittest.TestCase):
                 failures.append(f"{gate_id}: no shipping owner")
         self.assertEqual([], failures)
 
-    def test_helper_capabilities_reference_known_research_gates(self):
+    def test_helper_capabilities_reference_known_research_gates_or_are_local_native(self):
         self.assertTrue(GATES.exists())
         known = set(json.loads(GATES.read_text())["gates"])
         capabilities = json.loads(CAPABILITIES.read_text())["capabilities"]
@@ -99,8 +99,11 @@ class ResearchGateTests(unittest.TestCase):
         referenced = set()
         for capability, contract in capabilities.items():
             gates = contract.get("research_gates", [])
-            if not gates:
-                failures.append(f"{capability}: no research_gates")
+            local_native = contract.get("local_native") is True
+            if not gates and not local_native:
+                failures.append(f"{capability}: neither research_gates nor local_native")
+            if gates and local_native:
+                failures.append(f"{capability}: cannot be both research-derived and local_native")
             unknown = sorted(set(gates) - known)
             if unknown:
                 failures.append(f"{capability}: unknown gates {unknown}")

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -1,0 +1,91 @@
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = ROOT / "skills"
+REQUIRED_SECTIONS = (
+    "Purpose",
+    "Use when",
+    "Inputs",
+    "Outputs",
+    "Procedure",
+    "HOLD conditions",
+    "Related components",
+    "Research gates",
+)
+
+
+class SkillContractTests(unittest.TestCase):
+    def test_every_public_skill_has_v3_contract_sections(self):
+        skills = sorted(SKILL_ROOT.glob("*/SKILL.md"))
+        self.assertGreaterEqual(len(skills), 10)
+        failures = []
+        for path in skills:
+            text = path.read_text()
+            for section in REQUIRED_SECTIONS:
+                if not re.search(rf"^## {re.escape(section)}\s*$", text, re.MULTILINE):
+                    failures.append(f"{path.parent.name}: missing {section}")
+        self.assertEqual([], failures)
+
+    def test_every_skill_frontmatter_has_name_and_description(self):
+        failures = []
+        for path in sorted(SKILL_ROOT.glob("*/SKILL.md")):
+            text = path.read_text()
+            if not text.startswith("---\n"):
+                failures.append(f"{path.parent.name}: missing frontmatter")
+                continue
+            frontmatter = text.split("---", 2)[1]
+            for key in ("name:", "description:"):
+                if key not in frontmatter:
+                    failures.append(f"{path.parent.name}: missing {key[:-1]}")
+        self.assertEqual([], failures)
+
+    def test_every_skill_points_to_helper_authority(self):
+        failures = []
+        for path in sorted(SKILL_ROOT.glob("*/SKILL.md")):
+            text = path.read_text()
+            if "helper/GUIDE.md" not in text:
+                failures.append(path.parent.name)
+        self.assertEqual([], failures, f"skills missing helper authority: {failures}")
+
+    def test_workflow_skills_name_parent_or_focused_execution(self):
+        expectations = {
+            "post": "routing entrypoint",
+            "new-post": "parent workflow",
+            "qa-post": "parent workflow",
+            "render-gif": "focused workflow",
+        }
+        for skill, needle in expectations.items():
+            text = (SKILL_ROOT / skill / "SKILL.md").read_text().lower()
+            self.assertIn(needle, text, skill)
+
+    def test_named_mascot_rules_remain_exact_svg_only(self):
+        for skill in ("mascots", "svg-mascot-animator"):
+            text = (SKILL_ROOT / skill / "SKILL.md").read_text().lower()
+            self.assertIn("exact svg", text, skill)
+            self.assertIn("hold", text, skill)
+
+    def test_research_derived_skills_name_gate_ids(self):
+        expectations = {
+            "caption": ("prose-specificity", "voice-preservation"),
+            "artboard": ("structural-originality", "contrast-discipline"),
+            "info-stories": ("design-dials", "structural-originality"),
+            "new-post": ("evidence-traceability", "bounded-verification"),
+            "qa-post": ("bounded-verification",),
+            "render": ("bounded-verification",),
+        }
+        for skill, gates in expectations.items():
+            text = (SKILL_ROOT / skill / "SKILL.md").read_text()
+            for gate in gates:
+                self.assertIn(f"`{gate}`", text, f"{skill}: missing {gate}")
+
+    def test_visual_creation_skills_name_plugin_local_defaults(self):
+        for skill in ("artboard", "info-stories", "new-post"):
+            text = (SKILL_ROOT / skill / "SKILL.md").read_text().lower()
+            self.assertIn("creative-attractive-restrained", text, skill)
+            self.assertIn("center-first", text, skill)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_visual_defaults.py
+++ b/tests/test_visual_defaults.py
@@ -1,0 +1,49 @@
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CAPABILITIES = ROOT / "helper" / "capabilities.json"
+DESIGN_GATES = ROOT / "skills" / "info-stories" / "references" / "design-taste-gates.md"
+
+
+class VisualDefaultTests(unittest.TestCase):
+    def test_design_taste_declares_plugin_wide_visual_defaults(self):
+        design_taste = json.loads(CAPABILITIES.read_text())["capabilities"]["design-taste"]
+        defaults = design_taste.get("local_defaults", {})
+        self.assertEqual("creative-attractive-restrained", defaults.get("palette_character"))
+        self.assertEqual("center-first", defaults.get("composition_alignment"))
+        exceptions = set(defaults.get("alignment_exceptions", []))
+        for expected in ("tables", "ui-mockups", "code-or-terminal", "timelines", "arabic-rtl", "reference-dna"):
+            self.assertIn(expected, exceptions)
+
+    def test_design_gate_documents_restrained_color_and_center_first_rule(self):
+        text = DESIGN_GATES.read_text().lower()
+        self.assertIn("creative-attractive-restrained", text)
+        self.assertIn("center-first", text)
+        self.assertIn("avoid exaggerated saturation", text)
+        self.assertIn("alignment exception", text)
+
+    def test_shipping_visual_workers_enforce_defaults(self):
+        expectations = {
+            "palette-curator": ("creative-attractive-restrained", "avoid exaggerated saturation"),
+            "layout-composer": ("center-first", "alignment exception"),
+            "artboard-builder": ("center-first", "creative-attractive-restrained"),
+            "post-critic": ("center-first", "exaggerated saturation"),
+        }
+        failures = []
+        for agent, needles in expectations.items():
+            text = (ROOT / "agents" / f"{agent}.md").read_text().lower()
+            for needle in needles:
+                if needle not in text:
+                    failures.append(f"{agent}: missing {needle}")
+        self.assertEqual([], failures)
+
+    def test_helper_guide_names_center_first_default(self):
+        text = (ROOT / "helper" / "GUIDE.md").read_text().lower()
+        self.assertIn("center-first", text)
+        self.assertIn("creative-attractive-restrained", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/route_request.py
+++ b/tools/route_request.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.ecosystem_router import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(["route", *sys.argv[1:]]))


### PR DESCRIPTION
## Goal

Ship the full ecosystem v3 upgrade for the LinkedIn animated infographics plugin: one LLM routing helper, executable skill/agent contracts, active research-derived gates, creative concept generation, strict module validation, refreshed public docs, and a same-repository Claude Marketplace 3.0.0 release.

## Architecture

- `helper/` is the routing authority: routes, capabilities, local quality gates, artifacts, and active module inventory
- `architecture/plugin-graph.json` owns executable agent order and skill preloads
- `research/capability-notes/gates.json` turns adopted research into runtime gates with provenance, stages, owners, and local implementation refs
- `scripts/ecosystem_doctor.py` is the strict reality gate for declared/reachable/tested public modules and cross-registry consistency
- Info-stories remains authoritative through the merged `scripts/info_stories.py::load_catalog()` registry

## Creative runtime

- adds `creative-director` between evidence checking and story architecture
- requires multiple evidence-safe directions with visual hook, copy hook, aha mechanic, story shape, recommendations, dependencies, and risks
- adds blocking `hooked-design-copy` and `creative-payoff` gates
- keeps palettes `creative-attractive-restrained`
- makes composition `center-first` unless a documented comprehension/fidelity exception applies
- preserves exact-SVG identity for named/official mascots
- keeps UI Mockup Stories evidence-backed and feed-legible

## Research gates

Runtime gates:

`prose-specificity`, `voice-preservation`, `design-dials`, `structural-originality`, `reference-dna`, `contrast-discipline`, `evidence-traceability`, `bounded-verification`.

All five inspected upstream sources retain repository URL, exact inspected SHA, MIT license, local Adopt/Adapt/Reject notes, and shipping owners. Upstream working copies remain ignored and are not packaged.

## Public contracts

- all 12 public Skills follow the v3 contract
- all 15 Agents follow the v3 worker contract
- all 7 public Python tools are declared in `helper/modules.json`
- root `AGENTS.md`, `CLAUDE.md`, Codex/Claude convention guidance, README, and focused docs point to the same helper/research/module authority
- plugin + marketplace plugin entry are version `3.0.0`

## Review fixes and hardening

- Qodo: fixed repo-relative mascot SVG resolution so paths resolve against the routing root instead of process CWD
- Qodo: added required router-condition IDs, minimal condition schemas, and fail-fast `ValueError` behavior for malformed manifests
- focused mascot routes now HOLD when an SVG path string does not resolve to a real `.svg` file
- strict doctor and research validators reject absolute or parent-traversal paths that escape the repository
- GitHub Actions are pinned to the exact action SHAs verified in CI and the validation job has a 15-minute timeout

## Verification on current head

- complete unit suite passed; 4 intentional skips cover ignored local upstream research clones that are intentionally not shipped
- Python compile passed
- Info-stories registry passed
- ecosystem router passed
- research gates passed
- executable plugin graph passed
- strict ecosystem doctor passed
- marketplace contract passed
- JSON/hook/shell checks passed
- whitespace integrity passed
- current Claude Code installed in CI
- official `claude plugin validate .` passed
- same-repository marketplace add/list/install smoke passed for `linkedin-animated-infographics@mamdouh-creative-tools`
- Qlty status: success
- CodeRabbit status context: success; the requested fresh detailed review comment was rate-limited, so this PR does not claim a fresh full CodeRabbit review of the final head
- Qodo review findings: fixed and all review threads resolved

Do not merge if the PR head moves or a new blocking review/check appears.

## Design records

See:

- `docs/superpowers/specs/2026-08-07-ecosystem-routing-kernel-v3-design.md`
- `docs/superpowers/specs/2026-08-07-ecosystem-creative-runtime-addendum.md`
- `docs/superpowers/plans/2026-08-07-ecosystem-routing-kernel-v3.md`
- `docs/superpowers/plans/2026-08-07-ecosystem-creative-runtime-addendum.md`