### PR TITLE
feat: add native Codex plugin compatibility

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "mamdouh-creative-tools",
+  "interface": {
+    "displayName": "Mamdouh Creative Tools"
+  },
+  "plugins": [
+    {
+      "name": "linkedin-animated-infographics",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,8 @@
       "name": "linkedin-animated-infographics",
       "source": "./",
       "strict": true,
-      "version": "3.1.0",
-      "description": "Create LinkedIn Info-stories with LLM routing, creative concepting, research gates, exact-SVG mascots, UI stories, strict QA, and opt-in community demo publishing.",
+      "version": "3.2.0",
+      "description": "Create LinkedIn Info-stories with creative concepting, research gates, exact-SVG mascots, UI stories, strict QA, and opt-in community demo publishing.",
       "author": {
         "name": "Mamdouh Aboammar",
         "url": "https://github.com/imMamdouhaboammar"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-animated-infographics",
-  "description": "Claude Code plugin for creative LinkedIn infographics with LLM routing, Info-stories, research gates, UI stories, exact-SVG mascots, deterministic rendering, strict QA, and opt-in community demo publishing.",
-  "version": "3.1.0",
+  "description": "Claude Code package for animated LinkedIn visual stories with shared LLM routing, Info-stories, creative direction, research gates, exact-SVG mascots, deterministic rendering, strict QA, and opt-in community demo publishing.",
+  "version": "3.2.0",
   "author": {
     "name": "Mamdouh Aboammar",
     "url": "https://github.com/imMamdouhaboammar"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "linkedin-animated-infographics",
+  "version": "3.2.0",
+  "description": "Create animated LinkedIn visual stories with sharp hooks, useful reveals, deterministic motion, strict QA, and opt-in community publishing.",
+  "author": {
+    "name": "Mamdouh Aboammar",
+    "url": "https://github.com/imMamdouhaboammar"
+  },
+  "homepage": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
+  "repository": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
+  "license": "MIT",
+  "keywords": [
+    "linkedin",
+    "infographic",
+    "animation",
+    "visual-storytelling",
+    "info-stories",
+    "creative-direction",
+    "community-demos",
+    "arabic",
+    "rtl"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "LinkedIn Animated Infographics",
+    "shortDescription": "Turn ideas into animated LinkedIn visual stories",
+    "longDescription": "Build feed-ready animated infographics with concept exploration, hook-driven copy, Info-stories, evidence checks, deterministic motion, QA, exact-SVG mascot handling, Arabic/RTL support, and optional community demo publishing.",
+    "developerName": "Mamdouh Aboammar",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
+    "privacyPolicyURL": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics/blob/main/PRIVACY.md",
+    "termsOfServiceURL": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics/blob/main/TERMS.md",
+    "defaultPrompt": [
+      "Turn this idea into an animated LinkedIn infographic with a strong visual hook and a useful aha moment.",
+      "Create an Info-story from this material and choose the best story shape before designing it.",
+      "Review this finished LinkedIn infographic and tell me what must be fixed before publishing.",
+      "Prepare this verified demo for the community gallery and ask before publishing anything."
+    ],
+    "screenshots": ["./assets/demo_artboard_v4.gif"]
+  }
+}

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -2,9 +2,11 @@
 
 This supplements the root `AGENTS.md`. The repository-specific operating authority is `helper/GUIDE.md`.
 
+Codex and Claude are first-class hosts for the same product core. Do not fork the workflows or create a Codex-only copy of `skills/`.
+
 ## Required authority
 
-Before changing routing, skills, agents, tools, research, or marketplace packaging, read:
+Before changing routing, skills, agents, tools, research, packaging, or distribution, read:
 
 - `helper/GUIDE.md`
 - `helper/router.json`
@@ -14,14 +16,27 @@ Before changing routing, skills, agents, tools, research, or marketplace packagi
 - `helper/modules.json`
 - `research/capability-notes/gates.json`
 - `architecture/plugin-graph.json`
+- `compatibility/codex.json`
 
 Use the merged Info-stories registry from `scripts/info_stories.py::load_catalog()` rather than treating `catalog.json` alone as the source of truth.
 
+## OpenAI plugin surfaces
+
+- `.codex-plugin/plugin.json` is the native OpenAI plugin manifest
+- `.agents/plugins/marketplace.json` is the repository marketplace for Codex and ChatGPT
+- `skills/` is the canonical bundled skill root for both OpenAI and Claude packaging
+- `scripts/validate_codex_plugin.py` is the OpenAI packaging/parity gate
+- `.codex/config.toml` and `.codex/agents/*.toml` are repository-development configuration only; installed plugin behavior must not depend on them
+
+Public OpenAI submission materials live under `submission/`. They prepare the package for review but do not mean the plugin has been submitted or published.
+
 ## Execution model
 
-`new-post` is the parent workflow. Subtasks return bounded artifacts to it; no worker coordinates peer workers through hidden delegation.
+`new-post` is the production parent workflow. Subtasks return bounded artifacts to it; no worker coordinates peer workers through hidden delegation.
 
 The complete path includes `creative-director` after evidence gathering and before story architecture. The creative worker supplies evidence-safe concepts, copy/visual hooks, and a useful aha mechanic before downstream story/layout/motion decisions.
+
+After final verification and delivery, `new-post` may offer community sharing. `share-demo` runs only after explicit user consent, validates the public package, and delegates GitHub contribution mechanics to `community-publisher`. Community publication stops at an open PR for maintainer manual review and merge.
 
 Plugin-local defaults:
 
@@ -33,6 +48,18 @@ Plugin-local defaults:
 
 Research-derived gates remain active through `research/capability-notes/gates.json`.
 
+## Codex subagents
+
+Current Codex releases can delegate when a user, `AGENTS.md`, or a Skill requests subagents. Use project-scoped `.codex/agents/` only for repository maintenance tasks such as exploration, review, and documentation verification.
+
+The canonical product workers remain `agents/*.md` plus `architecture/plugin-graph.json`. Codex subagents may help execute bounded work, but they must return to the parent workflow and must not create a parallel product orchestration model. Sequential execution remains a valid fallback when delegation is unavailable or unnecessary.
+
+Project maintenance agents are intentionally narrow:
+
+- `explorer`: read-only execution-path evidence
+- `reviewer`: read-only correctness/security/test review
+- `docs_researcher`: read-only primary-documentation verification
+
 ## Strict validation
 
 Run:
@@ -43,14 +70,16 @@ python3 scripts/ecosystem_router.py check
 python3 scripts/research_gates.py check
 python3 scripts/plugin_graph.py check
 python3 scripts/ecosystem_doctor.py check
+python3 scripts/demo_gallery.py check
 python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
 ```
 
-`scripts/ecosystem_doctor.py` is the strict reality gate for module existence, reachability, ownership, artifacts, tests, and cross-registry drift.
+`scripts/ecosystem_doctor.py` is the strict runtime reality gate. `scripts/validate_codex_plugin.py` checks native OpenAI packaging, marketplace structure, Codex project config, and cross-host parity.
 
 ## Repo skills
 
 - Generic/coding-agent conventions: `.agents/skills/linkedin-animated-infographics/SKILL.md`
 - Claude-facing companion: `.claude/skills/linkedin-animated-infographics/SKILL.md`
 
-Keep user credentials and private MCP configuration outside the repository. Do not fabricate claims, UI behavior, proof, or mascot assets to satisfy a build.
+Keep user credentials and private MCP configuration outside the repository. Do not fabricate claims, UI behavior, proof, or mascot assets to satisfy a build. Do not publish a community demo without explicit user consent and export validation.

--- a/.codex/agents/docs-researcher.toml
+++ b/.codex/agents/docs-researcher.toml
@@ -1,9 +1,0 @@
-model = "gpt-5.4"
-model_reasoning_effort = "medium"
-sandbox_mode = "read-only"
-
-developer_instructions = """
-Verify APIs, framework behavior, and release-note claims against primary documentation before changes land.
-Cite the exact docs or file paths that support each claim.
-Do not invent undocumented behavior.
-"""

--- a/.codex/agents/docs_researcher.toml
+++ b/.codex/agents/docs_researcher.toml
@@ -1,0 +1,15 @@
+name = "docs_researcher"
+description = "Read-only documentation specialist for version-specific API, plugin, framework, and release behavior."
+model = "gpt-5.6-luna"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Verify API, plugin, framework, and release claims against primary documentation before changes land.
+Prefer official current documentation and record exact URLs or references that support each claim.
+Call out version-sensitive or uncertain behavior explicitly.
+Do not edit repository files or invent undocumented behavior.
+"""
+
+[mcp_servers.openaiDeveloperDocs]
+url = "https://developers.openai.com/mcp"

--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,9 +1,13 @@
-model = "gpt-5.4"
+name = "explorer"
+description = "Read-only codebase explorer for gathering evidence before changes are proposed."
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 
 developer_instructions = """
 Stay in exploration mode.
-Trace the real execution path, cite files and symbols, and avoid proposing fixes unless the parent agent asks for them.
-Prefer targeted search and file reads over broad scans.
+Read helper/GUIDE.md before reasoning about product behavior.
+Trace real execution paths through skills, helper registries, agents, scripts, tests, and the plugin graph.
+Return concise evidence with exact file and symbol references.
+Do not edit files or propose implementation until the parent asks for options.
 """

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,9 +1,13 @@
-model = "gpt-5.4"
+name = "reviewer"
+description = "Read-only reviewer focused on correctness, security, behavior regressions, and missing tests."
+model = "gpt-5.6"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 
 developer_instructions = """
-Review like an owner.
-Prioritize correctness, security, behavioral regressions, and missing tests.
-Lead with concrete findings and avoid style-only feedback unless it hides a real bug.
+Review like a repository owner.
+Read helper/GUIDE.md and the relevant tests before judging a change.
+Prioritize reproducible correctness bugs, security issues, broken contracts, behavioral regressions, and missing test coverage.
+Lead with concrete findings and reproduction evidence.
+Do not edit files, merge pull requests, or add style-only feedback unless it hides a real defect.
 """

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,6 @@
 #:schema https://developers.openai.com/codex/config-schema.json
 
-# ECC Tools generated Codex baseline
+# Repository-development Codex baseline. This file is not required by the installed plugin.
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 web_search = "live"
@@ -28,21 +28,6 @@ args = ["-y", "@playwright/mcp@latest", "--extension"]
 command = "npx"
 args = ["-y", "@modelcontextprotocol/server-sequential-thinking"]
 
-[features]
-multi_agent = true
-
 [agents]
-max_threads = 6
-max_depth = 1
-
-[agents.explorer]
-description = "Read-only codebase explorer for gathering evidence before changes are proposed."
-config_file = "agents/explorer.toml"
-
-[agents.reviewer]
-description = "PR reviewer focused on correctness, security, and missing tests."
-config_file = "agents/reviewer.toml"
-
-[agents.docs_researcher]
-description = "Documentation specialist that verifies APIs, framework behavior, and release notes."
-config_file = "agents/docs-researcher.toml"
+enabled = true
+max_concurrent_threads_per_session = 6

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -1,4 +1,4 @@
-name: Claude Plugin Validation
+name: Plugin Validation
 
 on:
   pull_request:
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Set up Node for Claude Code validator
+      - name: Set up Node for host validators
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
@@ -52,8 +52,11 @@ jobs:
       - name: Validate demo gallery
         run: python3 scripts/demo_gallery.py check
 
-      - name: Validate marketplace contract
+      - name: Validate Claude marketplace contract
         run: python3 scripts/validate_marketplace.py
+
+      - name: Validate Codex and OpenAI plugin contract
+        run: python3 scripts/validate_codex_plugin.py
 
       - name: Validate hook, JSON, and shell syntax
         run: |
@@ -65,6 +68,11 @@ jobs:
           python3 -m json.tool helper/modules.json >/dev/null
           python3 -m json.tool research/capability-notes/gates.json >/dev/null
           python3 -m json.tool schemas/demo.schema.json >/dev/null
+          python3 -m json.tool .codex-plugin/plugin.json >/dev/null
+          python3 -m json.tool .agents/plugins/marketplace.json >/dev/null
+          python3 -m json.tool compatibility/codex.json >/dev/null
+          python3 -m json.tool submission/openai-plugin.json >/dev/null
+          python3 -m json.tool submission/test-cases.json >/dev/null
           bash -n scripts/lint_artboard.sh
           bash -n scripts/setup.sh
 
@@ -77,7 +85,7 @@ jobs:
       - name: Run official Claude plugin validator
         run: claude plugin validate .
 
-      - name: Smoke-test marketplace registration and install
+      - name: Smoke-test Claude marketplace registration and install
         run: |
           export HOME="${RUNNER_TEMP}/claude-marketplace-smoke"
           mkdir -p "$HOME"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository Agent Guide
 
-This repository is an executable Claude/plugin ecosystem for evidence-safe LinkedIn infographics. Do not treat `skills/`, `agents/`, `research/`, or `tools/` as independent islands.
+This repository is an executable multi-host plugin ecosystem for evidence-safe LinkedIn infographics. Claude Code, Codex, and ChatGPT use package adapters around the same canonical product core. Do not treat `skills/`, `agents/`, `research/`, `helper/`, or `tools/` as independent islands.
 
 ## Start here
 
@@ -16,11 +16,14 @@ Machine-readable authority:
 - `research/capability-notes/gates.json`: adopted research-derived runtime gates
 - `architecture/plugin-graph.json`: executable worker order and skill preloads
 - `scripts/info_stories.py::load_catalog()`: merged Info-stories registry
+- `compatibility/codex.json`: OpenAI package/parity declaration
 
-Run the strict cross-repository validator after structural changes:
+Run the strict runtime and host-package validators after structural changes:
 
 ```bash
 python3 scripts/ecosystem_doctor.py check
+python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
 ```
 
 ## Complete production path
@@ -33,6 +36,8 @@ The complete path is:
 
 `creative-director` must generate evidence-safe concept directions before story architecture. Attention-bearing design copy follows `hooked-design-copy`, and a complete concept should produce a useful `creative-payoff` rather than decorative spectacle.
 
+After verified delivery, `share-demo` may run only with explicit user consent. Community publishing ends at an open contributor PR and requires maintainer manual review and merge.
+
 ## Product defaults
 
 - Palette default: `creative-attractive-restrained`
@@ -40,6 +45,15 @@ The complete path is:
 - Alignment exceptions are valid for tables, UI mockups, code/terminal surfaces, timelines, Arabic/RTL flow, or documented reference DNA when they improve comprehension/fidelity
 - Named or official mascots require the **exact SVG** supplied by the user/task. No automatic redraw, substitute, or lookalike
 - UI mockups that look real must be evidence-backed; conceptual UI must be identifiable when readers could mistake it for product proof
+
+## Host packaging
+
+- Claude Code: `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`
+- Codex/ChatGPT: `.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json`
+- canonical bundled workflows: `skills/`
+- Codex repo-development helpers: `.codex/config.toml` + `.codex/agents/*.toml`
+
+Do not create copied Codex-specific product Skills. The installed OpenAI plugin must not depend on the maintainer's `.codex/config.toml` or private MCP configuration.
 
 ## Research gates
 
@@ -58,7 +72,7 @@ Do not package ignored `research/upstreams/` clones. Keep source URL, inspected 
 3. Run focused tests
 4. Run the full suite and validators
 5. Update docs/manifest/version when public behavior changes
-6. Merge only after official Claude validation, same-repo marketplace install smoke, repository checks, and review findings are clean
+6. Merge only after exact-head host validation, available marketplace smoke checks, repository checks, and review findings are clean
 
 Minimum deterministic gate:
 
@@ -70,9 +84,11 @@ python3 scripts/ecosystem_router.py check
 python3 scripts/research_gates.py check
 python3 scripts/plugin_graph.py check
 python3 scripts/ecosystem_doctor.py check
+python3 scripts/demo_gallery.py check
 python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
 ```
 
 ## Safety
 
-Never commit credentials, private MCP data, or user secrets. Do not fabricate claims, metrics, logos, UI states, testimonials, product behavior, or evidence to satisfy a visual slot. Report browser/render environment blockers separately from non-browser validation.
+Never commit credentials, private MCP data, or user secrets. Do not fabricate claims, metrics, logos, UI states, testimonials, product behavior, or evidence to satisfy a visual slot. Report browser/render environment blockers separately from non-browser validation. Do not claim OpenAI public-directory publication until the external submission, review, and publication steps have actually completed.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,51 @@
+# Privacy Policy
+
+Last updated: August 8, 2026
+
+LinkedIn Animated Infographics is an open-source, skills-based plugin for ChatGPT, Codex, and Claude Code. Version 3.2.0 does not operate a maintainer-owned backend service and does not require a maintainer-hosted MCP server.
+
+## Data handled by the plugin
+
+The plugin provides instructions, local scripts, validators, templates, and repository assets. Content you give to ChatGPT, Codex, Claude Code, or another compatible host is handled by that host and by any tools or services you explicitly connect to it. Those services have their own privacy terms.
+
+The repository does not contain analytics code that sends prompts, generated content, or usage telemetry to a server operated by the maintainer.
+
+## Local files
+
+Generation and validation can read and write files in the workspace allowed by your host and its permission settings. Generated working artifacts may include HTML, GIF, PNG, JSON, Markdown, evidence notes, render reports, and verification reports.
+
+The community export flow is designed not to copy the complete working directory. It prepares only the public demo package described below.
+
+## Community demo publishing
+
+Community publishing is optional. A finished result is not submitted merely because it was generated or rendered.
+
+After final verification, the plugin may offer to share the demo. GitHub contribution work begins only after explicit user consent and rights confirmation.
+
+The public demo package contains exactly:
+
+- `demo.gif`
+- `index.html`
+- `demo.json`
+
+A generated `demos/catalog.json` change may also be included in the pull request. The export path checks for obvious credential markers, signed URLs, local absolute paths, and remote executable resources before publication.
+
+Source prompts are excluded by default. A source prompt may be included only when the user separately and explicitly consents to publish it.
+
+If GitHub publishing is approved, the plugin or coding host may use the user's authenticated GitHub tooling to create or reuse a contributor fork, create a branch, commit the approved demo package, push that branch, and open a pull request to `imMamdouhaboammar/linkedin-animated-infographics`. The publisher must stop at the pull request. Maintainer review and merge are manual.
+
+GitHub processes data involved in those operations under GitHub's own terms and privacy policies.
+
+## External tools
+
+Repository-development configuration may reference optional external tools such as GitHub, documentation services, browser tooling, or MCP servers. These are development conveniences, are not required by the installed skills-only plugin, and may have independent privacy policies.
+
+## Secrets and private material
+
+Do not place credentials, private keys, access tokens, confidential source material, or private URLs in content intended for community publication. The repository includes automated checks intended to catch common leakage patterns, but users remain responsible for reviewing material before making it public.
+
+## Changes and contact
+
+Material changes to this policy are tracked in the public repository history.
+
+For questions or reports, use the repository's GitHub Issues page: https://github.com/imMamdouhaboammar/linkedin-animated-infographics/issues

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Turn imagination into visual stories that stop the scroll and make the idea click**
 
-`Claude Code Plugin 3.1.0` · `1080×1350` · `Info-stories` · `UI stories` · `Exact-SVG mascots` · `Arabic / RTL`
+`Claude Code + Codex + ChatGPT · 3.2.0` · `1080×1350` · `Info-stories` · `Exact-SVG mascots` · `Arabic / RTL`
 
 <br>
 
@@ -28,11 +28,39 @@ The plugin aims for both
 
 If the effect looks good but adds no meaning, it is decoration
 
-`creative-director` develops the concept before layout starts, then the rest of the workflow tests whether the idea still works through copy, layout, motion, QA, and final verification
+`creative-director` develops the concept before layout starts, then the workflow tests whether the idea survives copy, layout, motion, QA, and final verification
+
+## Install
+
+The same canonical `skills/` power every supported host
+
+### Claude Code
+
+```text
+/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics
+/plugin install linkedin-animated-infographics@mamdouh-creative-tools
+```
+
+Validate a checkout with:
+
+```bash
+claude plugin validate .
+```
+
+### Codex + ChatGPT
+
+Add the repository marketplace:
+
+```bash
+codex plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics --ref main
+codex plugin marketplace list
+```
+
+The OpenAI package is `.codex-plugin/plugin.json`; the repo marketplace is `.agents/plugins/marketplace.json`. Installation and testing use a supported Plugins Directory surface
+
+[Codex / ChatGPT guide](docs/codex.md) · [Marketplace details](docs/marketplace.md)
 
 ## Demos
-
-Good outputs can live in the repo as working examples, not screenshots buried in a README
 
 There are two shelves:
 
@@ -41,26 +69,11 @@ There are two shelves:
 
 Every accepted demo is the same portable package: **GIF + HTML + demo.json**
 
-After a finished post reaches final verification `PASS`, the plugin can ask `Share this demo with the community?` If the user says yes, `share-demo` validates the public package and `community-publisher` can prepare a contributor fork, branch, commit, push, and pull request. It stops at the PR. Every contribution still needs maintainer manual review and merge
+After final verification `PASS`, the plugin can ask `Share this demo with the community?` If the user says yes, `share-demo` validates the public package and `community-publisher` can prepare a contributor fork, branch, commit, push, and pull request. It stops at the PR. Every contribution still needs maintainer manual review and merge
 
 [Browse the demo gallery](demos/README.md) · [Read the contribution contract](docs/community-demos.md)
 
-## Install from Claude Marketplace
-
-```text
-/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics
-/plugin install linkedin-animated-infographics@mamdouh-creative-tools
-```
-
-Validate a local checkout with
-
-```bash
-claude plugin validate .
-```
-
 ## What it makes
-
-Not a generic stack of cards with movement added at the end
 
 A strong output should have
 
@@ -81,18 +94,7 @@ A strong output should have
 
 Before story architecture starts, `creative-director` creates at least three genuinely different directions in `build/creative-concepts.json`
 
-Each direction defines
-
-- visual hook
-- copy hook
-- aha mechanic
-- story shape
-- Visual Style
-- Story Archetype
-- motion behavior
-- evidence dependencies
-- risks
-- why the idea deserves attention
+Each direction defines a visual hook, copy hook, aha mechanic, story shape, Visual Style, Story Archetype, motion behavior, evidence dependencies, risks, and why the idea deserves attention
 
 At least one direction must contain a real visual payoff, not a palette swap or a new card arrangement
 
@@ -100,7 +102,7 @@ The local gates are `hooked-design-copy`, `creative-payoff`, `restrained-palette
 
 ## Info-stories
 
-Info-stories separates four decisions
+Info-stories separates four decisions:
 
 1. **Story House** for visual character and palette
 2. **Visual Style** for composition grammar
@@ -109,19 +111,7 @@ Info-stories separates four decisions
 
 The source of truth is the merged registry returned by `scripts/info_stories.py::load_catalog()`
 
-UI Mockup Stories are first-class options
-
-- UI Storyboard
-- Interface Cutaway
-- Screen to Outcome
-- Inside the Interface
-- State Change Story
-- Cursor Focus
-- State Transition
-
-Real-looking product behavior must be supported by evidence
-
-Concept UI stays clearly identifiable when it could be mistaken for real product proof
+UI Mockup Stories are first-class options. Real-looking product behavior must be supported by evidence. Concept UI stays clearly identifiable when it could be mistaken for real product proof
 
 ## Exact-SVG mascots
 
@@ -169,13 +159,11 @@ Workers return artifacts to their parent instead of coordinating peers through h
 
 `research/` is part of production logic, not a reading folder
 
-Current gates
+Current gates:
 
 `prose-specificity` · `voice-preservation` · `design-dials` · `structural-originality` · `reference-dna` · `contrast-discipline` · `evidence-traceability` · `bounded-verification`
 
 Each adopted gate keeps source provenance, inspected commit SHA, local behavior, stage, severity, owners, implementation references, and tests
-
-Upstream working copies are research inputs only and are not packaged as runtime dependencies
 
 ## Visual defaults
 
@@ -197,7 +185,7 @@ Center-first can be overridden when comprehension or fidelity improves, includin
 /linkedin-animated-infographics:share-demo  [build directory]
 ```
 
-Programmatic routing
+Programmatic routing:
 
 ```bash
 python3 tools/route_request.py --request "Create an animated LinkedIn infographic"
@@ -217,12 +205,19 @@ python3 scripts/plugin_graph.py check
 python3 scripts/ecosystem_doctor.py check
 python3 scripts/demo_gallery.py check
 python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
 claude plugin validate .
 ```
 
 `scripts/ecosystem_doctor.py` rejects dead, undeclared, unreachable, untested, disconnected, or unsafe public modules and manifest references
 
-CI also registers the checkout as marketplace `mamdouh-creative-tools` and installs `linkedin-animated-infographics@mamdouh-creative-tools` into a clean Claude home
+`scripts/validate_codex_plugin.py` rejects OpenAI packaging, marketplace, Codex configuration, submission-readiness, or cross-host parity drift
+
+## Public Plugins Directory
+
+The 3.2.0 OpenAI package is **submission-ready**, not claimed as published
+
+`submission/` tracks listing metadata, five positive reviewer cases, three negative cases, and the manual OpenAI Platform handoff. Public availability still requires external publisher verification/permissions, OpenAI review, and publication after approval
 
 ## Public tools
 
@@ -244,10 +239,11 @@ scripts/demo_submit.py
 - [Routing protocol](docs/routing.md)
 - [Agents](docs/agents.md)
 - [Skills](docs/skills.md)
+- [Codex + ChatGPT](docs/codex.md)
 - [Community demos](docs/community-demos.md)
 - [Demo gallery](demos/README.md)
 - [Research gates and provenance](docs/research.md)
-- [Claude Marketplace](docs/marketplace.md)
+- [Marketplace packaging](docs/marketplace.md)
 - [Development and validation](docs/development.md)
 
 Coding agents should also read [`AGENTS.md`](AGENTS.md) or [`CLAUDE.md`](CLAUDE.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Scope
+
+Security reports for LinkedIn Animated Infographics should focus on repository code and packaging that can expose data, execute unintended commands, bypass publication consent, escape repository or workspace boundaries, or weaken validation and contribution gates
+
+Relevant areas include:
+
+- public demo export and secret scanning
+- GitHub community publishing and fork/PR boundaries
+- hook command execution
+- path traversal and repository-bound file handling
+- plugin and marketplace manifests
+- scripts that read or write workspace files
+- unsafe remote executable resources in public demos
+
+## Reporting a vulnerability
+
+Do not post live credentials, private exploit details, customer data, or other sensitive material in a public issue
+
+If the repository's GitHub Security page offers a private vulnerability reporting option, use that channel. If no private reporting option is available, open a minimal public issue that asks the maintainer for a private contact path without including exploit details or sensitive data
+
+Repository: https://github.com/imMamdouhaboammar/linkedin-animated-infographics
+
+## What to include
+
+A useful report includes the affected version or commit, the vulnerable path or workflow, reproduction steps that do not expose real secrets, the expected security boundary, the observed behavior, and the likely impact
+
+Use synthetic credentials and redacted data in reproductions whenever possible
+
+## Maintainer handling
+
+Reports should be reproduced against the current supported release before a fix is claimed. Security fixes should include regression coverage when the behavior can be tested deterministically
+
+Do not weaken tests, disable validation, expose credentials, or bypass manual community-review requirements to make a security check pass
+
+## Supported release
+
+The current release line is 3.x. Security fixes are applied to the current maintained release rather than to every historical revision

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,25 @@
+# Support
+
+LinkedIn Animated Infographics is maintained as an open-source project.
+
+## Where to ask for help
+
+Use GitHub Issues for reproducible bugs, installation problems, compatibility regressions, validation failures, and documentation gaps:
+
+https://github.com/imMamdouhaboammar/linkedin-animated-infographics/issues
+
+For a useful report, include the host you are using (ChatGPT, Codex, Claude Code, or another compatible agent), the plugin version, the command or workflow that failed, the relevant error output, and a minimal reproduction when possible. Remove credentials, private URLs, client data, and other sensitive material before posting publicly.
+
+## Community demo submissions
+
+Community demo pull requests are reviewed manually. A generated pull request is not accepted automatically. Maintainers may request changes when attribution, rights confirmation, export safety, metadata, or gallery validation is incomplete.
+
+## Security and privacy reports
+
+Do not post live credentials or confidential exploit material in a public issue. Follow `SECURITY.md` for security reporting instructions when the report should not be public.
+
+Privacy behavior is documented in `PRIVACY.md` and community publishing rules are documented in `docs/community-demos.md`.
+
+## Scope
+
+Support covers the repository and its documented workflows. Availability or account-specific behavior of ChatGPT, Codex, Claude Code, GitHub, third-party MCP servers, and other external services is controlled by those providers.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,41 @@
+# Terms of Use
+
+Last updated: August 8, 2026
+
+These terms apply to the open-source LinkedIn Animated Infographics plugin and repository.
+
+## License
+
+The software is provided under the repository's MIT License. The MIT License governs permission to use, copy, modify, merge, publish, distribute, sublicense, and sell copies of the software, subject to its terms.
+
+## Your content and rights
+
+You are responsible for the material you provide to the plugin and for confirming that you have the rights needed to use, reproduce, modify, and publish that material.
+
+Do not use the plugin to publish confidential information, credentials, private URLs, third-party assets you cannot redistribute, fabricated evidence, or misleading representations of a real product or person.
+
+## Generated output
+
+Generated infographics, HTML, GIFs, captions, and other output should be reviewed before publication. Automated validation can catch defined classes of errors, but it does not guarantee factual accuracy, legal clearance, accessibility, platform acceptance, or business results.
+
+When the plugin uses evidence or reference material, the user remains responsible for the source material and the final publication decision.
+
+## Community gallery
+
+Submitting a demo to the community gallery is optional and requires explicit user consent and rights confirmation.
+
+A community submission is proposed through a GitHub pull request. The publisher must not auto-merge the pull request or push directly to upstream `main`. The maintainer may accept, reject, request changes to, or remove community material at their discretion.
+
+By submitting a community demo, the contributor represents that they have permission to publish the submitted `demo.gif`, `index.html`, and `demo.json` under the license stated in the demo metadata.
+
+## External services
+
+ChatGPT, Codex, Claude Code, GitHub, and any connected tools or services are provided by their respective operators and are subject to their own terms, permissions, and availability. This repository does not control those services.
+
+## No warranty
+
+The software is provided on an "as is" basis without warranty, consistent with the MIT License. Use it at your own risk and review outputs before relying on or publishing them.
+
+## Support
+
+Support and issue reporting are handled through the public repository: https://github.com/imMamdouhaboammar/linkedin-animated-infographics/issues

--- a/compatibility/codex.json
+++ b/compatibility/codex.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "plugin_name": "linkedin-animated-infographics",
+  "plugin_version": "3.2.0",
+  "surfaces": ["codex", "chatgpt"],
+  "manifests": {
+    "openai": ".codex-plugin/plugin.json",
+    "claude": ".claude-plugin/plugin.json",
+    "openai_marketplace": ".agents/plugins/marketplace.json",
+    "claude_marketplace": ".claude-plugin/marketplace.json"
+  },
+  "canonical": {
+    "skills_root": "skills",
+    "agents_root": "agents",
+    "router": "helper/router.json",
+    "capabilities": "helper/capabilities.json",
+    "quality_gates": "helper/quality-gates.json",
+    "artifacts": "helper/artifacts.json",
+    "modules": "helper/modules.json",
+    "research_gates": "research/capability-notes/gates.json",
+    "worker_graph": "architecture/plugin-graph.json"
+  },
+  "repo_development": {
+    "codex_guide": ".codex/AGENTS.md",
+    "codex_config": ".codex/config.toml"
+  },
+  "public_submission": {
+    "type": "skills-only",
+    "metadata": "submission/openai-plugin.json",
+    "test_cases": "submission/test-cases.json"
+  },
+  "parity_invariants": [
+    "same-plugin-name",
+    "same-release-version",
+    "same-canonical-skills",
+    "same-router",
+    "same-quality-gates",
+    "same-research-gates",
+    "exact-svg-mascot-rule",
+    "evidence-and-ui-fidelity",
+    "community-publishing-opt-in",
+    "community-pr-requires-manual-review"
+  ]
+}

--- a/demos/catalog.json
+++ b/demos/catalog.json
@@ -21,30 +21,6 @@
         "editorial"
       ],
       "title": "Most Marketing Fails in Review — How I Use Claude Code Outside Code"
-    },
-    {
-      "author": "imMamdouhaboammar",
-      "author_url": "https://github.com/imMamdouhaboammar",
-      "created_at": "2026-08-08",
-      "created_with": "linkedin-animated-infographics v3.0.0",
-      "description": "An animated 1080x1350 LinkedIn thought-leadership infographic explaining Generative Engine Optimization (GEO) and Answer Engine Optimization (AEO). Features Claude Code, Codex, and GitHub Copilot mascots inspecting page readiness.",
-      "gif": "demos/community/imMamdouhaboammar/geo-aeo-marketing-infographic/demo.gif",
-      "html": "demos/community/imMamdouhaboammar/geo-aeo-marketing-infographic/index.html",
-      "id": "geo-aeo-marketing-infographic",
-      "kind": "community",
-      "language": "en",
-      "license": "MIT",
-      "path": "demos/community/imMamdouhaboammar/geo-aeo-marketing-infographic",
-      "story_type": "marketing-thought-leadership",
-      "tags": [
-        "geo",
-        "aeo",
-        "marketing",
-        "claude-code",
-        "codex",
-        "copilot"
-      ],
-      "title": "If AI Can't Quote You, Buyers Won't Find You — GEO/AEO Framework"
     }
   ],
   "schema_version": 1

--- a/demos/catalog.json
+++ b/demos/catalog.json
@@ -1,27 +1,4 @@
 {
-  "demos": [
-    {
-      "author": "imMamdouhaboammar",
-      "author_url": "https://github.com/imMamdouhaboammar",
-      "created_at": "2026-08-08",
-      "created_with": "linkedin-animated-infographics v3.0.0",
-      "description": "An animated 1080x1350 LinkedIn infographic showing how Claude Code reviews marketing draft content for buried answers, weak proof, vague angles, and bloated intros before publishing.",
-      "gif": "demos/community/imMamdouhaboammar/claude-code-marketing-review/demo.gif",
-      "html": "demos/community/imMamdouhaboammar/claude-code-marketing-review/index.html",
-      "id": "claude-code-marketing-review",
-      "kind": "community",
-      "language": "en",
-      "license": "MIT",
-      "path": "demos/community/imMamdouhaboammar/claude-code-marketing-review",
-      "story_type": "marketing-thought-leadership",
-      "tags": [
-        "claude-code",
-        "marketing",
-        "content-review",
-        "editorial"
-      ],
-      "title": "Most Marketing Fails in Review — How I Use Claude Code Outside Code"
-    }
-  ],
-  "schema_version": 1
+  "schema_version": 1,
+  "demos": []
 }

--- a/demos/catalog.json
+++ b/demos/catalog.json
@@ -1,4 +1,51 @@
 {
-  "schema_version": 1,
-  "demos": []
+  "demos": [
+    {
+      "author": "imMamdouhaboammar",
+      "author_url": "https://github.com/imMamdouhaboammar",
+      "created_at": "2026-08-08",
+      "created_with": "linkedin-animated-infographics v3.0.0",
+      "description": "An animated 1080x1350 LinkedIn infographic showing how Claude Code reviews marketing draft content for buried answers, weak proof, vague angles, and bloated intros before publishing.",
+      "gif": "demos/community/imMamdouhaboammar/claude-code-marketing-review/demo.gif",
+      "html": "demos/community/imMamdouhaboammar/claude-code-marketing-review/index.html",
+      "id": "claude-code-marketing-review",
+      "kind": "community",
+      "language": "en",
+      "license": "MIT",
+      "path": "demos/community/imMamdouhaboammar/claude-code-marketing-review",
+      "story_type": "marketing-thought-leadership",
+      "tags": [
+        "claude-code",
+        "marketing",
+        "content-review",
+        "editorial"
+      ],
+      "title": "Most Marketing Fails in Review — How I Use Claude Code Outside Code"
+    },
+    {
+      "author": "imMamdouhaboammar",
+      "author_url": "https://github.com/imMamdouhaboammar",
+      "created_at": "2026-08-08",
+      "created_with": "linkedin-animated-infographics v3.0.0",
+      "description": "An animated 1080x1350 LinkedIn thought-leadership infographic explaining Generative Engine Optimization (GEO) and Answer Engine Optimization (AEO). Features Claude Code, Codex, and GitHub Copilot mascots inspecting page readiness.",
+      "gif": "demos/community/imMamdouhaboammar/geo-aeo-marketing-infographic/demo.gif",
+      "html": "demos/community/imMamdouhaboammar/geo-aeo-marketing-infographic/index.html",
+      "id": "geo-aeo-marketing-infographic",
+      "kind": "community",
+      "language": "en",
+      "license": "MIT",
+      "path": "demos/community/imMamdouhaboammar/geo-aeo-marketing-infographic",
+      "story_type": "marketing-thought-leadership",
+      "tags": [
+        "geo",
+        "aeo",
+        "marketing",
+        "claude-code",
+        "codex",
+        "copilot"
+      ],
+      "title": "If AI Can't Quote You, Buyers Won't Find You — GEO/AEO Framework"
+    }
+  ],
+  "schema_version": 1
 }

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,96 @@
+# Codex and ChatGPT
+
+Version 3.2.0 treats Codex and ChatGPT as first-class hosts for the same product core used by the Claude package.
+
+There is one canonical skill tree. OpenAI packaging points directly at `skills/`; it does not maintain a copied Codex-specific version of the workflows.
+
+## Native OpenAI package
+
+The OpenAI plugin entry point is:
+
+```text
+.codex-plugin/plugin.json
+```
+
+It declares a skills-only plugin and points to:
+
+```text
+./skills/
+```
+
+The repository marketplace is:
+
+```text
+.agents/plugins/marketplace.json
+```
+
+The marketplace entry points back to the repository root, where the OpenAI manifest and canonical Skills live.
+
+## Add the repository marketplace
+
+With a Codex CLI release that supports plugins:
+
+```bash
+codex plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics --ref main
+codex plugin marketplace list
+```
+
+Adding the marketplace makes the repository source available to supported OpenAI plugin surfaces. Installation and local testing are completed through a supported Plugins Directory surface rather than by inventing a separate repository-specific skill installation path.
+
+## Same runtime contracts
+
+Codex and ChatGPT consume the same product authority as Claude:
+
+- `helper/GUIDE.md`
+- `helper/router.json`
+- `helper/capabilities.json`
+- `helper/quality-gates.json`
+- `helper/artifacts.json`
+- `helper/modules.json`
+- `research/capability-notes/gates.json`
+- `architecture/plugin-graph.json`
+- `scripts/info_stories.py::load_catalog()`
+
+Cross-host parity is declared in `compatibility/codex.json` and validated by:
+
+```bash
+python3 scripts/validate_codex_plugin.py
+```
+
+The gate checks OpenAI packaging, the repo marketplace, shared identity/version, canonical paths, Codex repository configuration, submission materials, and public-review test cases.
+
+## Codex subagents
+
+`.codex/config.toml` and `.codex/agents/*.toml` are repository-development helpers. They are not a dependency of the installed plugin.
+
+The project-scoped maintenance roles are:
+
+- `explorer` for read-only execution-path inspection
+- `reviewer` for read-only correctness, security, regression, and test review
+- `docs_researcher` for read-only primary-documentation verification
+
+Product workers remain canonical in `agents/*.md` and `architecture/plugin-graph.json`. Codex may delegate bounded work to subagents when useful, but the parent workflow still owns orchestration and artifacts. Sequential execution is a valid fallback.
+
+## Community publishing
+
+The Codex/ChatGPT package exposes the same `share-demo` contract as Claude.
+
+A generated result is not published automatically. The share path starts only after final verification `PASS`, delivery, explicit user consent, and rights confirmation. The publisher prepares the three-file public package, validates it, opens a contributor pull request, and stops. Maintainer review and merge remain manual.
+
+## Public Plugins Directory
+
+Version 3.2.0 is **submission-ready** as a skills-only OpenAI plugin. The tracked handoff lives under `submission/` and includes listing metadata plus exactly five positive and three negative reviewer cases.
+
+The repository status is `prepared-not-submitted`. Public availability still requires external steps in the OpenAI Platform, including publisher permissions/verification, submission, OpenAI review, and publication after approval.
+
+See [`../submission/README.md`](../submission/README.md) for the tracked handoff.
+
+## Validation
+
+Run the OpenAI compatibility gate:
+
+```bash
+python3 scripts/validate_codex_plugin.py
+```
+
+For a complete repository release gate, also run the shared validators documented in [`development.md`](development.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development and Validation
 
-The repository uses contract-first development. Public behavior is represented in machine-readable helper/graph/gate/module files and protected by regression tests.
+The repository uses contract-first development. Public behavior is represented in machine-readable helper, graph, gate, module, demo, and host-packaging files and protected by regression tests.
 
 ## Core development loop
 
@@ -24,6 +24,7 @@ python3 scripts/plugin_graph.py check
 python3 scripts/ecosystem_doctor.py check
 python3 scripts/demo_gallery.py check
 python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
 python3 -m json.tool hooks/hooks.json >/dev/null
 python3 -m json.tool schemas/demo.schema.json >/dev/null
 bash -n scripts/lint_artboard.sh
@@ -37,7 +38,7 @@ For Claude packaging:
 claude plugin validate .
 ```
 
-CI also performs a same-repository marketplace add/list/install smoke test.
+CI also performs the same-repository Claude Marketplace add/list/install smoke. OpenAI packaging is validated structurally and for cross-host parity by `scripts/validate_codex_plugin.py`; any Codex CLI marketplace smoke must use documented non-interactive behavior rather than a fabricated install command.
 
 ## Validator responsibilities
 
@@ -63,7 +64,7 @@ Strict repository reality gate. It validates active module inventory, paths, tes
 
 ### `scripts/demo_gallery.py check`
 
-Validates every owned/community demo package, author namespace, metadata contract, safe local paths, duplicate IDs, exact three-file package shape, and deterministic `demos/catalog.json` drift.
+Validates every owned/community demo package, author namespace, metadata contract, public-export scanning, safe local paths, duplicate IDs, exact three-file package shape, and deterministic `demos/catalog.json` drift.
 
 ### `scripts/demo_submit.py check`
 
@@ -72,6 +73,10 @@ Validates one staged public contribution before GitHub publication. Preparation 
 ### `scripts/validate_marketplace.py`
 
 Validates the Claude Marketplace/plugin manifests, same-repository source, strict mode, version agreement, and required component structure.
+
+### `scripts/validate_codex_plugin.py`
+
+Validates `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, canonical Skills linkage, OpenAI/Claude identity and version parity, `compatibility/codex.json`, current repository Codex subagent configuration, public policy files, and the tracked OpenAI submission package including exactly five positive and three negative reviewer cases.
 
 ## Community demo changes
 
@@ -113,10 +118,12 @@ Ignored upstream clones under `research/upstreams/` never ship.
 
 ## Adding a skill, agent, or public tool
 
-A new public module is incomplete until it is declared in `helper/modules.json` with a real path, role, tests, and reachability links. Update routes/graph/preloads/artifacts/gates as appropriate. `scripts/ecosystem_doctor.py check` must remain clean.
+A new public module is incomplete until it is declared in `helper/modules.json` with a real path, role, tests, and reachability links. Update routes, graph, preloads, artifacts, and gates as appropriate. `scripts/ecosystem_doctor.py check` must remain clean.
 
 ## Release work
 
-A plugin release requires matching version values in `.claude-plugin/plugin.json` and the plugin entry in `.claude-plugin/marketplace.json`. The current release is `3.1.0`.
+The current release is `3.2.0`.
 
-Before merge, require unit/validator success, official Claude validation, marketplace install smoke, no blocking external check, and no unresolved review thread.
+A public release requires the same plugin version across the Claude plugin manifest, Claude marketplace plugin entry, OpenAI plugin manifest, Codex compatibility registry, and OpenAI submission metadata.
+
+Before merge, require unit/validator success, official Claude validation, the available marketplace smoke, no blocking external check, and no unresolved review thread. Public OpenAI directory publication remains a separate external submission/review step and must not be claimed from repository CI alone.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,6 +1,8 @@
 # Ecosystem Architecture
 
-Version 3 organizes the repository around a central routing helper and explicit worker contracts. Skills, agents, research, tools, artifacts, Claude Marketplace packaging, and the demo gallery are validated as one connected product.
+Version 3 organizes the repository around a central routing helper and explicit worker contracts. Skills, agents, research, tools, artifacts, host packaging, and the demo gallery are validated as one connected product.
+
+Claude Code, Codex, and ChatGPT are package adapters over the same canonical runtime. Host compatibility must not fork product Skills, routes, gates, or worker contracts.
 
 ## Authority
 
@@ -18,6 +20,22 @@ Machine-readable contracts:
 - `scripts/info_stories.py::load_catalog()`: merged Info-stories registry
 - `schemas/demo.schema.json`: public demo metadata contract
 - `scripts/demo_gallery.py`: owned/community demo validation and deterministic catalog
+- `compatibility/codex.json`: OpenAI host-parity declaration
+
+## Host packaging
+
+Claude Code packaging lives under `.claude-plugin/`.
+
+OpenAI packaging lives under `.codex-plugin/`, while the repository marketplace for Codex/ChatGPT lives at `.agents/plugins/marketplace.json`.
+
+Both packages consume the same `skills/` tree. `.codex/config.toml` and `.codex/agents/*.toml` are repository-development helpers and are not dependencies of the installed OpenAI plugin.
+
+Host packaging is validated separately from runtime topology:
+
+```bash
+python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
+```
 
 ## Complete shipping path
 
@@ -98,7 +116,7 @@ The registry is the deterministic result of `load_catalog()`, merging the base c
 
 Research-derived gates have source provenance and local independently-worded behavior. Plugin-local behavior such as exact mascot identity, hook-led design copy, restrained palettes, center-first composition, creative payoff, and opt-in public demo export is kept separate from upstream attribution.
 
-See [`research.md`](research.md) for the provenance chain and [`community-demos.md`](community-demos.md) for the public-export contract.
+See [`research.md`](research.md) for the provenance chain, [`community-demos.md`](community-demos.md) for the public-export contract, and [`codex.md`](codex.md) for OpenAI packaging.
 
 ## Strict reality gate
 
@@ -107,6 +125,8 @@ See [`research.md`](research.md) for the provenance chain and [`community-demos.
 ```bash
 python3 scripts/ecosystem_doctor.py check
 python3 scripts/demo_gallery.py check
+python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
 ```
 
-A module or demo contract that exists only in documentation does not pass these gates.
+A module, host package, or demo contract that exists only in documentation does not pass these gates.

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -1,56 +1,75 @@
-# Claude Marketplace
+# Marketplace Packaging
 
-The plugin and marketplace live in the same repository.
+Version 3.2.0 ships two host adapters over one canonical product core.
 
-- marketplace: `mamdouh-creative-tools`
-- plugin: `linkedin-animated-infographics`
-- plugin release: `3.1.0`
-- marketplace source: `./`
-- strict mode: `true`
+- Claude marketplace: `.claude-plugin/marketplace.json`
+- Claude plugin manifest: `.claude-plugin/plugin.json`
+- OpenAI repo marketplace: `.agents/plugins/marketplace.json`
+- OpenAI plugin manifest: `.codex-plugin/plugin.json`
+- canonical Skills for both hosts: `skills/`
 
-## Install
+The plugin name is `linkedin-animated-infographics`. The marketplace source name is `mamdouh-creative-tools`.
 
-In Claude Code:
+## Claude Code
+
+Install from Claude Code:
 
 ```text
 /plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics
 /plugin install linkedin-animated-infographics@mamdouh-creative-tools
 ```
 
-The marketplace catalog is `.claude-plugin/marketplace.json`; the plugin manifest is `.claude-plugin/plugin.json`.
-
-## Validate locally
+Validate locally:
 
 ```bash
 python3 scripts/validate_marketplace.py
 claude plugin validate .
 ```
 
-The local validator checks the same-repository source, strict mode, plugin identity, version agreement, required component directories, demo/schema components, and manifest fields.
+CI also registers the checked-out repository as a clean Claude marketplace source and installs `linkedin-animated-infographics@mamdouh-creative-tools`.
 
-## CI install smoke
+## Codex and ChatGPT
 
-The GitHub validation workflow creates a clean temporary Claude home, registers the checked-out repository as a local marketplace, verifies that `mamdouh-creative-tools` appears in the marketplace list, and installs:
+Add the repository marketplace with a current Codex CLI:
 
-```text
-linkedin-animated-infographics@mamdouh-creative-tools
+```bash
+codex plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics --ref main
+codex plugin marketplace list
 ```
 
-That smoke test proves the marketplace entry is not only schema-valid but installable from the repository layout used by CI.
+The OpenAI marketplace entry points at the repository root using a local `./` source. The root `.codex-plugin/plugin.json` points at the canonical `./skills/` tree.
+
+Use a supported Plugins Directory surface to install and test the plugin. Do not substitute undocumented `codex plugin install` syntax for the current marketplace/Plugins Directory flow.
+
+Validate the OpenAI package and cross-host parity with:
+
+```bash
+python3 scripts/validate_codex_plugin.py
+```
+
+See [`codex.md`](codex.md) for the full Codex/ChatGPT contract.
+
+## Public OpenAI directory
+
+The 3.2.0 OpenAI package is prepared as a skills-only public submission. Tracked reviewer materials live in `submission/`.
+
+The repository status is `prepared-not-submitted`. OpenAI Platform permissions, verified publisher identity, availability selection, submission, review, and final publication remain external steps.
 
 ## Versioning
 
-The plugin manifest version and marketplace plugin-entry version must match.
+The 3.2.0 release must agree across:
 
-Version `3.1.0` adds the owned/community demo gallery and opt-in publisher flow on top of the v3 routing-kernel architecture. It includes `share-demo`, `community-publisher`, the strict three-file demo schema, deterministic gallery catalog, export/privacy preflight, and manual-review PR policy.
+- `.claude-plugin/plugin.json`
+- the plugin entry inside `.claude-plugin/marketplace.json`
+- `.codex-plugin/plugin.json`
+- `compatibility/codex.json`
+- `submission/openai-plugin.json`
 
-The top-level marketplace catalog has its own catalog version. It does not need to match the plugin version.
-
-Any future public plugin release should update both the plugin manifest and its marketplace entry and rerun the official Claude validator plus marketplace add/install smoke.
+The top-level Claude marketplace catalog has its own catalog version and does not need to equal the plugin version.
 
 ## Release gate
 
-Before merging a marketplace release:
+Before merging a packaging release:
 
 ```bash
 python3 -m unittest discover -s tests -v
@@ -60,7 +79,8 @@ python3 scripts/plugin_graph.py check
 python3 scripts/ecosystem_doctor.py check
 python3 scripts/demo_gallery.py check
 python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
 claude plugin validate .
 ```
 
-Do not treat a version bump as complete until CI installs that exact checked-out plugin from the same-repository marketplace.
+Do not treat a release as complete until the exact PR head passes the shared validators, both packaging validators, the official Claude validator, the available install smoke checks, and review closure.

--- a/docs/superpowers/plans/2026-08-08-codex-native-plugin.md
+++ b/docs/superpowers/plans/2026-08-08-codex-native-plugin.md
@@ -1,0 +1,302 @@
+# Codex Native Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship version 3.2.0 as a first-class OpenAI skills-only plugin for Codex and ChatGPT, with repo marketplace distribution, host parity validation, public-submission materials, and no duplicated product core.
+
+**Architecture:** Keep `skills/`, `agents/`, `helper/`, `research/`, and `architecture/` canonical. Add OpenAI packaging and marketplace adapters around that core, then enforce cross-host parity with a dedicated validator and CI gate. Public submission remains prepared but manual.
+
+**Tech Stack:** JSON manifests, TOML Codex config, Markdown policy/docs, Python 3 validators, unittest, GitHub Actions, Claude Code validator, documented Codex plugin marketplace CLI where non-interactive smoke is reliable.
+
+## Global Constraints
+
+- Release version is `3.2.0`.
+- OpenAI plugin type is `skills-only`; do not add an MCP server.
+- `.codex-plugin/plugin.json` is the OpenAI package entry point.
+- `.agents/plugins/marketplace.json` is the repo-scoped Codex/ChatGPT marketplace.
+- Canonical skills remain `./skills/`; do not copy them into a Codex-only tree.
+- Public submission is prepared but never claimed as submitted or published automatically.
+- Five positive and three negative reviewer test cases are mandatory.
+- Claude and Codex must share plugin identity, version, routes, safety gates, exact-SVG rules, and community publishing semantics.
+- Community contributions still stop at a PR and require maintainer manual review/merge.
+
+---
+
+### Task 1: OpenAI plugin manifest and repo marketplace
+
+**Files:**
+- Create: `.codex-plugin/plugin.json`
+- Create: `.agents/plugins/marketplace.json`
+- Create: `tests/test_codex_plugin.py`
+
+**Interfaces:**
+- Consumes: canonical `skills/` root and `.claude-plugin/plugin.json` identity/version
+- Produces: OpenAI manifest and marketplace data loaded later by `validate_codex_plugin.py`
+
+- [ ] **Step 1: Write failing manifest/marketplace tests**
+
+Add tests asserting `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json` exist, use version `3.2.0`, reference `./skills/`, expose root plugin source `./`, and contain `AVAILABLE` / `ON_INSTALL` / `Productivity` marketplace fields.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `python3 -m unittest tests.test_codex_plugin -v`
+Expected: FAIL because OpenAI package files do not exist.
+
+- [ ] **Step 3: Add minimal valid OpenAI packaging**
+
+Create `.codex-plugin/plugin.json` with top-level identity/publisher fields, `skills: "./skills/"`, and an `interface` object containing display name, descriptions, developer name, category, capabilities, repository-hosted website/legal links, starter prompts, and real visual asset paths only.
+
+Create `.agents/plugins/marketplace.json` with a single root plugin entry using:
+
+```json
+{
+  "name": "mamdouh-creative-tools",
+  "interface": {"displayName": "Mamdouh Creative Tools"},
+  "plugins": [{
+    "name": "linkedin-animated-infographics",
+    "source": {"source": "local", "path": "./"},
+    "policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
+    "category": "Productivity"
+  }]
+}
+```
+
+- [ ] **Step 4: Run focused tests to verify GREEN**
+
+Run: `python3 -m unittest tests.test_codex_plugin -v`
+Expected: PASS for packaging tests added in this task.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat: add native Codex plugin packaging`
+
+---
+
+### Task 2: Codex parity registry and strict validator
+
+**Files:**
+- Create: `compatibility/codex.json`
+- Create: `scripts/validate_codex_plugin.py`
+- Modify: `tests/test_codex_plugin.py`
+
+**Interfaces:**
+- Consumes: Claude plugin/marketplace, OpenAI plugin/marketplace, `.codex/config.toml`, `skills/`, helper registries
+- Produces: `validate_codex_plugin(root: Path) -> list[str]` and CLI exit status
+
+- [ ] **Step 1: Write failing parity/validator tests**
+
+Cover version mismatch, unsafe manifest path, missing skills root, malformed marketplace policy, dead `.codex/agents/*.toml` references, and mismatch between compatibility registry and live paths.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `python3 -m unittest tests.test_codex_plugin -v`
+Expected: FAIL because validator/registry do not exist.
+
+- [ ] **Step 3: Implement `compatibility/codex.json`**
+
+Declare version `3.2.0`, manifest/marketplace paths, canonical skills/helper/graph paths, surfaces (`codex`, `chatgpt`), submission type `skills-only`, and parity invariants.
+
+- [ ] **Step 4: Implement `scripts/validate_codex_plugin.py`**
+
+Implement repo-bound path resolution and deterministic checks for:
+
+```python
+def validate_codex_plugin(root: Path = ROOT) -> list[str]:
+    ...
+```
+
+Validate manifest identity/version, canonical skills path, install metadata, marketplace source/policies/category, compatibility registry drift, Codex config custom-agent references, legal/support files, submission case counts, and all release-version copies.
+
+- [ ] **Step 5: Run focused tests to verify GREEN**
+
+Run: `python3 -m unittest tests.test_codex_plugin -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Commit message: `feat: add Codex parity validator`
+
+---
+
+### Task 3: Repair and strengthen Codex repository configuration
+
+**Files:**
+- Modify: `.codex/AGENTS.md`
+- Modify: `.codex/config.toml`
+- Create: `.codex/agents/explorer.toml`
+- Create: `.codex/agents/reviewer.toml`
+- Create: `.codex/agents/docs-researcher.toml`
+- Modify: `tests/test_codex_plugin.py`
+
+**Interfaces:**
+- Consumes: current Codex config schema conventions and repository helper authority
+- Produces: a self-consistent repo-development Codex setup with no dead config-file references
+
+- [ ] **Step 1: Write failing config-reference tests**
+
+Require every `.codex/config.toml` custom agent `config_file` to resolve inside `.codex/agents/`, and require each role to be narrow maintenance guidance rather than a parallel product worker graph.
+
+- [ ] **Step 2: Run focused tests to verify RED**
+
+Run: `python3 -m unittest tests.test_codex_plugin -v`
+Expected: FAIL because the three referenced agent TOMLs are missing.
+
+- [ ] **Step 3: Add the real agent TOMLs and update guidance**
+
+Create read-only explorer, correctness/security reviewer, and docs researcher configs. Update `.codex/AGENTS.md` to cover `share-demo`, OpenAI packaging, parity validation, and optional subagent use with parent-controlled orchestration.
+
+- [ ] **Step 4: Run focused tests to verify GREEN**
+
+Run: `python3 -m unittest tests.test_codex_plugin -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat: complete Codex repository configuration`
+
+---
+
+### Task 4: Public OpenAI submission preparation and legal/support material
+
+**Files:**
+- Create: `PRIVACY.md`
+- Create: `TERMS.md`
+- Create: `SUPPORT.md`
+- Create: `submission/openai-plugin.json`
+- Create: `submission/test-cases.json`
+- Create: `submission/README.md`
+- Modify: `tests/test_codex_plugin.py`
+
+**Interfaces:**
+- Consumes: plugin metadata and current OpenAI public-submission requirements
+- Produces: repository-hosted review materials and deterministic submission readiness data
+
+- [ ] **Step 1: Write failing submission-material tests**
+
+Require public docs, submission type `skills-only`, five positive cases, three negative cases, starter prompts, release notes, and explicit external prerequisites for Apps Management write access and verified publisher identity.
+
+- [ ] **Step 2: Run focused tests to verify RED**
+
+Run: `python3 -m unittest tests.test_codex_plugin -v`
+Expected: FAIL because submission/legal files are missing.
+
+- [ ] **Step 3: Add accurate legal/support docs**
+
+Describe the plugin as local skills-based software. State that community publication is opt-in, only approved demo package data is sent through user-authenticated GitHub tooling, and source prompts stay excluded unless separately consented to.
+
+- [ ] **Step 4: Add submission metadata and exactly eight tests**
+
+Positive reviewer cases cover create-post, Info-story, QA, exact-SVG mascot with asset, and explicit community sharing. Negative cases cover missing exact mascot SVG, unverified/unsafe demo export, and community sharing without explicit consent.
+
+- [ ] **Step 5: Run focused tests and validator to verify GREEN**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_codex_plugin -v
+python3 scripts/validate_codex_plugin.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Commit message: `docs: prepare OpenAI plugin submission materials`
+
+---
+
+### Task 5: Dual-host docs and release metadata
+
+**Files:**
+- Create: `docs/codex.md`
+- Modify: `README.md`
+- Modify: `docs/marketplace.md`
+- Modify: `docs/development.md`
+- Modify: `docs/ecosystem.md`
+- Modify: `AGENTS.md`
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `tests/test_marketplace.py`
+- Modify: `tests/test_docs_contract.py`
+- Modify: `tests/test_repository_guidance.py`
+
+**Interfaces:**
+- Consumes: final OpenAI and Claude package data
+- Produces: user-facing dual-host installation docs and release version `3.2.0`
+
+- [ ] **Step 1: Write failing release/docs tests**
+
+Require version `3.2.0` across Claude/OpenAI manifests and marketplace data, README sections for Claude and Codex, documented Codex repo marketplace commands, and a focused `docs/codex.md` link from the README.
+
+- [ ] **Step 2: Run relevant tests to verify RED**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_marketplace tests.test_docs_contract tests.test_repository_guidance -v
+```
+
+Expected: FAIL on stale `3.1.0` and missing Codex docs.
+
+- [ ] **Step 3: Update release metadata and concise docs**
+
+Keep README as a gateway. Add Codex/ChatGPT installation beside Claude installation, explain that the same canonical Skills power both hosts, and document public-directory status as submission-ready rather than published.
+
+- [ ] **Step 4: Run docs/release tests to verify GREEN**
+
+Run the command from Step 2 plus `python3 scripts/validate_codex_plugin.py`.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Commit message: `docs: publish dual-host 3.2.0 guidance`
+
+---
+
+### Task 6: CI dual-host gate and final verification
+
+**Files:**
+- Modify: `.github/workflows/claude-plugin-validation.yml`
+- Modify: `docs/development.md` if CI command list changes
+- Modify: `tests/test_codex_plugin.py` only if CI contract requires a regression assertion
+
+**Interfaces:**
+- Consumes: all prior tasks
+- Produces: a PR gate proving shared runtime + Claude packaging + OpenAI packaging are coherent
+
+- [ ] **Step 1: Add a failing CI-contract assertion if needed**
+
+Require workflow text to execute `python3 scripts/validate_codex_plugin.py` and JSON-parse `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `compatibility/codex.json`, `submission/openai-plugin.json`, and `submission/test-cases.json`.
+
+- [ ] **Step 2: Update CI**
+
+Rename display name to a host-neutral title such as `Plugin Validation`, keep all existing shared/Claude gates, add the Codex validator and JSON syntax checks, and do not add a fake interactive marketplace smoke.
+
+If a documented non-interactive Codex CLI marketplace smoke can be proven in the runner, add it; otherwise retain deterministic structural validation and document the limitation.
+
+- [ ] **Step 3: Run full deterministic gate**
+
+Run through GitHub Actions on the feature PR:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
+python3 scripts/info_stories.py check
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/demo_gallery.py check
+python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
+```
+
+Expected: all pass, plus official Claude plugin validation and existing Claude Marketplace smoke in CI.
+
+- [ ] **Step 4: Review and merge gate**
+
+Open a PR, inspect Qodo/Qlty/CodeRabbit output, fix reproducible findings with regression coverage, resolve threads only after fixes, re-run the exact-head gate, then squash merge with expected head SHA.
+
+- [ ] **Step 5: Post-merge verification**
+
+Fetch from `main` and verify `.codex-plugin/plugin.json` version `3.2.0`, `.agents/plugins/marketplace.json`, `compatibility/codex.json`, public submission materials, and merged PR state.

--- a/docs/superpowers/specs/2026-08-08-codex-native-plugin-design.md
+++ b/docs/superpowers/specs/2026-08-08-codex-native-plugin-design.md
@@ -1,0 +1,267 @@
+# Codex Native Plugin Compatibility Design
+
+Date: 2026-08-08
+Status: approved for implementation
+Target release: 3.2.0
+
+## Goal
+
+Make `linkedin-animated-infographics` a first-class OpenAI plugin for Codex and ChatGPT without weakening or duplicating the existing Claude plugin ecosystem.
+
+The same product must install and behave consistently across:
+
+- Claude Code through `.claude-plugin/`
+- Codex and ChatGPT through `.codex-plugin/`
+- repo-scoped Codex/ChatGPT marketplace distribution through `.agents/plugins/marketplace.json`
+- the OpenAI universal public Plugins Directory after external submission and review
+
+The canonical product logic remains shared: `skills/`, `agents/`, `helper/`, `research/`, `architecture/`, scripts, tests, and the community demo publisher are not forked per host.
+
+## Upstream contracts
+
+This design follows the current OpenAI plugin contract documented at:
+
+- https://developers.openai.com/plugins/build/plugins
+- https://developers.openai.com/plugins/deploy/submission
+
+Required OpenAI packaging facts used by this design:
+
+- every OpenAI plugin has `.codex-plugin/plugin.json`
+- bundled skills can be referenced with `"skills": "./skills/"`
+- repo marketplaces live at `.agents/plugins/marketplace.json`
+- marketplace entries use explicit source, installation policy, authentication policy, and category
+- `codex plugin marketplace add owner/repo --ref main` is the supported CLI path for adding a repo marketplace source
+- public plugins are submitted once and, after approval/publication, appear in the universal Plugins Directory shared by ChatGPT and Codex
+- skills-only public submissions are supported
+- public submission requires five positive and three negative reviewer test cases
+- public listing requires website, support, privacy, and terms URLs plus a verified publisher identity
+
+## Product architecture
+
+### One core, two host packages
+
+Claude and Codex packaging are adapters over one canonical product core.
+
+```text
+.claude-plugin/                 Claude package metadata
+.codex-plugin/                  OpenAI/Codex package metadata
+.agents/plugins/                Codex/ChatGPT repo marketplace
+skills/                         canonical workflows for every host
+agents/                         canonical worker contracts
+helper/                         canonical router, capabilities, gates, artifacts, modules
+research/                       canonical research-derived gates
+architecture/                   canonical execution graph
+scripts/                        canonical validators and runtime helpers
+compatibility/                  host parity declaration
+submission/                     public OpenAI review materials
+```
+
+No copied Codex-only version of each skill is allowed. Host-specific guidance may adapt invocation mechanics, but it must reference the same canonical skills and machine-readable authorities.
+
+## OpenAI plugin manifest
+
+Add `.codex-plugin/plugin.json` as the OpenAI package entry point.
+
+The manifest must:
+
+- use plugin name `linkedin-animated-infographics`
+- use version `3.2.0`
+- point `skills` to `./skills/`
+- include publisher metadata matching the repository owner
+- include repository and homepage URLs
+- include install-surface metadata under `interface`
+- use realistic starter prompts for create, Info-story, QA, and share-demo workflows
+- use only real repository assets
+- use public legal/support URLs that resolve to repository-hosted documents
+- avoid declaring MCP servers or apps because this release is intentionally skills-only
+
+The plugin is a skills-only OpenAI plugin in 3.2.0. MCP can be added in a future release only when a real external service dependency justifies it.
+
+## Codex marketplace
+
+Add `.agents/plugins/marketplace.json` as the repo-scoped marketplace source.
+
+The marketplace must expose exactly the root plugin using a local source path that resolves to `./`, with:
+
+- installation: `AVAILABLE`
+- authentication: `ON_INSTALL`
+- category: `Productivity`
+- marketplace display name suitable for the Plugins Directory picker
+
+The README and Codex docs must document:
+
+```bash
+codex plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics --ref main
+codex plugin marketplace list
+```
+
+Installation itself is completed from a supported Plugins Directory surface. Documentation must not invent unsupported `codex plugin install` syntax unless current upstream documentation explicitly supports it.
+
+## Codex runtime compatibility
+
+### Repository guidance
+
+The current `.codex/AGENTS.md` remains the Codex development guide and is expanded to cover:
+
+- the canonical helper authority
+- `share-demo` and community publishing
+- OpenAI plugin packaging and marketplace validation
+- the dual-host parity gate
+- safe use of subagents
+
+### Codex config
+
+`.codex/config.toml` is repository-development configuration, not part of the installed plugin contract.
+
+It must not reference missing custom agent files. Any declared `[agents.*] config_file` must resolve to a real `.codex/agents/*.toml` file in the repository and have a narrow maintenance role.
+
+The installed plugin must remain useful without requiring the consumer to copy this repository-development config into their global Codex configuration.
+
+### Worker execution
+
+Canonical product worker definitions stay in `agents/*.md` and `architecture/plugin-graph.json`.
+
+Codex may use subagents when available, but product correctness must not depend on hidden peer-to-peer delegation. Parent workflows remain responsible for orchestration and bounded artifacts. Sequential execution is a valid fallback.
+
+## Compatibility registry
+
+Add `compatibility/codex.json` as a machine-readable parity contract.
+
+It records:
+
+- schema version
+- plugin release version
+- canonical skills root
+- canonical helper/router locations
+- canonical worker graph
+- supported OpenAI surfaces
+- repo marketplace path
+- OpenAI manifest path
+- public submission type `skills-only`
+- parity invariants between Claude and Codex
+
+The parity invariants include:
+
+- same plugin name and release version
+- same canonical skills
+- same request routes
+- same quality and research gates
+- same exact-SVG mascot rule
+- same evidence/UI fidelity requirements
+- same community demo publishing contract
+- same manual-review-only contribution rule
+
+## Validation
+
+Add `scripts/validate_codex_plugin.py` and `tests/test_codex_plugin.py`.
+
+The validator is fail-closed and checks at minimum:
+
+1. `.codex-plugin/plugin.json` exists and is valid JSON
+2. manifest identity/version matches `.claude-plugin/plugin.json`
+3. manifest `skills` resolves to the canonical `skills/` root
+4. required install-surface metadata exists
+5. all manifest paths are repo-bound and resolve
+6. the repo marketplace exists at `.agents/plugins/marketplace.json`
+7. marketplace source resolves to the plugin root and contains required policy/category fields
+8. `compatibility/codex.json` exists and matches live paths/version
+9. `.codex/config.toml` contains no dead custom-agent references
+10. declared `.codex/agents/*.toml` files exist and stay repo-bound
+11. public submission materials contain exactly five positive and three negative cases
+12. public legal/support documents exist
+13. version parity remains true across Claude plugin, Claude marketplace, Codex plugin, compatibility registry, and submission metadata
+
+The existing strict ecosystem doctor remains authoritative for runtime modules. The Codex validator must not duplicate its full module graph logic.
+
+## Public submission package
+
+Add tracked, reviewable submission preparation files under `submission/`.
+
+Required files:
+
+- `submission/openai-plugin.json`: listing metadata, submission type, starter prompts, release notes, external prerequisites
+- `submission/test-cases.json`: five positive and three negative reviewer cases with expected behavior and result shape
+- `submission/README.md`: exact manual steps for uploading the final skills bundle and completing the OpenAI Platform form
+
+The repository prepares the public submission but does not claim the plugin is submitted or published automatically.
+
+External prerequisites are explicitly marked as external:
+
+- Apps Management write access in the publishing OpenAI organization
+- verified individual or business developer identity
+- final selection of country/region availability
+- manual submission through the OpenAI Platform portal
+- OpenAI review and publisher-triggered publication after approval
+
+## Legal and support material
+
+Add public repository documents:
+
+- `PRIVACY.md`
+- `TERMS.md`
+- `SUPPORT.md`
+
+They must describe this repository accurately as a local skills-based plugin. They must not claim that OpenAI or GitHub sends data to a maintainer-owned server when no such server exists.
+
+The community demo publication flow is opt-in and may send the user-approved `demo.gif`, `index.html`, `demo.json`, and generated catalog change to GitHub through the contributor's authenticated tooling. Source prompts remain excluded unless separately consented to under the existing `share-demo` contract.
+
+## README and docs
+
+Update the root README so Claude Code and Codex/ChatGPT are presented as first-class installation targets without turning the README back into a long manual.
+
+Add focused `docs/codex.md` covering:
+
+- OpenAI plugin structure
+- repo marketplace setup
+- Plugins Directory installation/testing
+- Codex development guidance
+- validation commands
+- public submission status
+
+Update `docs/marketplace.md`, `docs/development.md`, `docs/ecosystem.md`, and repository guidance where needed.
+
+## CI
+
+Extend the existing validation workflow after the shared product validators with:
+
+```bash
+python3 scripts/validate_codex_plugin.py
+```
+
+CI must validate both host packages on every PR.
+
+A true Codex marketplace smoke test should be added only if the current CI environment can install a Codex CLI version that exposes the documented plugin marketplace commands without interactive requirements. If that command cannot be run reliably in CI, the validator must still deterministically verify marketplace structure and the limitation must be documented rather than faking a passing smoke test.
+
+Claude validation and same-repo Claude Marketplace smoke remain required.
+
+## Release semantics
+
+This is a feature release: `3.1.0 -> 3.2.0`.
+
+Version must be updated consistently across all public host manifests and submission metadata.
+
+## Acceptance criteria
+
+The implementation is ready to merge only when:
+
+- the OpenAI manifest and repo marketplace are present and strict-valid
+- Codex config has no dead references
+- all canonical Skills remain shared, not copied
+- `compatibility/codex.json` passes parity validation
+- five positive and three negative public-review cases exist
+- privacy, terms, support, and website links in manifest/submission resolve to public repository URLs
+- README documents Claude and Codex installation accurately
+- all existing tests pass
+- all new Codex tests pass
+- strict ecosystem validators remain green
+- demo gallery/community publisher validators remain green
+- Claude official validator remains green
+- review findings are resolved before merge
+
+## Non-goals
+
+- no new MCP server in 3.2.0
+- no automatic OpenAI public submission
+- no duplicated Codex-only skill tree
+- no direct write or auto-merge changes to the community publisher
+- no requirement that plugin users adopt the repository maintainer's MCP configuration

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | grep -Ei '\\.html$' | xargs -r grep -lE 'id=\"artboard\"' 2>/dev/null | xargs -r -n1 bash ${CLAUDE_PLUGIN_ROOT}/scripts/lint_artboard.sh || true"
+            "command": "python3 \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.}}/scripts/post_tool_artboard_lint.py\""
           }
         ]
       }

--- a/scripts/post_tool_artboard_lint.py
+++ b/scripts/post_tool_artboard_lint.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Run the artboard linter after Claude/Codex file-edit hook events.
+
+The hook is advisory: lint output is useful during iteration, but this adapter
+always exits successfully so a PostToolUse hook cannot turn a completed edit
+into a blocking product failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+PATCH_FILE_RE = re.compile(r"^\*\*\* (?:Update|Add) File: (.+)$", re.MULTILINE)
+DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$", re.MULTILINE)
+
+
+def extract_html_targets(payload: dict[str, Any]) -> list[str]:
+    """Extract edited HTML paths from Claude Write/Edit or Codex apply_patch input."""
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return []
+
+    candidates: list[str] = []
+    file_path = tool_input.get("file_path")
+    if isinstance(file_path, str) and file_path.lower().endswith(".html"):
+        candidates.append(file_path)
+
+    command = tool_input.get("command")
+    if isinstance(command, str):
+        candidates.extend(PATCH_FILE_RE.findall(command))
+        candidates.extend(DIFF_FILE_RE.findall(command))
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        candidate = candidate.strip()
+        if not candidate.lower().endswith(".html") or candidate in seen:
+            continue
+        seen.add(candidate)
+        result.append(candidate)
+    return result
+
+
+def _workspace_file(cwd: Path, value: str) -> Path | None:
+    supplied = Path(value).expanduser()
+    resolved = supplied.resolve() if supplied.is_absolute() else (cwd / supplied).resolve()
+    try:
+        resolved.relative_to(cwd.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def _plugin_root() -> Path:
+    value = os.environ.get("PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if value:
+        return Path(value).expanduser().resolve()
+    return Path(__file__).resolve().parents[1]
+
+
+def run(payload: dict[str, Any]) -> int:
+    cwd_value = payload.get("cwd")
+    cwd = Path(cwd_value).expanduser().resolve() if isinstance(cwd_value, str) and cwd_value else Path.cwd().resolve()
+    lint_script = _plugin_root() / "scripts" / "lint_artboard.sh"
+    if not lint_script.is_file():
+        return 0
+
+    for value in extract_html_targets(payload):
+        target = _workspace_file(cwd, value)
+        if target is None or not target.is_file():
+            continue
+        try:
+            text = target.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if not re.search(r"\bid\s*=\s*['\"]artboard['\"]", text, re.IGNORECASE):
+            continue
+        subprocess.run(["bash", str(lint_script), str(target)], cwd=cwd, check=False)
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    return run(payload)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_codex_plugin.py
+++ b/scripts/validate_codex_plugin.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Validate native OpenAI/Codex plugin packaging and shared-core parity."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_NAME = "linkedin-animated-infographics"
+EXPECTED_VERSION = "3.2.0"
+EXPECTED_CANONICAL = {
+    "skills_root": "skills",
+    "agents_root": "agents",
+    "router": "helper/router.json",
+    "capabilities": "helper/capabilities.json",
+    "quality_gates": "helper/quality-gates.json",
+    "artifacts": "helper/artifacts.json",
+    "modules": "helper/modules.json",
+    "research_gates": "research/capability-notes/gates.json",
+    "worker_graph": "architecture/plugin-graph.json",
+}
+REQUIRED_INTERFACE = {
+    "displayName",
+    "shortDescription",
+    "longDescription",
+    "developerName",
+    "category",
+    "capabilities",
+    "websiteURL",
+    "privacyPolicyURL",
+    "termsOfServiceURL",
+    "defaultPrompt",
+}
+
+
+def _load_json(path: Path, errors: list[str], label: str) -> dict[str, Any] | None:
+    if not path.is_file():
+        errors.append(f"missing {label}: {path}")
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid JSON in {label}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{label} root must be an object")
+        return None
+    return data
+
+
+def _safe_repo_path(root: Path, relative: str) -> Path | None:
+    if not isinstance(relative, str) or not relative.strip():
+        return None
+    candidate = Path(relative)
+    if candidate.is_absolute():
+        return None
+    root_resolved = root.resolve()
+    resolved = (root_resolved / candidate).resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        return None
+    return resolved
+
+
+def _validate_openai_manifest(root: Path, manifest: dict[str, Any], errors: list[str]) -> None:
+    if manifest.get("name") != EXPECTED_NAME:
+        errors.append("OpenAI plugin name drift")
+    if manifest.get("version") != EXPECTED_VERSION:
+        errors.append("OpenAI plugin version drift")
+
+    skills_value = manifest.get("skills")
+    if skills_value != "./skills/":
+        errors.append("OpenAI plugin skills path must be ./skills/")
+    skills_path = _safe_repo_path(root, skills_value or "")
+    if skills_path is None:
+        errors.append("unsafe OpenAI plugin skills path")
+    elif not skills_path.is_dir():
+        errors.append("OpenAI plugin skills path does not resolve to a directory")
+
+    interface = manifest.get("interface")
+    if not isinstance(interface, dict):
+        errors.append("OpenAI plugin interface must be an object")
+        return
+    for field in sorted(REQUIRED_INTERFACE):
+        value = interface.get(field)
+        if value in (None, "", []):
+            errors.append(f"OpenAI plugin interface missing {field}")
+    if interface.get("category") != "Productivity":
+        errors.append("OpenAI plugin interface category must be Productivity")
+    prompts = interface.get("defaultPrompt", [])
+    if not isinstance(prompts, list) or len(prompts) < 3 or any(not isinstance(item, str) or not item.strip() for item in prompts):
+        errors.append("OpenAI plugin defaultPrompt must contain at least three non-empty prompts")
+
+    for field in ("composerIcon", "logo"):
+        value = interface.get(field)
+        if value is None:
+            continue
+        target = _safe_repo_path(root, value)
+        if target is None:
+            errors.append(f"unsafe OpenAI plugin {field} path")
+        elif not target.is_file():
+            errors.append(f"OpenAI plugin {field} path does not exist")
+    screenshots = interface.get("screenshots", [])
+    if screenshots is not None:
+        if not isinstance(screenshots, list):
+            errors.append("OpenAI plugin screenshots must be a list")
+        else:
+            for value in screenshots:
+                target = _safe_repo_path(root, value) if isinstance(value, str) else None
+                if target is None:
+                    errors.append("unsafe OpenAI plugin screenshot path")
+                elif not target.is_file():
+                    errors.append(f"OpenAI plugin screenshot path does not exist: {value}")
+
+
+def _validate_marketplace(root: Path, marketplace: dict[str, Any], errors: list[str]) -> None:
+    if marketplace.get("name") != "mamdouh-creative-tools":
+        errors.append("Codex marketplace name drift")
+    interface = marketplace.get("interface")
+    if not isinstance(interface, dict) or not interface.get("displayName"):
+        errors.append("Codex marketplace missing interface.displayName")
+    plugins = marketplace.get("plugins")
+    if not isinstance(plugins, list) or len(plugins) != 1:
+        errors.append("Codex marketplace must expose exactly one plugin")
+        return
+    entry = plugins[0]
+    if not isinstance(entry, dict):
+        errors.append("Codex marketplace plugin entry must be an object")
+        return
+    if entry.get("name") != EXPECTED_NAME:
+        errors.append("Codex marketplace plugin name drift")
+    source = entry.get("source")
+    if source != {"source": "local", "path": "./"}:
+        errors.append("Codex marketplace source must resolve to local plugin root ./")
+    else:
+        target = _safe_repo_path(root, source["path"])
+        if target is None or target != root.resolve():
+            errors.append("Codex marketplace source path is unsafe or does not resolve to plugin root")
+    policy = entry.get("policy")
+    if not isinstance(policy, dict):
+        errors.append("Codex marketplace policy must be an object")
+    else:
+        if policy.get("installation") != "AVAILABLE":
+            errors.append("Codex marketplace installation policy must be AVAILABLE")
+        if policy.get("authentication") != "ON_INSTALL":
+            errors.append("Codex marketplace authentication policy must be ON_INSTALL")
+    if entry.get("category") != "Productivity":
+        errors.append("Codex marketplace category must be Productivity")
+
+
+def _validate_compatibility(root: Path, registry: dict[str, Any], errors: list[str]) -> None:
+    if registry.get("plugin_name") != EXPECTED_NAME:
+        errors.append("compatibility plugin name drift")
+    if registry.get("plugin_version") != EXPECTED_VERSION:
+        errors.append("compatibility plugin version drift")
+    surfaces = registry.get("surfaces")
+    if not isinstance(surfaces, list) or not {"codex", "chatgpt"}.issubset(set(surfaces)):
+        errors.append("compatibility surfaces must include codex and chatgpt")
+
+    manifests = registry.get("manifests")
+    expected_manifests = {
+        "openai": ".codex-plugin/plugin.json",
+        "claude": ".claude-plugin/plugin.json",
+        "openai_marketplace": ".agents/plugins/marketplace.json",
+        "claude_marketplace": ".claude-plugin/marketplace.json",
+    }
+    if not isinstance(manifests, dict):
+        errors.append("compatibility manifests must be an object")
+    else:
+        for key, expected in expected_manifests.items():
+            if manifests.get(key) != expected:
+                errors.append(f"compatibility manifest path drift: {key}")
+
+    canonical = registry.get("canonical")
+    if not isinstance(canonical, dict):
+        errors.append("compatibility canonical registry must be an object")
+    else:
+        for key, expected in EXPECTED_CANONICAL.items():
+            actual = canonical.get(key)
+            if actual != expected:
+                errors.append(f"compatibility canonical {key.replace('_', ' ')} path drift")
+                continue
+            target = _safe_repo_path(root, actual)
+            if target is None:
+                errors.append(f"unsafe compatibility canonical path: {key}")
+            elif not target.exists():
+                errors.append(f"compatibility canonical path does not exist: {key}")
+
+    submission = registry.get("public_submission")
+    if not isinstance(submission, dict) or submission.get("type") != "skills-only":
+        errors.append("compatibility public submission type must be skills-only")
+
+
+def validate_codex_plugin(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    manifest = _load_json(root / ".codex-plugin" / "plugin.json", errors, "OpenAI plugin manifest")
+    marketplace = _load_json(root / ".agents" / "plugins" / "marketplace.json", errors, "Codex marketplace")
+    registry = _load_json(root / "compatibility" / "codex.json", errors, "Codex compatibility registry")
+    claude = _load_json(root / ".claude-plugin" / "plugin.json", errors, "Claude plugin manifest")
+
+    if manifest:
+        _validate_openai_manifest(root, manifest, errors)
+    if marketplace:
+        _validate_marketplace(root, marketplace, errors)
+    if registry:
+        _validate_compatibility(root, registry, errors)
+    if manifest and claude and manifest.get("name") != claude.get("name"):
+        errors.append("Claude/OpenAI plugin name drift")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", nargs="?", default="check", choices=("check",))
+    parser.parse_args(argv)
+    errors = validate_codex_plugin(ROOT)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        print(f"Codex plugin validation: FAIL ({len(errors)} findings)")
+        return 1
+    print("Codex plugin validation: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_codex_plugin.py
+++ b/scripts/validate_codex_plugin.py
@@ -36,6 +36,20 @@ REQUIRED_INTERFACE = {
     "termsOfServiceURL",
     "defaultPrompt",
 }
+REQUIRED_POSITIVE_CASE_FIELDS = {
+    "id",
+    "user_prompt",
+    "expected_behavior",
+    "expected_result_shape",
+    "fixture_data",
+}
+REQUIRED_NEGATIVE_CASE_FIELDS = {
+    "id",
+    "user_prompt_or_scenario",
+    "expected_safe_behavior",
+    "why_not_complete",
+}
+POLICY_FILES = ("PRIVACY.md", "TERMS.md", "SUPPORT.md")
 
 
 def _load_json(path: Path, errors: list[str], label: str) -> dict[str, Any] | None:
@@ -268,6 +282,70 @@ def _validate_codex_config(root: Path, errors: list[str]) -> None:
         errors.append(f"missing required project-scoped Codex agents: {', '.join(missing)}")
 
 
+def _validate_submission(root: Path, errors: list[str]) -> None:
+    for filename in POLICY_FILES:
+        path = root / filename
+        if not path.is_file():
+            errors.append(f"missing public policy document {filename}")
+        elif len(path.read_text(encoding="utf-8").strip()) < 200:
+            errors.append(f"public policy document is unexpectedly small: {filename}")
+
+    metadata = _load_json(root / "submission" / "openai-plugin.json", errors, "OpenAI submission metadata")
+    cases = _load_json(root / "submission" / "test-cases.json", errors, "OpenAI submission test cases")
+    readme = root / "submission" / "README.md"
+    if not readme.is_file():
+        errors.append("missing OpenAI submission README")
+
+    if metadata:
+        if metadata.get("name") != EXPECTED_NAME:
+            errors.append("OpenAI submission plugin name drift")
+        if metadata.get("version") != EXPECTED_VERSION:
+            errors.append("OpenAI submission version drift")
+        if metadata.get("submission_type") != "skills-only":
+            errors.append("OpenAI submission type must be skills-only")
+        if metadata.get("category") != "Productivity":
+            errors.append("OpenAI submission category must be Productivity")
+        if metadata.get("submission_status") != "prepared-not-submitted":
+            errors.append("OpenAI submission status must remain prepared-not-submitted until external publication completes")
+        prompts = metadata.get("starter_prompts")
+        if not isinstance(prompts, list) or len(prompts) < 4 or any(not isinstance(item, str) or not item.strip() for item in prompts):
+            errors.append("OpenAI submission must include at least four starter prompts")
+        if not isinstance(metadata.get("release_notes"), str) or not metadata["release_notes"].strip():
+            errors.append("OpenAI submission release notes are required")
+        urls = metadata.get("urls")
+        if not isinstance(urls, dict) or any(not isinstance(urls.get(key), str) or not urls[key].startswith("https://") for key in ("website", "support", "privacy", "terms")):
+            errors.append("OpenAI submission requires public HTTPS website/support/privacy/terms URLs")
+        prerequisites = metadata.get("external_prerequisites")
+        prerequisite_text = " ".join(prerequisites).lower() if isinstance(prerequisites, list) and all(isinstance(item, str) for item in prerequisites) else ""
+        for marker in ("apps management", "verified", "manual", "review"):
+            if marker not in prerequisite_text:
+                errors.append(f"OpenAI submission external prerequisites missing marker: {marker}")
+
+    if cases:
+        positive = cases.get("positive")
+        negative = cases.get("negative")
+        if not isinstance(positive, list) or len(positive) != 5:
+            errors.append("OpenAI submission requires exactly five positive reviewer test cases")
+        if not isinstance(negative, list) or len(negative) != 3:
+            errors.append("OpenAI submission requires exactly three negative reviewer test cases")
+        if isinstance(positive, list):
+            for index, case in enumerate(positive, start=1):
+                if not isinstance(case, dict):
+                    errors.append(f"OpenAI positive reviewer case {index} must be an object")
+                    continue
+                missing = sorted(field for field in REQUIRED_POSITIVE_CASE_FIELDS if not case.get(field))
+                if missing:
+                    errors.append(f"OpenAI positive reviewer case {index} missing: {', '.join(missing)}")
+        if isinstance(negative, list):
+            for index, case in enumerate(negative, start=1):
+                if not isinstance(case, dict):
+                    errors.append(f"OpenAI negative reviewer case {index} must be an object")
+                    continue
+                missing = sorted(field for field in REQUIRED_NEGATIVE_CASE_FIELDS if not case.get(field))
+                if missing:
+                    errors.append(f"OpenAI negative reviewer case {index} missing: {', '.join(missing)}")
+
+
 def validate_codex_plugin(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     manifest = _load_json(root / ".codex-plugin" / "plugin.json", errors, "OpenAI plugin manifest")
@@ -284,6 +362,7 @@ def validate_codex_plugin(root: Path = ROOT) -> list[str]:
     if manifest and claude and manifest.get("name") != claude.get("name"):
         errors.append("Claude/OpenAI plugin name drift")
     _validate_codex_config(root, errors)
+    _validate_submission(root, errors)
 
     return errors
 

--- a/scripts/validate_codex_plugin.py
+++ b/scripts/validate_codex_plugin.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate native OpenAI/Codex plugin packaging and shared-core parity."""
+"""Validate native OpenAI/Codex packaging, submission readiness, and host parity."""
 
 from __future__ import annotations
 
@@ -85,11 +85,11 @@ def _load_toml(path: Path, errors: list[str], label: str) -> dict[str, Any] | No
 def _safe_repo_path(root: Path, relative: str) -> Path | None:
     if not isinstance(relative, str) or not relative.strip():
         return None
-    candidate = Path(relative)
-    if candidate.is_absolute():
+    supplied = Path(relative)
+    if supplied.is_absolute():
         return None
     root_resolved = root.resolve()
-    resolved = (root_resolved / candidate).resolve()
+    resolved = (root_resolved / supplied).resolve()
     try:
         resolved.relative_to(root_resolved)
     except ValueError:
@@ -117,13 +117,15 @@ def _validate_openai_manifest(root: Path, manifest: dict[str, Any], errors: list
         errors.append("OpenAI plugin interface must be an object")
         return
     for field in sorted(REQUIRED_INTERFACE):
-        value = interface.get(field)
-        if value in (None, "", []):
+        if interface.get(field) in (None, "", []):
             errors.append(f"OpenAI plugin interface missing {field}")
     if interface.get("category") != "Productivity":
         errors.append("OpenAI plugin interface category must be Productivity")
-    prompts = interface.get("defaultPrompt", [])
-    if not isinstance(prompts, list) or len(prompts) < 3 or any(not isinstance(item, str) or not item.strip() for item in prompts):
+
+    prompts = interface.get("defaultPrompt")
+    if not isinstance(prompts, list) or len(prompts) < 3 or any(
+        not isinstance(item, str) or not item.strip() for item in prompts
+    ):
         errors.append("OpenAI plugin defaultPrompt must contain at least three non-empty prompts")
 
     for field in ("composerIcon", "logo"):
@@ -135,25 +137,26 @@ def _validate_openai_manifest(root: Path, manifest: dict[str, Any], errors: list
             errors.append(f"unsafe OpenAI plugin {field} path")
         elif not target.is_file():
             errors.append(f"OpenAI plugin {field} path does not exist")
+
     screenshots = interface.get("screenshots", [])
-    if screenshots is not None:
-        if not isinstance(screenshots, list):
-            errors.append("OpenAI plugin screenshots must be a list")
-        else:
-            for value in screenshots:
-                target = _safe_repo_path(root, value) if isinstance(value, str) else None
-                if target is None:
-                    errors.append("unsafe OpenAI plugin screenshot path")
-                elif not target.is_file():
-                    errors.append(f"OpenAI plugin screenshot path does not exist: {value}")
+    if not isinstance(screenshots, list):
+        errors.append("OpenAI plugin screenshots must be a list")
+    else:
+        for value in screenshots:
+            target = _safe_repo_path(root, value) if isinstance(value, str) else None
+            if target is None:
+                errors.append("unsafe OpenAI plugin screenshot path")
+            elif not target.is_file():
+                errors.append(f"OpenAI plugin screenshot path does not exist: {value}")
 
 
-def _validate_marketplace(root: Path, marketplace: dict[str, Any], errors: list[str]) -> None:
+def _validate_codex_marketplace(root: Path, marketplace: dict[str, Any], errors: list[str]) -> None:
     if marketplace.get("name") != "mamdouh-creative-tools":
         errors.append("Codex marketplace name drift")
     interface = marketplace.get("interface")
     if not isinstance(interface, dict) or not interface.get("displayName"):
         errors.append("Codex marketplace missing interface.displayName")
+
     plugins = marketplace.get("plugins")
     if not isinstance(plugins, list) or len(plugins) != 1:
         errors.append("Codex marketplace must expose exactly one plugin")
@@ -164,6 +167,7 @@ def _validate_marketplace(root: Path, marketplace: dict[str, Any], errors: list[
         return
     if entry.get("name") != EXPECTED_NAME:
         errors.append("Codex marketplace plugin name drift")
+
     source = entry.get("source")
     if source != {"source": "local", "path": "./"}:
         errors.append("Codex marketplace source must resolve to local plugin root ./")
@@ -171,6 +175,7 @@ def _validate_marketplace(root: Path, marketplace: dict[str, Any], errors: list[
         target = _safe_repo_path(root, source["path"])
         if target is None or target != root.resolve():
             errors.append("Codex marketplace source path is unsafe or does not resolve to plugin root")
+
     policy = entry.get("policy")
     if not isinstance(policy, dict):
         errors.append("Codex marketplace policy must be an object")
@@ -183,22 +188,56 @@ def _validate_marketplace(root: Path, marketplace: dict[str, Any], errors: list[
         errors.append("Codex marketplace category must be Productivity")
 
 
+def _validate_claude_release(
+    claude: dict[str, Any] | None,
+    claude_marketplace: dict[str, Any] | None,
+    openai_manifest: dict[str, Any] | None,
+    errors: list[str],
+) -> None:
+    if claude:
+        if claude.get("name") != EXPECTED_NAME:
+            errors.append("Claude plugin name drift")
+        if claude.get("version") != EXPECTED_VERSION:
+            errors.append("Claude plugin version drift")
+        if openai_manifest and claude.get("name") != openai_manifest.get("name"):
+            errors.append("Claude/OpenAI plugin name drift")
+        if openai_manifest and claude.get("version") != openai_manifest.get("version"):
+            errors.append("Claude/OpenAI plugin version drift")
+
+    if not claude_marketplace:
+        return
+    entries = claude_marketplace.get("plugins")
+    if not isinstance(entries, list):
+        errors.append("Claude marketplace plugins must be a list")
+        return
+    matching = [entry for entry in entries if isinstance(entry, dict) and entry.get("name") == EXPECTED_NAME]
+    if len(matching) != 1:
+        errors.append("Claude marketplace must contain exactly one matching plugin entry")
+        return
+    entry = matching[0]
+    if entry.get("version") != EXPECTED_VERSION:
+        errors.append("Claude marketplace version drift")
+    if claude and entry.get("version") != claude.get("version"):
+        errors.append("Claude marketplace/plugin version drift")
+
+
 def _validate_compatibility(root: Path, registry: dict[str, Any], errors: list[str]) -> None:
     if registry.get("plugin_name") != EXPECTED_NAME:
         errors.append("compatibility plugin name drift")
     if registry.get("plugin_version") != EXPECTED_VERSION:
         errors.append("compatibility plugin version drift")
+
     surfaces = registry.get("surfaces")
     if not isinstance(surfaces, list) or not {"codex", "chatgpt"}.issubset(set(surfaces)):
         errors.append("compatibility surfaces must include codex and chatgpt")
 
-    manifests = registry.get("manifests")
     expected_manifests = {
         "openai": ".codex-plugin/plugin.json",
         "claude": ".claude-plugin/plugin.json",
         "openai_marketplace": ".agents/plugins/marketplace.json",
         "claude_marketplace": ".claude-plugin/marketplace.json",
     }
+    manifests = registry.get("manifests")
     if not isinstance(manifests, dict):
         errors.append("compatibility manifests must be an object")
     else:
@@ -227,8 +266,7 @@ def _validate_compatibility(root: Path, registry: dict[str, Any], errors: list[s
 
 
 def _validate_codex_config(root: Path, errors: list[str]) -> None:
-    config_path = root / ".codex" / "config.toml"
-    config = _load_toml(config_path, errors, "Codex repository config")
+    config = _load_toml(root / ".codex" / "config.toml", errors, "Codex repository config")
     if config is None:
         return
     agents = config.get("agents", {})
@@ -261,6 +299,7 @@ def _validate_codex_config(root: Path, errors: list[str]) -> None:
     if not agent_dir.is_dir():
         errors.append("missing .codex/agents directory")
         return
+
     found: set[str] = set()
     for path in sorted(agent_dir.glob("*.toml")):
         data = _load_toml(path, errors, f"Codex agent {path.name}")
@@ -277,6 +316,7 @@ def _validate_codex_config(root: Path, errors: list[str]) -> None:
             errors.append(f"Codex agent {path.name} missing required description")
         if not isinstance(data.get("developer_instructions"), str) or not data["developer_instructions"].strip():
             errors.append(f"Codex agent {path.name} missing required developer_instructions")
+
     missing = sorted(EXPECTED_CODEX_AGENTS - found)
     if missing:
         errors.append(f"missing required project-scoped Codex agents: {', '.join(missing)}")
@@ -292,8 +332,7 @@ def _validate_submission(root: Path, errors: list[str]) -> None:
 
     metadata = _load_json(root / "submission" / "openai-plugin.json", errors, "OpenAI submission metadata")
     cases = _load_json(root / "submission" / "test-cases.json", errors, "OpenAI submission test cases")
-    readme = root / "submission" / "README.md"
-    if not readme.is_file():
+    if not (root / "submission" / "README.md").is_file():
         errors.append("missing OpenAI submission README")
 
     if metadata:
@@ -307,16 +346,28 @@ def _validate_submission(root: Path, errors: list[str]) -> None:
             errors.append("OpenAI submission category must be Productivity")
         if metadata.get("submission_status") != "prepared-not-submitted":
             errors.append("OpenAI submission status must remain prepared-not-submitted until external publication completes")
+
         prompts = metadata.get("starter_prompts")
-        if not isinstance(prompts, list) or len(prompts) < 4 or any(not isinstance(item, str) or not item.strip() for item in prompts):
+        if not isinstance(prompts, list) or len(prompts) < 4 or any(
+            not isinstance(item, str) or not item.strip() for item in prompts
+        ):
             errors.append("OpenAI submission must include at least four starter prompts")
         if not isinstance(metadata.get("release_notes"), str) or not metadata["release_notes"].strip():
             errors.append("OpenAI submission release notes are required")
+
         urls = metadata.get("urls")
-        if not isinstance(urls, dict) or any(not isinstance(urls.get(key), str) or not urls[key].startswith("https://") for key in ("website", "support", "privacy", "terms")):
+        if not isinstance(urls, dict) or any(
+            not isinstance(urls.get(key), str) or not urls[key].startswith("https://")
+            for key in ("website", "support", "privacy", "terms")
+        ):
             errors.append("OpenAI submission requires public HTTPS website/support/privacy/terms URLs")
+
         prerequisites = metadata.get("external_prerequisites")
-        prerequisite_text = " ".join(prerequisites).lower() if isinstance(prerequisites, list) and all(isinstance(item, str) for item in prerequisites) else ""
+        prerequisite_text = (
+            " ".join(prerequisites).lower()
+            if isinstance(prerequisites, list) and all(isinstance(item, str) for item in prerequisites)
+            else ""
+        )
         for marker in ("apps management", "verified", "manual", "review"):
             if marker not in prerequisite_text:
                 errors.append(f"OpenAI submission external prerequisites missing marker: {marker}")
@@ -328,6 +379,7 @@ def _validate_submission(root: Path, errors: list[str]) -> None:
             errors.append("OpenAI submission requires exactly five positive reviewer test cases")
         if not isinstance(negative, list) or len(negative) != 3:
             errors.append("OpenAI submission requires exactly three negative reviewer test cases")
+
         if isinstance(positive, list):
             for index, case in enumerate(positive, start=1):
                 if not isinstance(case, dict):
@@ -336,6 +388,7 @@ def _validate_submission(root: Path, errors: list[str]) -> None:
                 missing = sorted(field for field in REQUIRED_POSITIVE_CASE_FIELDS if not case.get(field))
                 if missing:
                     errors.append(f"OpenAI positive reviewer case {index} missing: {', '.join(missing)}")
+
         if isinstance(negative, list):
             for index, case in enumerate(negative, start=1):
                 if not isinstance(case, dict):
@@ -348,22 +401,21 @@ def _validate_submission(root: Path, errors: list[str]) -> None:
 
 def validate_codex_plugin(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
-    manifest = _load_json(root / ".codex-plugin" / "plugin.json", errors, "OpenAI plugin manifest")
-    marketplace = _load_json(root / ".agents" / "plugins" / "marketplace.json", errors, "Codex marketplace")
+    openai_manifest = _load_json(root / ".codex-plugin" / "plugin.json", errors, "OpenAI plugin manifest")
+    codex_marketplace = _load_json(root / ".agents" / "plugins" / "marketplace.json", errors, "Codex marketplace")
     registry = _load_json(root / "compatibility" / "codex.json", errors, "Codex compatibility registry")
     claude = _load_json(root / ".claude-plugin" / "plugin.json", errors, "Claude plugin manifest")
+    claude_marketplace = _load_json(root / ".claude-plugin" / "marketplace.json", errors, "Claude marketplace")
 
-    if manifest:
-        _validate_openai_manifest(root, manifest, errors)
-    if marketplace:
-        _validate_marketplace(root, marketplace, errors)
+    if openai_manifest:
+        _validate_openai_manifest(root, openai_manifest, errors)
+    if codex_marketplace:
+        _validate_codex_marketplace(root, codex_marketplace, errors)
     if registry:
         _validate_compatibility(root, registry, errors)
-    if manifest and claude and manifest.get("name") != claude.get("name"):
-        errors.append("Claude/OpenAI plugin name drift")
+    _validate_claude_release(claude, claude_marketplace, openai_manifest, errors)
     _validate_codex_config(root, errors)
     _validate_submission(root, errors)
-
     return errors
 
 

--- a/scripts/validate_codex_plugin.py
+++ b/scripts/validate_codex_plugin.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import tomllib
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_NAME = "linkedin-animated-infographics"
 EXPECTED_VERSION = "3.2.0"
+EXPECTED_CODEX_AGENTS = {"explorer", "reviewer", "docs_researcher"}
 EXPECTED_CANONICAL = {
     "skills_root": "skills",
     "agents_root": "agents",
@@ -47,6 +49,21 @@ def _load_json(path: Path, errors: list[str], label: str) -> dict[str, Any] | No
         return None
     if not isinstance(data, dict):
         errors.append(f"{label} root must be an object")
+        return None
+    return data
+
+
+def _load_toml(path: Path, errors: list[str], label: str) -> dict[str, Any] | None:
+    if not path.is_file():
+        errors.append(f"missing {label}: {path}")
+        return None
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        errors.append(f"invalid TOML in {label}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{label} root must be a table")
         return None
     return data
 
@@ -195,6 +212,62 @@ def _validate_compatibility(root: Path, registry: dict[str, Any], errors: list[s
         errors.append("compatibility public submission type must be skills-only")
 
 
+def _validate_codex_config(root: Path, errors: list[str]) -> None:
+    config_path = root / ".codex" / "config.toml"
+    config = _load_toml(config_path, errors, "Codex repository config")
+    if config is None:
+        return
+    agents = config.get("agents", {})
+    if not isinstance(agents, dict):
+        errors.append("Codex repository config agents must be a table")
+        return
+    if agents.get("enabled") is not True:
+        errors.append("Codex repository config must explicitly enable agents")
+    if agents.get("max_concurrent_threads_per_session") != 6:
+        errors.append("Codex repository config max_concurrent_threads_per_session must be 6")
+    if "max_threads" in agents:
+        errors.append("Codex repository config must not use legacy agents.max_threads")
+
+    for key, contract in agents.items():
+        if not isinstance(contract, dict):
+            continue
+        config_file = contract.get("config_file")
+        if config_file is None:
+            continue
+        if not isinstance(config_file, str):
+            errors.append(f"Codex agent config reference for {key} must be a string")
+            continue
+        target = _safe_repo_path(root / ".codex", config_file)
+        if target is None:
+            errors.append(f"unsafe Codex agent config reference for {key}: {config_file}")
+        elif not target.is_file():
+            errors.append(f"Codex agent config reference does not exist for {key}: {config_file}")
+
+    agent_dir = root / ".codex" / "agents"
+    if not agent_dir.is_dir():
+        errors.append("missing .codex/agents directory")
+        return
+    found: set[str] = set()
+    for path in sorted(agent_dir.glob("*.toml")):
+        data = _load_toml(path, errors, f"Codex agent {path.name}")
+        if data is None:
+            continue
+        name = data.get("name")
+        if not isinstance(name, str) or not name.strip():
+            errors.append(f"Codex agent {path.name} missing required name")
+            continue
+        found.add(name)
+        if path.stem != name:
+            errors.append(f"Codex agent filename/name drift: {path.name} != {name}")
+        if not isinstance(data.get("description"), str) or not data["description"].strip():
+            errors.append(f"Codex agent {path.name} missing required description")
+        if not isinstance(data.get("developer_instructions"), str) or not data["developer_instructions"].strip():
+            errors.append(f"Codex agent {path.name} missing required developer_instructions")
+    missing = sorted(EXPECTED_CODEX_AGENTS - found)
+    if missing:
+        errors.append(f"missing required project-scoped Codex agents: {', '.join(missing)}")
+
+
 def validate_codex_plugin(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     manifest = _load_json(root / ".codex-plugin" / "plugin.json", errors, "OpenAI plugin manifest")
@@ -210,6 +283,7 @@ def validate_codex_plugin(root: Path = ROOT) -> list[str]:
         _validate_compatibility(root, registry, errors)
     if manifest and claude and manifest.get("name") != claude.get("name"):
         errors.append("Claude/OpenAI plugin name drift")
+    _validate_codex_config(root, errors)
 
     return errors
 

--- a/scripts/validate_codex_plugin.py
+++ b/scripts/validate_codex_plugin.py
@@ -104,11 +104,12 @@ def _validate_openai_manifest(root: Path, manifest: dict[str, Any], errors: list
         errors.append("OpenAI plugin version drift")
 
     skills_value = manifest.get("skills")
-    if skills_value != "./skills/":
-        errors.append("OpenAI plugin skills path must be ./skills/")
-    skills_path = _safe_repo_path(root, skills_value or "")
+    skills_path = _safe_repo_path(root, skills_value) if isinstance(skills_value, str) else None
+    expected_skills = (root / "skills").resolve()
     if skills_path is None:
         errors.append("unsafe OpenAI plugin skills path")
+    elif skills_path != expected_skills:
+        errors.append("OpenAI plugin skills path must resolve to the canonical skills root")
     elif not skills_path.is_dir():
         errors.append("OpenAI plugin skills path does not resolve to a directory")
 
@@ -169,12 +170,17 @@ def _validate_codex_marketplace(root: Path, marketplace: dict[str, Any], errors:
         errors.append("Codex marketplace plugin name drift")
 
     source = entry.get("source")
-    if source != {"source": "local", "path": "./"}:
-        errors.append("Codex marketplace source must resolve to local plugin root ./")
+    if not isinstance(source, dict):
+        errors.append("Codex marketplace source must be an object")
     else:
-        target = _safe_repo_path(root, source["path"])
-        if target is None or target != root.resolve():
-            errors.append("Codex marketplace source path is unsafe or does not resolve to plugin root")
+        if source.get("source") != "local":
+            errors.append("Codex marketplace source type must be local")
+        source_path = source.get("path")
+        target = _safe_repo_path(root, source_path) if isinstance(source_path, str) else None
+        if target is None:
+            errors.append("Codex marketplace source path is unsafe")
+        elif target != root.resolve():
+            errors.append("Codex marketplace source path must resolve to plugin root")
 
     policy = entry.get("policy")
     if not isinstance(policy, dict):

--- a/scripts/validate_marketplace.py
+++ b/scripts/validate_marketplace.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_PLUGIN_VERSION = "3.1.0"
+EXPECTED_PLUGIN_VERSION = "3.2.0"
 
 
 def _load_json(path: Path, errors: list[str]):

--- a/submission/README.md
+++ b/submission/README.md
@@ -1,0 +1,53 @@
+# OpenAI Plugin Submission Handoff
+
+This directory prepares LinkedIn Animated Infographics for the universal OpenAI Plugins Directory used by ChatGPT and Codex.
+
+The repository does not submit or publish the plugin automatically. Final submission is a manual OpenAI Platform action performed by a verified publisher with the required organization permissions.
+
+## Prepared package
+
+- OpenAI manifest: `../.codex-plugin/plugin.json`
+- canonical skills bundle: `../skills/`
+- listing metadata: `openai-plugin.json`
+- reviewer cases: `test-cases.json`
+- privacy policy: `../PRIVACY.md`
+- terms: `../TERMS.md`
+- support: `../SUPPORT.md`
+
+Version 3.2.0 is a skills-only plugin. There is no maintainer-owned MCP server to register for this release.
+
+## Reviewer tests
+
+OpenAI currently requires at least five positive and three negative test cases. This repository tracks exactly five positive and three negative cases in `test-cases.json` so changes are reviewable and deterministic.
+
+Before submission, run the repository validation gate and exercise the cases on the final packaged skill tree. Record any environment-specific fixture details needed by the reviewer without adding credentials or private customer data to the repository.
+
+## Manual OpenAI Platform steps
+
+1. Use an OpenAI organization where the publisher has Apps Management write access
+2. Complete or confirm the required individual or business developer verification
+3. Open the OpenAI Platform plugin submission flow
+4. Submit the skills-only plugin package and listing information from `openai-plugin.json`
+5. Add the five positive and three negative reviewer cases from `test-cases.json`
+6. Select the intended country or region availability in the Platform form
+7. Submit for OpenAI review
+8. After approval, use the publisher controls to publish when ready
+
+Do not describe the plugin as publicly available until the OpenAI review and publication steps have actually completed.
+
+## Pre-submission validation
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -v
+python3 scripts/ecosystem_router.py check
+python3 scripts/research_gates.py check
+python3 scripts/plugin_graph.py check
+python3 scripts/ecosystem_doctor.py check
+python3 scripts/demo_gallery.py check
+python3 scripts/validate_marketplace.py
+python3 scripts/validate_codex_plugin.py
+```
+
+The validator checks tracked submission structure and cross-host parity. It cannot verify external publisher identity, organization permissions, country selection, OpenAI review status, or final publication state.

--- a/submission/openai-plugin.json
+++ b/submission/openai-plugin.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "name": "linkedin-animated-infographics",
+  "display_name": "LinkedIn Animated Infographics",
+  "version": "3.2.0",
+  "submission_type": "skills-only",
+  "category": "Productivity",
+  "developer": "Mamdouh Aboammar",
+  "description": "Create animated LinkedIn visual stories with concept exploration, hook-driven copy, Info-stories, deterministic motion, strict QA, and opt-in community publishing.",
+  "urls": {
+    "website": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
+    "support": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics/blob/main/SUPPORT.md",
+    "privacy": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics/blob/main/PRIVACY.md",
+    "terms": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics/blob/main/TERMS.md"
+  },
+  "starter_prompts": [
+    "Turn this idea into an animated LinkedIn infographic with a strong visual hook and a useful aha moment.",
+    "Create an Info-story from this material and choose the best story shape before designing it.",
+    "Review this finished LinkedIn infographic and tell me what must be fixed before publishing.",
+    "Animate this named mascot using the exact SVG I attached.",
+    "Prepare this verified demo for the community gallery and ask before publishing anything."
+  ],
+  "skills_bundle": "./skills/",
+  "manifest": ".codex-plugin/plugin.json",
+  "test_cases": "submission/test-cases.json",
+  "release_notes": "Version 3.2.0 adds first-class Codex and ChatGPT plugin packaging, a repo-scoped OpenAI marketplace, native Codex maintenance-agent configuration, cross-host parity validation, and public submission materials while keeping the existing Claude plugin and one canonical skill tree.",
+  "availability": "select-during-platform-submission",
+  "external_prerequisites": [
+    "Apps Management write access in the OpenAI organization used for publishing",
+    "Verified individual or business developer identity for the publisher",
+    "Manual country or region availability selection in the OpenAI Platform submission form",
+    "Manual OpenAI Platform submission followed by OpenAI review and publisher-triggered publication after approval"
+  ],
+  "submission_status": "prepared-not-submitted"
+}

--- a/submission/test-cases.json
+++ b/submission/test-cases.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "positive": [
+    {
+      "id": "create-post",
+      "user_prompt": "Turn these supplied campaign notes into an animated LinkedIn infographic with a strong visual hook and a useful aha moment.",
+      "expected_behavior": "Route to create-post, inspect supplied evidence, generate multiple creative directions, resolve one story shape, build the artboard and motion, run render QA and independent story verification, then return the finished artifacts. Community sharing may be offered only after verified delivery.",
+      "expected_result_shape": "A verified final HTML/GIF package plus bounded reports and caption assets, or a clear HOLD if a blocking requirement cannot be satisfied.",
+      "fixture_data": "Use a short local Markdown brief containing a headline, three supported facts, and one CTA. No network dependency is required."
+    },
+    {
+      "id": "info-story",
+      "user_prompt": "Create an Info-story that explains why a product metric changed, and choose the story structure before designing it.",
+      "expected_behavior": "Route to info-story, use the merged Info-stories registry, generate evidence-safe concepts, select a story archetype and visual style, and preserve hook, creative-payoff, restrained-color, and center-first gates.",
+      "expected_result_shape": "A resolved story brief or concept package with the chosen archetype/style, copy hook, visual hook, aha mechanic, and evidence dependencies.",
+      "fixture_data": "Use a local brief with old metric, new metric, date range, and two evidence-backed drivers."
+    },
+    {
+      "id": "qa",
+      "user_prompt": "Review this finished LinkedIn infographic before I publish it. Check copy, hierarchy, evidence, motion, and rendering.",
+      "expected_behavior": "Route to qa, run render QA, adversarial post critique, and story verification without redesigning unrelated content. Report blocking findings separately from advisory polish.",
+      "expected_result_shape": "A bounded QA/verifier report with PASS, fixable failure, or blocking HOLD plus concrete evidence for every failure.",
+      "fixture_data": "Use a local finished HTML/GIF fixture and its evidence/verification inputs."
+    },
+    {
+      "id": "exact-svg-mascot",
+      "user_prompt": "Use the exact mascot SVG I attached and animate it inside this infographic without changing its identity.",
+      "expected_behavior": "Activate the exact-SVG asset gate, verify the provided asset resolves to an SVG, preserve identity, and route mascot animation through the declared mascot skill/worker contract.",
+      "expected_result_shape": "A mascot motion contract integrated into the final artboard, or HOLD if the supplied SVG is invalid or unavailable.",
+      "fixture_data": "Attach a local valid SVG file and a simple infographic brief."
+    },
+    {
+      "id": "share-demo",
+      "user_prompt": "Yes, share this verified demo with the community gallery under my GitHub account.",
+      "expected_behavior": "Only after explicit consent and final verification PASS, prepare exactly demo.gif, index.html, and demo.json, run export/privacy and gallery checks, then use authenticated GitHub contribution tooling to create or reuse the contributor fork, create a fresh community branch, commit the scoped package plus regenerated catalog, push, and open a PR. Stop at the PR.",
+      "expected_result_shape": "A real open PR URL targeting upstream main, contributor fork/branch, demo path, validation summary, and explicit status awaiting maintainer manual review and merge.",
+      "fixture_data": "Use a verified build directory containing final post.html, post.gif, verification-report.json with PASS, contributor metadata, and explicit rights confirmation."
+    }
+  ],
+  "negative": [
+    {
+      "id": "missing-exact-svg",
+      "user_prompt_or_scenario": "Animate our official named mascot, but no exact SVG asset is supplied or resolvable.",
+      "expected_safe_behavior": "Return HOLD and request the exact SVG. Do not redraw, substitute, approximate, or fabricate the mascot.",
+      "why_not_complete": "Named or official mascot identity is protected by a blocking exact-SVG asset gate."
+    },
+    {
+      "id": "unsafe-demo-export",
+      "user_prompt_or_scenario": "Publish a community demo whose HTML or metadata contains a credential-like token, local absolute path, signed URL, or unreviewed remote executable script.",
+      "expected_safe_behavior": "Fail closed during submission/gallery validation and return HOLD with the named export-safety finding. Do not create or push the contribution PR until the unsafe content is removed or explicitly reviewed where the contract permits review.",
+      "why_not_complete": "Public export must not leak credentials, private local paths, signed URLs, or bypass executable-resource review."
+    },
+    {
+      "id": "share-without-consent",
+      "user_prompt_or_scenario": "A demo passes QA, but the user has not explicitly agreed to share it or has declined the sharing offer.",
+      "expected_safe_behavior": "Do not invoke share-demo or community-publisher and perform zero GitHub publication writes. End after delivering the verified result.",
+      "why_not_complete": "Community publishing is optional and requires explicit user consent plus rights confirmation."
+    }
+  ]
+}

--- a/tests/test_codex_ci.py
+++ b/tests/test_codex_ci.py
@@ -1,0 +1,38 @@
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "claude-plugin-validation.yml"
+
+
+class DualHostCIContractTests(unittest.TestCase):
+    def test_workflow_is_host_neutral_and_runs_codex_validator(self):
+        text = WORKFLOW.read_text()
+        self.assertIn("name: Plugin Validation", text)
+        self.assertIn("python3 scripts/validate_codex_plugin.py", text)
+        self.assertIn("Validate Codex and OpenAI plugin contract", text)
+
+    def test_workflow_parses_all_openai_contract_json(self):
+        text = WORKFLOW.read_text()
+        for relative in (
+            ".codex-plugin/plugin.json",
+            ".agents/plugins/marketplace.json",
+            "compatibility/codex.json",
+            "submission/openai-plugin.json",
+            "submission/test-cases.json",
+        ):
+            self.assertIn(f"python3 -m json.tool {relative}", text, relative)
+
+    def test_existing_claude_validation_and_smoke_remain_required(self):
+        text = WORKFLOW.read_text()
+        self.assertIn("claude plugin validate .", text)
+        self.assertIn("claude plugin marketplace add ./ --scope user", text)
+        self.assertIn("claude plugin install linkedin-animated-infographics@mamdouh-creative-tools", text)
+
+    def test_ci_does_not_invent_codex_install_command(self):
+        text = WORKFLOW.read_text()
+        self.assertNotIn("codex plugin install", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -1,4 +1,7 @@
+import importlib.util
 import json
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -6,6 +9,38 @@ ROOT = Path(__file__).resolve().parents[1]
 CODEX_PLUGIN = ROOT / ".codex-plugin" / "plugin.json"
 CODEX_MARKETPLACE = ROOT / ".agents" / "plugins" / "marketplace.json"
 CLAUDE_PLUGIN = ROOT / ".claude-plugin" / "plugin.json"
+COMPATIBILITY = ROOT / "compatibility" / "codex.json"
+VALIDATOR = ROOT / "scripts" / "validate_codex_plugin.py"
+
+
+def load_validator():
+    if not VALIDATOR.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("validate_codex_plugin", VALIDATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def copy_fixture(root: Path):
+    for relative in (
+        ".claude-plugin",
+        ".codex-plugin",
+        ".agents",
+        ".codex",
+        "skills",
+        "helper",
+        "architecture",
+        "compatibility",
+        "submission",
+    ):
+        source = ROOT / relative
+        if source.exists():
+            shutil.copytree(source, root / relative)
+    for relative in ("PRIVACY.md", "TERMS.md", "SUPPORT.md"):
+        source = ROOT / relative
+        if source.exists():
+            shutil.copy2(source, root / relative)
 
 
 class CodexPluginPackagingTests(unittest.TestCase):
@@ -54,10 +89,79 @@ class CodexPluginPackagingTests(unittest.TestCase):
         self.assertEqual("Productivity", entry["category"])
 
     def test_codex_and_claude_plugin_identity_stays_shared(self):
-        self.assertTrue(CODEX_PLUGIN.exists(), "missing .codex-plugin/plugin.json")
         codex = json.loads(CODEX_PLUGIN.read_text())
         claude = json.loads(CLAUDE_PLUGIN.read_text())
         self.assertEqual(claude["name"], codex["name"])
+
+
+class CodexPluginParityTests(unittest.TestCase):
+    def require_validator(self):
+        module = load_validator()
+        self.assertIsNotNone(module, "missing scripts/validate_codex_plugin.py")
+        return module
+
+    def test_compatibility_registry_declares_shared_core(self):
+        self.assertTrue(COMPATIBILITY.exists(), "missing compatibility/codex.json")
+        data = json.loads(COMPATIBILITY.read_text())
+        self.assertEqual("3.2.0", data["plugin_version"])
+        self.assertEqual("skills", data["canonical"]["skills_root"])
+        self.assertEqual("helper/router.json", data["canonical"]["router"])
+        self.assertEqual("architecture/plugin-graph.json", data["canonical"]["worker_graph"])
+        self.assertEqual("skills-only", data["public_submission"]["type"])
+        self.assertIn("codex", data["surfaces"])
+        self.assertIn("chatgpt", data["surfaces"])
+
+    def test_validator_reports_clean_repository(self):
+        module = self.require_validator()
+        self.assertEqual([], module.validate_codex_plugin(ROOT))
+
+    def test_validator_rejects_version_drift(self):
+        module = self.require_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / ".codex-plugin" / "plugin.json"
+            data = json.loads(path.read_text())
+            data["version"] = "9.9.9"
+            path.write_text(json.dumps(data))
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("version" in error.lower() and "drift" in error.lower() for error in errors), errors)
+
+    def test_validator_rejects_skills_path_escape(self):
+        module = self.require_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / ".codex-plugin" / "plugin.json"
+            data = json.loads(path.read_text())
+            data["skills"] = "../outside-skills"
+            path.write_text(json.dumps(data))
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("unsafe" in error.lower() and "skills" in error.lower() for error in errors), errors)
+
+    def test_validator_rejects_marketplace_policy_drift(self):
+        module = self.require_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / ".agents" / "plugins" / "marketplace.json"
+            data = json.loads(path.read_text())
+            data["plugins"][0]["policy"]["installation"] = "INSTALLED_BY_DEFAULT"
+            path.write_text(json.dumps(data))
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("marketplace" in error.lower() and "installation" in error.lower() for error in errors), errors)
+
+    def test_validator_rejects_compatibility_path_drift(self):
+        module = self.require_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / "compatibility" / "codex.json"
+            data = json.loads(path.read_text())
+            data["canonical"]["router"] = "helper/not-real.json"
+            path.write_text(json.dumps(data))
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("compatibility" in error.lower() and "router" in error.lower() for error in errors), errors)
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import shutil
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -11,6 +12,13 @@ CODEX_MARKETPLACE = ROOT / ".agents" / "plugins" / "marketplace.json"
 CLAUDE_PLUGIN = ROOT / ".claude-plugin" / "plugin.json"
 COMPATIBILITY = ROOT / "compatibility" / "codex.json"
 VALIDATOR = ROOT / "scripts" / "validate_codex_plugin.py"
+CODEX_CONFIG = ROOT / ".codex" / "config.toml"
+CODEX_AGENT_DIR = ROOT / ".codex" / "agents"
+EXPECTED_CODEX_AGENTS = {
+    "explorer": "read-only",
+    "reviewer": "read-only",
+    "docs_researcher": "read-only",
+}
 
 
 def load_validator():
@@ -31,6 +39,7 @@ def copy_fixture(root: Path):
         "skills",
         "helper",
         "architecture",
+        "research",
         "compatibility",
         "submission",
     ):
@@ -162,6 +171,50 @@ class CodexPluginParityTests(unittest.TestCase):
             path.write_text(json.dumps(data))
             errors = module.validate_codex_plugin(root)
             self.assertTrue(any("compatibility" in error.lower() and "router" in error.lower() for error in errors), errors)
+
+
+class CodexRepositoryAgentTests(unittest.TestCase):
+    def require_validator(self):
+        module = load_validator()
+        self.assertIsNotNone(module, "missing scripts/validate_codex_plugin.py")
+        return module
+
+    def test_codex_config_uses_current_subagent_controls(self):
+        data = tomllib.loads(CODEX_CONFIG.read_text())
+        agents = data.get("agents", {})
+        self.assertIs(True, agents.get("enabled"))
+        self.assertEqual(6, agents.get("max_concurrent_threads_per_session"))
+        self.assertNotIn("max_threads", agents)
+
+    def test_project_scoped_codex_agents_are_real_and_narrow(self):
+        self.assertTrue(CODEX_AGENT_DIR.is_dir(), "missing .codex/agents")
+        for filename, expected_sandbox in EXPECTED_CODEX_AGENTS.items():
+            path = CODEX_AGENT_DIR / f"{filename}.toml"
+            self.assertTrue(path.is_file(), f"missing {path.relative_to(ROOT)}")
+            data = tomllib.loads(path.read_text())
+            self.assertEqual(filename, data.get("name"))
+            self.assertTrue(data.get("description"))
+            self.assertTrue(data.get("developer_instructions"))
+            self.assertEqual(expected_sandbox, data.get("sandbox_mode"))
+
+    def test_installed_plugin_does_not_depend_on_repo_codex_config(self):
+        manifest = json.loads(CODEX_PLUGIN.read_text())
+        text = json.dumps(manifest)
+        self.assertNotIn(".codex/config.toml", text)
+        self.assertNotIn(".codex/agents", text)
+
+    def test_validator_rejects_explicit_dead_agent_config_reference(self):
+        module = self.require_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            config_path = root / ".codex" / "config.toml"
+            config_path.write_text(
+                config_path.read_text()
+                + '\n[agents.broken]\ndescription = "broken fixture"\nconfig_file = "agents/not-real.toml"\n'
+            )
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("agent config" in error.lower() and "not-real.toml" in error for error in errors), errors)
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_plugin.py
+++ b/tests/test_codex_plugin.py
@@ -1,0 +1,64 @@
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CODEX_PLUGIN = ROOT / ".codex-plugin" / "plugin.json"
+CODEX_MARKETPLACE = ROOT / ".agents" / "plugins" / "marketplace.json"
+CLAUDE_PLUGIN = ROOT / ".claude-plugin" / "plugin.json"
+
+
+class CodexPluginPackagingTests(unittest.TestCase):
+    def test_openai_plugin_manifest_exists_and_uses_canonical_skills(self):
+        self.assertTrue(CODEX_PLUGIN.exists(), "missing .codex-plugin/plugin.json")
+        data = json.loads(CODEX_PLUGIN.read_text())
+        self.assertEqual("linkedin-animated-infographics", data["name"])
+        self.assertEqual("3.2.0", data["version"])
+        self.assertEqual("./skills/", data["skills"])
+        self.assertEqual("Mamdouh Aboammar", data["author"]["name"])
+        self.assertEqual(
+            "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
+            data["repository"],
+        )
+
+    def test_openai_plugin_manifest_has_install_surface_metadata(self):
+        self.assertTrue(CODEX_PLUGIN.exists(), "missing .codex-plugin/plugin.json")
+        interface = json.loads(CODEX_PLUGIN.read_text())["interface"]
+        for field in (
+            "displayName",
+            "shortDescription",
+            "longDescription",
+            "developerName",
+            "category",
+            "capabilities",
+            "websiteURL",
+            "privacyPolicyURL",
+            "termsOfServiceURL",
+            "defaultPrompt",
+        ):
+            self.assertTrue(interface.get(field), field)
+        self.assertEqual("Productivity", interface["category"])
+        self.assertGreaterEqual(len(interface["defaultPrompt"]), 3)
+
+    def test_repo_marketplace_exposes_root_plugin(self):
+        self.assertTrue(CODEX_MARKETPLACE.exists(), "missing .agents/plugins/marketplace.json")
+        data = json.loads(CODEX_MARKETPLACE.read_text())
+        self.assertEqual("mamdouh-creative-tools", data["name"])
+        self.assertEqual("Mamdouh Creative Tools", data["interface"]["displayName"])
+        self.assertEqual(1, len(data["plugins"]))
+        entry = data["plugins"][0]
+        self.assertEqual("linkedin-animated-infographics", entry["name"])
+        self.assertEqual({"source": "local", "path": "./"}, entry["source"])
+        self.assertEqual("AVAILABLE", entry["policy"]["installation"])
+        self.assertEqual("ON_INSTALL", entry["policy"]["authentication"])
+        self.assertEqual("Productivity", entry["category"])
+
+    def test_codex_and_claude_plugin_identity_stays_shared(self):
+        self.assertTrue(CODEX_PLUGIN.exists(), "missing .codex-plugin/plugin.json")
+        codex = json.loads(CODEX_PLUGIN.read_text())
+        claude = json.loads(CLAUDE_PLUGIN.read_text())
+        self.assertEqual(claude["name"], codex["name"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_release_parity.py
+++ b/tests/test_codex_release_parity.py
@@ -1,0 +1,72 @@
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate_codex_plugin.py"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_codex_plugin_release", VALIDATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def copy_fixture(root: Path):
+    for relative in (
+        ".claude-plugin",
+        ".codex-plugin",
+        ".agents",
+        ".codex",
+        "skills",
+        "agents",
+        "assets",
+        "helper",
+        "architecture",
+        "research",
+        "compatibility",
+        "submission",
+    ):
+        source = ROOT / relative
+        if source.exists():
+            shutil.copytree(source, root / relative)
+    for relative in ("PRIVACY.md", "TERMS.md", "SUPPORT.md"):
+        shutil.copy2(ROOT / relative, root / relative)
+
+
+class CodexReleaseParityTests(unittest.TestCase):
+    def test_validator_rejects_claude_plugin_version_drift(self):
+        module = load_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / ".claude-plugin" / "plugin.json"
+            data = json.loads(path.read_text())
+            data["version"] = "3.1.9"
+            path.write_text(json.dumps(data))
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("claude" in error.lower() and "version" in error.lower() for error in errors), errors)
+
+    def test_validator_rejects_claude_marketplace_version_drift(self):
+        module = load_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / ".claude-plugin" / "marketplace.json"
+            data = json.loads(path.read_text())
+            data["plugins"][0]["version"] = "3.1.9"
+            path.write_text(json.dumps(data))
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("claude marketplace" in error.lower() and "version" in error.lower() for error in errors), errors)
+
+    def test_validator_accepts_current_release_parity(self):
+        module = load_validator()
+        self.assertEqual([], module.validate_codex_plugin(ROOT))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_review_fixes.py
+++ b/tests/test_codex_review_fixes.py
@@ -1,0 +1,77 @@
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate_codex_plugin.py"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_codex_plugin_review", VALIDATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def copy_fixture(root: Path):
+    for relative in (
+        ".claude-plugin",
+        ".codex-plugin",
+        ".agents",
+        ".codex",
+        "skills",
+        "agents",
+        "assets",
+        "helper",
+        "architecture",
+        "research",
+        "compatibility",
+        "submission",
+    ):
+        source = ROOT / relative
+        if source.exists():
+            shutil.copytree(source, root / relative)
+    for relative in ("PRIVACY.md", "TERMS.md", "SUPPORT.md"):
+        shutil.copy2(ROOT / relative, root / relative)
+
+
+class CodexReviewFixTests(unittest.TestCase):
+    def test_support_security_reference_resolves(self):
+        support = (ROOT / "SUPPORT.md").read_text()
+        self.assertIn("SECURITY.md", support)
+        security = ROOT / "SECURITY.md"
+        self.assertTrue(security.is_file(), "SUPPORT.md references missing SECURITY.md")
+        self.assertGreater(len(security.read_text().strip()), 200)
+
+    def test_validator_accepts_semantically_equivalent_skills_path(self):
+        module = load_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / ".codex-plugin" / "plugin.json"
+            data = json.loads(path.read_text())
+            data["skills"] = "./skills"
+            path.write_text(json.dumps(data))
+            self.assertEqual([], module.validate_codex_plugin(root))
+
+    def test_validator_accepts_semantically_equivalent_marketplace_root_with_metadata(self):
+        module = load_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / ".agents" / "plugins" / "marketplace.json"
+            data = json.loads(path.read_text())
+            data["plugins"][0]["source"] = {
+                "source": "local",
+                "path": ".",
+                "label": "repository root"
+            }
+            path.write_text(json.dumps(data))
+            self.assertEqual([], module.validate_codex_plugin(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cross_host_hooks.py
+++ b/tests/test_cross_host_hooks.py
@@ -1,0 +1,58 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "post_tool_artboard_lint.py"
+HOOKS = ROOT / "hooks" / "hooks.json"
+
+
+def load_module():
+    if not SCRIPT.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("post_tool_artboard_lint", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CrossHostHookTests(unittest.TestCase):
+    def test_hook_delegates_to_cross_host_adapter(self):
+        hooks = json.loads(HOOKS.read_text())
+        command = hooks["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+        self.assertIn("post_tool_artboard_lint.py", command)
+        self.assertIn("PLUGIN_ROOT", command)
+        self.assertIn("CLAUDE_PLUGIN_ROOT", command)
+        self.assertEqual("Write|Edit", hooks["hooks"]["PostToolUse"][0]["matcher"])
+
+    def test_adapter_extracts_claude_write_file_path(self):
+        module = load_module()
+        self.assertIsNotNone(module, "missing scripts/post_tool_artboard_lint.py")
+        payload = {"tool_input": {"file_path": "build/post.html"}}
+        self.assertEqual(["build/post.html"], module.extract_html_targets(payload))
+
+    def test_adapter_extracts_codex_apply_patch_paths(self):
+        module = load_module()
+        self.assertIsNotNone(module, "missing scripts/post_tool_artboard_lint.py")
+        payload = {
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Update File: build/post.html\n@@\n-old\n+new\n*** End Patch"
+            },
+        }
+        self.assertEqual(["build/post.html"], module.extract_html_targets(payload))
+
+    def test_adapter_ignores_non_html_patch_paths(self):
+        module = load_module()
+        self.assertIsNotNone(module, "missing scripts/post_tool_artboard_lint.py")
+        payload = {
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Update File: README.md\n*** Add File: build/post.html\n*** End Patch"
+            }
+        }
+        self.assertEqual(["build/post.html"], module.extract_html_targets(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -13,6 +13,7 @@ DOCS = {
     "marketplace": ROOT / "docs" / "marketplace.md",
     "development": ROOT / "docs" / "development.md",
     "community_demos": ROOT / "docs" / "community-demos.md",
+    "codex": ROOT / "docs" / "codex.md",
 }
 README = ROOT / "README.md"
 DEMOS_README = ROOT / "demos" / "README.md"
@@ -30,12 +31,26 @@ class DocsContractTests(unittest.TestCase):
         for relative in (
             "docs/ecosystem.md", "docs/routing.md", "docs/agents.md", "docs/skills.md",
             "docs/research.md", "docs/marketplace.md", "docs/development.md",
-            "docs/community-demos.md", "demos/README.md",
+            "docs/community-demos.md", "docs/codex.md", "demos/README.md",
         ):
             self.assertIn(relative, text)
         self.assertIn("helper/GUIDE.md", text)
         self.assertIn("creative-director", text)
         self.assertIn("ecosystem_doctor.py", text)
+
+    def test_codex_doc_names_native_packaging_and_real_marketplace_commands(self):
+        self.assertTrue(DOCS["codex"].exists())
+        text = DOCS["codex"].read_text()
+        for needle in (
+            ".codex-plugin/plugin.json",
+            ".agents/plugins/marketplace.json",
+            "codex plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics --ref main",
+            "codex plugin marketplace list",
+            "python3 scripts/validate_codex_plugin.py",
+            "skills-only",
+            "submission-ready",
+        ):
+            self.assertIn(needle, text)
 
     def test_demo_gallery_readme_names_both_sections_and_contract(self):
         self.assertTrue(DEMOS_README.exists())
@@ -93,8 +108,11 @@ class DocsContractTests(unittest.TestCase):
         for needle in (
             "/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics",
             "/plugin install linkedin-animated-infographics@mamdouh-creative-tools",
+            "codex plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics --ref main",
+            "codex plugin marketplace list",
             "claude plugin validate .",
             "python3 scripts/validate_marketplace.py",
+            "python3 scripts/validate_codex_plugin.py",
         ):
             self.assertIn(needle, text)
 
@@ -108,6 +126,7 @@ class DocsContractTests(unittest.TestCase):
             "python3 scripts/ecosystem_doctor.py check",
             "python3 scripts/demo_gallery.py check",
             "python3 scripts/validate_marketplace.py",
+            "python3 scripts/validate_codex_plugin.py",
         ):
             self.assertIn(command, text)
 

--- a/tests/test_info_stories.py
+++ b/tests/test_info_stories.py
@@ -121,7 +121,7 @@ class InfoStoriesRegistryTests(unittest.TestCase):
         artboard=(ROOT/"agents/artboard-builder.md").read_text().lower(); motion=(ROOT/"agents/motion-engineer.md").read_text().lower(); self.assertIn("story brief",artboard); self.assertIn("story house",artboard); self.assertIn("motion pattern",motion); self.assertIn("story brief",motion)
 
     def test_plugin_version_and_readme_publish_info_stories(self):
-        plugin=json.loads((ROOT/".claude-plugin/plugin.json").read_text()); self.assertEqual("3.1.0",plugin["version"]); self.assertIn("info-stories",plugin["keywords"])
+        plugin=json.loads((ROOT/".claude-plugin/plugin.json").read_text()); self.assertEqual("3.2.0",plugin["version"]); self.assertIn("info-stories",plugin["keywords"])
         readme=(ROOT/"README.md").read_text().lower()
         for needle in ["info-stories","story house","scripts/info_stories.py","tools/palette_preview.py","tools/story_scaffold.py","tools/composition_check.py","tools/copy_slop_check.py"]: self.assertIn(needle,readme)
 

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -6,6 +6,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
 PLUGIN = ROOT / ".claude-plugin" / "plugin.json"
+CODEX_PLUGIN = ROOT / ".codex-plugin" / "plugin.json"
+CODEX_MARKETPLACE = ROOT / ".agents" / "plugins" / "marketplace.json"
 VALIDATOR = ROOT / "scripts" / "validate_marketplace.py"
 README = ROOT / "README.md"
 
@@ -32,21 +34,40 @@ class MarketplaceTests(unittest.TestCase):
         self.assertEqual("./", entry["source"])
         self.assertIs(True, entry["strict"])
 
-    def test_marketplace_and_plugin_versions_match_community_release(self):
+    def test_all_host_packages_share_release_version(self):
         market = json.loads(MARKETPLACE.read_text())["plugins"][0]
-        plugin = json.loads(PLUGIN.read_text())
-        self.assertEqual("3.1.0", plugin["version"])
-        self.assertEqual(plugin["version"], market["version"])
+        claude = json.loads(PLUGIN.read_text())
+        codex = json.loads(CODEX_PLUGIN.read_text())
+        self.assertEqual("3.2.0", claude["version"])
+        self.assertEqual(claude["version"], market["version"])
+        self.assertEqual(claude["version"], codex["version"])
 
     def test_standard_component_directories_exist(self):
-        for relative in ("skills", "agents", "hooks/hooks.json", "helper", "demos", "schemas/demo.schema.json"):
+        for relative in (
+            "skills",
+            "agents",
+            "hooks/hooks.json",
+            "helper",
+            "demos",
+            "schemas/demo.schema.json",
+            ".codex-plugin/plugin.json",
+            ".agents/plugins/marketplace.json",
+        ):
             self.assertTrue((ROOT / relative).exists(), relative)
 
-    def test_readme_documents_marketplace_install(self):
+    def test_readme_documents_claude_and_codex_install_surfaces(self):
         text = README.read_text()
         self.assertIn("/plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics", text)
         self.assertIn("/plugin install linkedin-animated-infographics@mamdouh-creative-tools", text)
-        self.assertIn("3.1.0", text)
+        self.assertIn("codex plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics --ref main", text)
+        self.assertIn("codex plugin marketplace list", text)
+        self.assertIn("3.2.0", text)
+        self.assertIn("docs/codex.md", text)
+
+    def test_codex_marketplace_is_repo_scoped(self):
+        data = json.loads(CODEX_MARKETPLACE.read_text())
+        self.assertEqual("./", data["plugins"][0]["source"]["path"])
+        self.assertEqual("AVAILABLE", data["plugins"][0]["policy"]["installation"])
 
     def test_local_marketplace_validator_is_clean(self):
         module = load_validator()

--- a/tests/test_openai_submission.py
+++ b/tests/test_openai_submission.py
@@ -1,0 +1,75 @@
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SUBMISSION = ROOT / "submission" / "openai-plugin.json"
+CASES = ROOT / "submission" / "test-cases.json"
+README = ROOT / "submission" / "README.md"
+LEGAL = (ROOT / "PRIVACY.md", ROOT / "TERMS.md", ROOT / "SUPPORT.md")
+
+
+class OpenAISubmissionContractTests(unittest.TestCase):
+    def test_public_legal_and_support_documents_exist(self):
+        for path in LEGAL:
+            self.assertTrue(path.is_file(), f"missing {path.name}")
+            self.assertGreater(len(path.read_text().strip()), 200, path.name)
+
+    def test_submission_metadata_is_skills_only_3_2_0(self):
+        self.assertTrue(SUBMISSION.is_file(), "missing submission/openai-plugin.json")
+        data = json.loads(SUBMISSION.read_text())
+        self.assertEqual("linkedin-animated-infographics", data["name"])
+        self.assertEqual("3.2.0", data["version"])
+        self.assertEqual("skills-only", data["submission_type"])
+        self.assertEqual("Productivity", data["category"])
+        self.assertGreaterEqual(len(data["starter_prompts"]), 4)
+        self.assertTrue(data["release_notes"])
+
+    def test_submission_metadata_has_public_urls_and_external_prerequisites(self):
+        data = json.loads(SUBMISSION.read_text())
+        urls = data["urls"]
+        for field in ("website", "support", "privacy", "terms"):
+            self.assertTrue(urls[field].startswith("https://github.com/imMamdouhaboammar/linkedin-animated-infographics"), field)
+        prereqs = " ".join(data["external_prerequisites"]).lower()
+        self.assertIn("apps management", prereqs)
+        self.assertIn("verified", prereqs)
+        self.assertIn("manual", prereqs)
+        self.assertIn("review", prereqs)
+
+    def test_exactly_five_positive_and_three_negative_cases(self):
+        self.assertTrue(CASES.is_file(), "missing submission/test-cases.json")
+        data = json.loads(CASES.read_text())
+        self.assertEqual(5, len(data["positive"]))
+        self.assertEqual(3, len(data["negative"]))
+
+    def test_positive_cases_have_required_reviewer_fields(self):
+        data = json.loads(CASES.read_text())
+        for case in data["positive"]:
+            for field in ("id", "user_prompt", "expected_behavior", "expected_result_shape", "fixture_data"):
+                self.assertTrue(case.get(field), f"positive {case.get('id')}: {field}")
+
+    def test_negative_cases_have_required_reviewer_fields(self):
+        data = json.loads(CASES.read_text())
+        for case in data["negative"]:
+            for field in ("id", "user_prompt_or_scenario", "expected_safe_behavior", "why_not_complete"):
+                self.assertTrue(case.get(field), f"negative {case.get('id')}: {field}")
+
+    def test_cases_cover_product_safety_boundaries(self):
+        data = json.loads(CASES.read_text())
+        positive_ids = {case["id"] for case in data["positive"]}
+        negative_ids = {case["id"] for case in data["negative"]}
+        self.assertTrue({"create-post", "info-story", "qa", "exact-svg-mascot", "share-demo"}.issubset(positive_ids))
+        self.assertTrue({"missing-exact-svg", "unsafe-demo-export", "share-without-consent"}.issubset(negative_ids))
+
+    def test_submission_readme_states_manual_external_submission(self):
+        self.assertTrue(README.is_file(), "missing submission/README.md")
+        text = README.read_text().lower()
+        self.assertIn("manual", text)
+        self.assertIn("openai platform", text)
+        self.assertIn("five positive", text)
+        self.assertIn("three negative", text)
+        self.assertNotIn("already published", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_submission.py
+++ b/tests/test_openai_submission.py
@@ -1,4 +1,7 @@
+import importlib.util
 import json
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -7,6 +10,36 @@ SUBMISSION = ROOT / "submission" / "openai-plugin.json"
 CASES = ROOT / "submission" / "test-cases.json"
 README = ROOT / "submission" / "README.md"
 LEGAL = (ROOT / "PRIVACY.md", ROOT / "TERMS.md", ROOT / "SUPPORT.md")
+VALIDATOR = ROOT / "scripts" / "validate_codex_plugin.py"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_codex_plugin_submission", VALIDATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def copy_fixture(root: Path):
+    for relative in (
+        ".claude-plugin",
+        ".codex-plugin",
+        ".agents",
+        ".codex",
+        "skills",
+        "agents",
+        "assets",
+        "helper",
+        "architecture",
+        "research",
+        "compatibility",
+        "submission",
+    ):
+        source = ROOT / relative
+        if source.exists():
+            shutil.copytree(source, root / relative)
+    for relative in ("PRIVACY.md", "TERMS.md", "SUPPORT.md"):
+        shutil.copy2(ROOT / relative, root / relative)
 
 
 class OpenAISubmissionContractTests(unittest.TestCase):
@@ -69,6 +102,27 @@ class OpenAISubmissionContractTests(unittest.TestCase):
         self.assertIn("five positive", text)
         self.assertIn("three negative", text)
         self.assertNotIn("already published", text)
+
+    def test_validator_rejects_wrong_reviewer_case_count(self):
+        module = load_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            path = root / "submission" / "test-cases.json"
+            data = json.loads(path.read_text())
+            data["positive"].pop()
+            path.write_text(json.dumps(data))
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("five positive" in error.lower() for error in errors), errors)
+
+    def test_validator_rejects_missing_public_policy_document(self):
+        module = load_validator()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copy_fixture(root)
+            (root / "PRIVACY.md").unlink()
+            errors = module.validate_codex_plugin(root)
+            self.assertTrue(any("privacy.md" in error.lower() for error in errors), errors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal

Ship version `3.2.0` as a first-class OpenAI skills-only plugin for Codex and ChatGPT while preserving Claude Code compatibility and one canonical product core.

## One core, two host packages

No Codex-only copy of the product Skills was created. Canonical runtime stays shared across `skills/`, `agents/`, `helper/`, `research/`, `architecture/`, scripts, and tests.

Host adapters:

- Claude: `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`
- Codex/ChatGPT: `.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json`

## Codex and ChatGPT packaging

- native OpenAI manifest: `.codex-plugin/plugin.json`
- canonical skills target: `./skills/`
- repo marketplace: `.agents/plugins/marketplace.json`
- marketplace policy: `AVAILABLE` / `ON_INSTALL`
- category: `Productivity`
- documented commands:
  - `codex plugin marketplace add imMamdouhaboammar/linkedin-animated-infographics --ref main`
  - `codex plugin marketplace list`
- no invented `codex plugin install` path
- no MCP server added in 3.2.0; this release is intentionally skills-only

## Codex repository development

`.codex/config.toml` now uses the current project-scoped subagent configuration model.

Real narrow maintenance agents:

- `.codex/agents/explorer.toml`
- `.codex/agents/reviewer.toml`
- `.codex/agents/docs_researcher.toml`

They are repository-development helpers only. Installed plugin behavior does not depend on the maintainer Codex config or MCP setup.

## Cross-host runtime details

`compatibility/codex.json` declares shared paths and invariants.

`scripts/validate_codex_plugin.py` fails closed on OpenAI packaging, repo marketplace, cross-host identity/version drift, unsafe paths, stale Codex config, legal/support material, submission readiness, and reviewer-case counts.

The validator now resolves canonical Skills and marketplace root paths semantically, so safe equivalents such as `./skills` and `./skills/` are treated consistently while path traversal remains blocked.

Root `hooks/hooks.json` now delegates artboard linting to `scripts/post_tool_artboard_lint.py`, which understands both Claude `file_path` hook payloads and Codex `apply_patch` command payloads. The hook remains advisory and repo/workspace-bound.

## Public OpenAI submission preparation

Tracked submission handoff:

- `submission/openai-plugin.json`
- `submission/test-cases.json`
- `submission/README.md`
- `PRIVACY.md`
- `TERMS.md`
- `SUPPORT.md`
- `SECURITY.md`

The package contains exactly five positive and three negative reviewer cases.

Repository status is `prepared-not-submitted`. Apps Management permissions, verified publisher identity, availability selection, OpenAI Platform submission, review, and publication remain external/manual steps.

## Docs and release

- release version is `3.2.0` across Claude/OpenAI public package metadata
- root README presents Claude Code + Codex + ChatGPT as first-class hosts
- `docs/codex.md` is the focused OpenAI-host guide
- marketplace, development, ecosystem, and repository guidance are dual-host aware
- existing WOW/AHA positioning and live GIF demo remain intact

## CI

Workflow is now host-neutral `Plugin Validation` and runs the complete shared runtime gate plus:

- Claude marketplace validator
- Codex/OpenAI plugin validator
- OpenAI manifest/marketplace/compatibility/submission JSON syntax checks
- official `claude plugin validate .`
- same-repository Claude marketplace add/list/install smoke

No undocumented Codex install smoke was added.

## Verification on current head

Current head: `6aa929bd1bf9503e88f5cdcd5f3b949497cdf6e9`

GitHub `Plugin Validation` run `31228618260` passed end-to-end on this exact head:

- `238` tests run
- `4` intentional research-corpus skips
- Python compile PASS
- Info-stories PASS
- ecosystem router PASS
- research gates PASS
- plugin graph PASS
- strict ecosystem doctor PASS
- demo gallery PASS
- Claude marketplace validator PASS
- Codex/OpenAI plugin validator PASS
- JSON/shell/whitespace checks PASS
- official Claude plugin validator PASS
- Claude same-repo marketplace add/list/install smoke PASS

## Review closure

Qodo reported two actionable findings. Both were fixed with regression coverage:

1. `SUPPORT.md` referenced a missing security policy, so `SECURITY.md` is now a real tracked policy file
2. Codex manifest/marketplace path validation used brittle literal equality, so it now compares safe resolved paths and permits harmless additive marketplace metadata

Both Qodo review threads are resolved. Qlty is green. CodeRabbit status is green, though its detailed review remains rate-limited and is not counted as a completed detailed review.

## Design records

- `docs/superpowers/specs/2026-08-08-codex-native-plugin-design.md`
- `docs/superpowers/plans/2026-08-08-codex-native-plugin.md`

Do not merge if the head moves, a blocking check appears, or a review thread remains unresolved.