### PR TITLE
docs: make README showcase the wow and aha experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
-# linkedin-animated-infographics
+<div align="center">
 
-A Claude Code plugin for designing, validating, rendering, and animating evidence-safe LinkedIn infographics with structured Info-stories, creative concept development, UI mockup stories, exact-SVG mascots, Arabic/RTL support, deterministic GIF rendering, and strict repository validation.
+# LinkedIn Animated Infographics
 
-Current plugin release: **3.0.0**
+**Turn evidence into a visual story with a sharp hook, a memorable reveal, and motion that earns its place**
+
+`Claude Code Plugin 3.0.0` · `1080×1350` · `Info-stories` · `UI stories` · `Exact-SVG mascots` · `Arabic / RTL`
+
+<br>
+
+<a href="./assets/demo_artboard_v4.gif">
+  <img src="./assets/demo_artboard_v4.gif" alt="Animated LinkedIn infographic demo generated with the plugin" width="720">
+</a>
+
+<sub>Live 1080×1350 demo · click the animation to open it full size</sub>
+
+</div>
+
+## The idea
+
+**WOW gets the scroll to stop  
+AHA makes the idea click**
+
+This plugin is built to earn both
+
+The **WOW moment** comes from a strong concept, distinctive composition, confident color, a clear visual anchor, and motion with timing and purpose
+
+The **AHA moment** comes when the visual changes understanding through a reveal, comparison, relationship, transformation, state change, interface sequence, or another useful payoff
+
+If an effect looks impressive but does not make the idea clearer, more memorable, or easier to understand, it does not count as the payoff
+
+That principle is enforced before layout by the `creative-director`, then checked again through story, layout, motion, review, and verification
 
 ## Install from Claude Marketplace
 
@@ -11,32 +38,93 @@ Current plugin release: **3.0.0**
 /plugin install linkedin-animated-infographics@mamdouh-creative-tools
 ```
 
-The marketplace and plugin live in this same repository. Validate a local checkout with:
+The marketplace and plugin live in this repository
+
+Validate a local checkout with
 
 ```bash
 claude plugin validate .
 ```
 
-## What v3 adds
+## What the plugin is trying to make
 
-The repository is now one connected production ecosystem instead of a loose collection of prompts and workers.
+Not another generic card stack with animated decoration
 
-- `helper/` is the LLM routing and guidance authority
-- `creative-director` develops multiple evidence-safe concepts before story architecture
-- attention-bearing design copy uses `hooked-design-copy`
-- complete concepts require a useful `creative-payoff`, not decorative spectacle
-- palette default is `creative-attractive-restrained`
-- composition default is `center-first`, with documented comprehension/fidelity exceptions
-- `research/` ships as active runtime capability gates with provenance and real owners
-- named or official mascots require the exact user-supplied/task-attached SVG
-- UI Mockup Stories are first-class Info-stories with evidence and feed-width fidelity rules
-- `scripts/ecosystem_doctor.py` rejects dead, undeclared, unreachable, untested, or disconnected public modules
+A finished post should have
 
-## Quick architecture
+| Job | What the plugin looks for |
+| --- | --- |
+| **Hook** | A headline or opening frame that earns attention through specificity, tension, outcome, recognition, or useful surprise |
+| **Visual idea** | One dominant concept that the reader can understand at feed scale |
+| **WOW moment** | A visual or motion payoff that feels fresh without becoming excessive |
+| **AHA moment** | A reveal that adds understanding instead of simply adding movement |
+| **Story shape** | A deliberate sequence such as comparison, transformation, state change, process, interface story, proof view, or framework |
+| **Color** | Creative, attractive, restrained palettes with enough character to feel designed |
+| **Composition** | Center-first by default, with alignment exceptions only when content, fidelity, or reading order benefits |
+| **Motion** | Seekable, deterministic movement tied to meaning rather than constant activity |
+| **Evidence** | Claims, product states, metrics, logos, and proof tied back to supplied material |
+| **Finish** | Mechanical QA, adversarial critique, and independent verification before delivery |
 
-Read [`helper/GUIDE.md`](helper/GUIDE.md) before choosing a workflow or worker.
+## Creative runtime
 
-The complete production path is:
+Before story architecture hardens, `creative-director` produces at least three genuinely different directions in `build/creative-concepts.json`
+
+Each direction defines
+
+- visual hook
+- copy hook
+- aha mechanic
+- story shape
+- recommended Visual Style
+- recommended Story Archetype
+- recommended motion behavior
+- evidence dependencies
+- risks
+- why the direction earns attention
+
+At least one direction must contain a useful visual payoff rather than a palette variation or decorative treatment
+
+The local creative gates include `hooked-design-copy`, `creative-payoff`, `restrained-palette`, and `center-first-composition`
+
+## Info-stories
+
+Info-stories separates four decisions that are often mixed together
+
+1. **Story House** for the visual language and palette character
+2. **Visual Style** for composition grammar
+3. **Story Archetype** for the information structure
+4. **Motion Pattern** for how attention moves through the story
+
+The source of truth is the merged registry returned by `scripts/info_stories.py::load_catalog()`
+
+UI Mockup Stories are first-class story options, including
+
+- UI Storyboard
+- Interface Cutaway
+- Screen to Outcome
+- Inside the Interface
+- State Change Story
+- Cursor Focus
+- State Transition
+
+Real-looking product behavior stays evidence-backed, while concept UI is identified when readers could mistake it for documented product behavior
+
+## Exact-SVG mascots
+
+Named or official mascots use the **exact SVG supplied by the user or attached to the task**
+
+The plugin does not silently redraw, approximate, replace, or generate a lookalike
+
+The mascot path inspects the supplied SVG, finds addressable geometry, develops a communication-led motion direction, preserves the source identity, integrates the animation, and checks the result against the untouched asset
+
+```bash
+python3 scripts/mascot_contract.py directions
+python3 scripts/mascot_contract.py check build/mascot-request.json
+```
+
+## The connected production path
+
+Read [`helper/GUIDE.md`](helper/GUIDE.md) before choosing a workflow or worker
 
 ```text
 design-study
@@ -56,57 +144,32 @@ design-study
   -> story-verifier
 ```
 
-`new-post` is the parent workflow. Agents return bounded artifacts to it; they do not secretly orchestrate peer agents.
+`new-post` is the parent workflow
 
-## Creative runtime
+Workers return bounded artifacts to the parent instead of coordinating peers through hidden handoffs
 
-Before layout starts, `creative-director` produces at least three genuinely different directions in `build/creative-concepts.json`. Every direction includes a visual hook, copy hook, aha mechanic, story shape, recommended visual style/archetype/motion, evidence dependencies, risks, and a reason it earns attention.
+## Research that actually runs
 
-A useful wow/aha moment can be a reveal, relationship, comparison, transformation, state change, or interaction that makes the idea easier to understand or remember. It is not a license for random 3D, glow, extreme saturation, arbitrary asymmetry, or excessive motion.
+The `research/` directory is active production guidance rather than background reading
 
-Design copy follows one strong-hook principle: hero/opening copy should earn attention through specificity, supported tension, concrete outcome, recognizable problem, useful surprise, or strong framing. Literal labels, commands, table headers, and UI controls stay literal when clarity is the job.
+Current runtime gates
+
+`prose-specificity` · `voice-preservation` · `design-dials` · `structural-originality` · `reference-dna` · `contrast-discipline` · `evidence-traceability` · `bounded-verification`
+
+Each adopted gate keeps source provenance, inspected commit SHA, local behavior, stage, severity, real owners, implementation references, and tests
+
+Upstream working copies are research inputs only and are not packaged as runtime dependencies
 
 ## Visual defaults
 
 - Palette character: `creative-attractive-restrained`
 - Composition: `center-first`
-- Text contrast: 4.5:1 floor for meaningful text
-- State-defining contrast: 3:1 floor
-- One clear visual anchor at feed scale
+- Text contrast: `4.5:1` minimum for meaningful text
+- State-defining contrast: `3:1` minimum
+- One dominant visual anchor at feed scale
+- Motion intensity resolved from the story rather than added by default
 
-Alignment can move away from center-first when the content genuinely benefits, including tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or documented reference-DNA decisions.
-
-## Info-stories
-
-Info-stories resolves four independent choices:
-
-1. Story House
-2. Visual Style
-3. Story Archetype
-4. Motion Pattern
-
-The source of truth is the merged registry returned by `scripts/info_stories.py::load_catalog()`, combining the stable base with first-party extensions.
-
-UI Mockup Stories include UI Storyboard, Interface Cutaway, Screen to Outcome, Inside the Interface, State Change Story, Cursor Focus, and State Transition. Real-looking product behavior must be evidence-backed; conceptual UI must be identifiable when readers could mistake it for product proof.
-
-## Exact-SVG mascots
-
-If the user names a specific or official mascot, the plugin requires the **exact SVG** supplied by the user or attached to the task. It does not redraw, approximate, substitute, or generate a lookalike automatically.
-
-The mascot path inspects the real SVG, identifies addressable geometry, selects a communication-led creative direction, preserves identity, integrates motion, and verifies the result against the untouched source.
-
-```bash
-python3 scripts/mascot_contract.py directions
-python3 scripts/mascot_contract.py check build/mascot-request.json
-```
-
-## Research gates
-
-Tracked research is active production guidance. The current runtime gates are:
-
-`prose-specificity`, `voice-preservation`, `design-dials`, `structural-originality`, `reference-dna`, `contrast-discipline`, `evidence-traceability`, and `bounded-verification`.
-
-Each gate has source provenance, a local independently-worded behavior, stage, severity, real shipping owners, implementation references, and tests. Ignored upstream working copies are never packaged with the plugin.
+Center-first can be overridden when comprehension or fidelity genuinely improves, including tables, UI mockups, terminal surfaces, timelines, Arabic / RTL reading flow, or a documented reference-DNA decision
 
 ## Workflows
 
@@ -116,13 +179,15 @@ Each gate has source provenance, a local independently-worded behavior, stage, s
 /linkedin-animated-infographics:qa-post     [path.html] [caption.md]
 ```
 
-For programmatic routing:
+Programmatic routing
 
 ```bash
 python3 tools/route_request.py --request "Create an animated LinkedIn infographic"
 ```
 
 ## Strict validation
+
+The repository treats disconnected capabilities as failures rather than documentation debt
 
 ```bash
 python3 -m unittest discover -s tests -v
@@ -136,9 +201,11 @@ python3 scripts/validate_marketplace.py
 claude plugin validate .
 ```
 
-The CI also registers the checked-out repository as marketplace `mamdouh-creative-tools` and installs `linkedin-animated-infographics@mamdouh-creative-tools` in a clean Claude home.
+`scripts/ecosystem_doctor.py` rejects dead, undeclared, unreachable, untested, disconnected, or unsafe public modules and manifest references
 
-Useful public tools include:
+CI also registers the checked-out repository as marketplace `mamdouh-creative-tools` and installs `linkedin-animated-infographics@mamdouh-creative-tools` into a clean Claude home
+
+## Public tools
 
 ```text
 tools/story_scaffold.py
@@ -152,7 +219,7 @@ tools/route_request.py
 
 ## Documentation
 
-- [Ecosystem architecture](docs/ecosystem.md)
+- [Architecture](docs/ecosystem.md)
 - [Routing protocol](docs/routing.md)
 - [Agents](docs/agents.md)
 - [Skills](docs/skills.md)
@@ -160,9 +227,9 @@ tools/route_request.py
 - [Claude Marketplace](docs/marketplace.md)
 - [Development and validation](docs/development.md)
 
-## Development entrypoints
+Coding agents should also read [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md)
 
-Coding agents should also read [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md). Both point back to the same helper, research, module, and validation authority.
+Both point back to the same helper, research, module, and validation authority
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@
 
 ## The idea
 
-**WOW gets the scroll to stop  
-AHA makes the idea click**
+<strong>WOW gets the scroll to stop<br>AHA makes the idea click</strong>
 
 This plugin is built to earn both
 


### PR DESCRIPTION
## Goal

Turn the README into a product showcase rather than a dense manual, while preserving every v3 install, routing, validation, and documentation contract

## What changed

- adds the real `assets/demo_artboard_v4.gif` as the centered hero demo
- keeps the original GIF file intact and links the preview to the full-size asset
- reframes the product around two outcomes: WOW stops the scroll, AHA improves understanding
- explains what qualifies as a useful wow/aha payoff and what does not
- surfaces `creative-director`, hook-driven design copy, Info-stories, UI Mockup Stories, exact-SVG mascots, research gates, center-first composition, restrained creative palettes, and strict validation
- keeps Marketplace install commands and all focused docs links
- no plugin/runtime version change because this is a documentation/demo-only update

## Verification intent

Do not merge unless the existing docs contract tests and full Claude plugin validation workflow remain green