### PR TITLE
chore: verify OpenAI visual parity 3.2.1

### DIFF
--- a/docs/superpowers/verification/2026-08-08-openai-visual-parity-ci.md
+++ b/docs/superpowers/verification/2026-08-08-openai-visual-parity-ci.md
@@ -1,0 +1,15 @@
+# OpenAI Visual Parity CI Verification
+
+This file exists to create a pull-request head over the completed 3.2.1 repository state so the repository's PR-triggered validation can run against the exact OpenAI visual parity changes.
+
+The verification target includes:
+
+- isolated `openai-skills/` packaging
+- Claude behavior regression boundary
+- directory metadata compliance
+- visual-quality failure taxonomy
+- still-before-motion gate
+- bounded repair contract
+- version and submission metadata consistency
+
+No runtime behavior is changed by this verification marker.

--- a/openai-skills/exact-svg-mascot/SKILL.md
+++ b/openai-skills/exact-svg-mascot/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: exact-svg-mascot
+description: Animate a named or official mascot using the exact user-supplied SVG while preserving its identity. Use when the mascot asset must not be redrawn, substituted, approximated, or silently regenerated.
+---
+
+# Exact SVG Mascot
+
+## Purpose
+
+Animate the exact SVG supplied by the user without changing the mascot's identity.
+
+This is an asset-integrity workflow. The supplied SVG is the identity source.
+
+## Blocking asset gate
+
+Before animation:
+
+1. confirm an SVG file was supplied or is directly available to the task
+2. confirm the file is actually SVG content and can be read
+3. preserve an untouched source copy or source representation for comparison
+4. inspect `viewBox`, visible groups/elements, transforms, clipping, and IDs/classes that may support animation
+
+If the exact SVG is missing, unreadable, or not actually SVG, return `HOLD` and request the exact asset.
+
+Do not:
+
+- redraw the mascot
+- generate a lookalike
+- substitute another mascot
+- trace a raster image into a replacement
+- replace the identity with emoji, iconography, or a generic character
+
+## Motion directions
+
+Develop 2-3 motion directions around geometry that already exists in the SVG. Examples include:
+
+- whole-character entrance or travel
+- head/body/limb motion when the SVG structure safely supports it
+- eye or expression changes only when the original SVG contains appropriate elements
+- prop movement when the prop is part of the supplied SVG
+- reading-pointer movement that guides attention through the infographic
+
+Do not invent new facial features, body parts, logos, or branded details.
+
+## Implementation rules
+
+Prefer non-destructive animation:
+
+- CSS transforms on existing SVG groups
+- SVG transforms on existing elements
+- opacity changes on existing elements
+- clip or mask animation only when existing identity remains intact
+- wrapper movement around the untouched SVG when internal rigging is unsafe
+
+Avoid rewriting path geometry unless the user explicitly asks for a morph and identity preservation can be verified.
+
+The final animated composition must keep the original mascot recognizable at every important frame.
+
+## Identity check
+
+Before delivery compare the animated mascot with the original source for:
+
+- silhouette
+- proportions
+- colors
+- logo/brand markings
+- face and defining features
+- accessory placement
+
+Any unintended identity drift is blocking.
+
+## Output
+
+Return:
+
+- asset validation verdict
+- selected motion direction
+- which original SVG elements are animated
+- identity-preservation notes
+- final artifact or integration instructions
+- final verdict: `PASS`, `FAIL:fixable`, or `HOLD`
+
+Never complete a named-mascot request by substituting an asset when the exact SVG gate fails.

--- a/openai-skills/linkedin-infographic-review/SKILL.md
+++ b/openai-skills/linkedin-infographic-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: linkedin-infographic-review
+description: Review a finished static or animated LinkedIn infographic before publishing. Check hierarchy, visual balance, dead space, generic UI patterns, copy, evidence, motion, rendering, and feed-scale legibility without redesigning unrelated content.
+---
+
+# LinkedIn Infographic Review
+
+## Purpose
+
+Run a focused pre-publish critique on an existing LinkedIn infographic. Diagnose what is blocking publication, separate required fixes from optional polish, and avoid turning review into an unrelated redesign.
+
+## Inputs
+
+Use the finished HTML, GIF, PNG, screenshots, caption, source material, or evidence the user provides.
+
+If evidence required to validate a factual claim is unavailable, mark that claim as unverified instead of inventing support.
+
+## Review order
+
+### 1. Static composition
+
+Inspect the full artboard before looking at small details.
+
+Check:
+
+- one dominant visual anchor is obvious within two seconds
+- the page has a clear macro rhythm from hook to visual relationship to takeaway
+- the composition is not top-heavy
+- there is no unexplained dead zone near the footer
+- the footer belongs to the composition instead of floating far below it
+- text remains readable at feed scale
+- copy density is solved through hierarchy and editing rather than tiny type
+
+For a 1080x1350 artboard, treat an unexplained vertical gap greater than 120px between the main composition and footer/takeaway as a blocking warning unless negative space has an intentional visual job.
+
+### 2. Component grammar
+
+Reject generic component patterns when they replace art direction.
+
+Check:
+
+- no more than two bordered containment levels
+- repeated cards exist only when repetition is meaningful
+- pills, badges, status chips, and tiny uppercase labels have semantic jobs
+- no fake dashboards, fake analytics, fake proof bars, or invented metrics
+- visual structure fits the story rather than the easiest HTML pattern
+
+### 3. Copy and evidence
+
+Check:
+
+- one primary message
+- hook is specific to the subject
+- body copy adds mechanism, evidence, comparison, consequence, or action
+- takeaway completes the idea instead of repeating the headline
+- claims, numbers, logos, product states, and proof are supported by supplied material
+- no generic filler or exaggerated marketing language
+
+### 4. Motion when animated
+
+Every meaningful animation must explain at least one of:
+
+- what should I read next?
+- what changed?
+- where did this item travel?
+- which state is active?
+
+Fail decorative motion when it dominates the explanatory motion.
+Fail `motion-on-weak-still` when the composition itself should be repaired before animation.
+
+Inspect frame zero, a representative mid-state, the final state, and the loop seam.
+
+### 5. Failure taxonomy
+
+Return PASS or FAIL for each:
+
+- `top-heavy-composition`
+- `bottom-dead-zone`
+- `nested-card-density`
+- `generic-ui-grammar`
+- `weak-macro-rhythm`
+- `weak-visual-anchor`
+- `footer-detachment`
+- `motion-on-weak-still`
+- `decorative-motion`
+- `feed-scale-legibility`
+
+## Output
+
+Return:
+
+1. verdict: `PASS`, `FAIL:fixable`, or `HOLD`
+2. blocking findings
+3. top three repair actions in priority order
+4. advisory polish, if any
+5. evidence limitations
+6. motion/render notes when applicable
+
+Do not return PASS while a severe blocking finding remains.

--- a/openai-skills/share-community-demo/SKILL.md
+++ b/openai-skills/share-community-demo/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: share-community-demo
+description: Prepare and publish a verified LinkedIn infographic demo to the community gallery through a contributor GitHub pull request. Use only after explicit user consent, rights confirmation, and final verification PASS.
+---
+
+# Share Community Demo
+
+## Purpose
+
+Prepare a verified demo for the community gallery and, when authenticated GitHub contribution tools are available, open a contributor pull request. Stop at the pull request. Never merge it automatically.
+
+## Consent gate
+
+Do nothing unless all are true:
+
+- the user explicitly agreed to share the demo
+- the final infographic verification verdict is `PASS`
+- the user confirms they have the rights to publish the included material
+
+Silence, ambiguity, or a previous decline means zero publication writes.
+
+## Public package
+
+The public demo package contains exactly:
+
+- `demo.gif`
+- `index.html`
+- `demo.json`
+
+The gallery catalog may also be regenerated as part of the contribution when the repository contract requires it.
+
+Do not copy the whole working directory.
+
+## Export safety
+
+Before any GitHub write, inspect public text and metadata for:
+
+- credential-like tokens or private keys
+- local absolute filesystem paths
+- signed or temporary private URLs
+- private customer/source material
+- remote executable scripts that have not been intentionally reviewed
+- source prompts unless the user separately consents to publish them
+
+A blocking finding returns `HOLD`. Do not push first and clean up later.
+
+## Metadata
+
+Require contributor identity appropriate for the public gallery, including the GitHub username used for the community namespace and rights confirmation.
+
+Keep sample or concept data clearly identified when it could be mistaken for real proof.
+
+## GitHub contribution flow
+
+When authenticated GitHub contribution tooling is available:
+
+1. create or reuse the user's contributor fork as appropriate
+2. create a fresh branch for the demo
+3. place the three-file package under the contributor namespace expected by the repository
+4. regenerate the catalog only when required by the repository contract
+5. commit only the scoped public contribution
+6. push the contributor branch
+7. open a pull request targeting upstream `main`
+8. stop and report the PR URL and validation status
+
+Never push directly to upstream `main` for a community submission.
+Never merge the PR automatically.
+
+If authenticated GitHub contribution tooling is unavailable, return `HOLD` with the exact missing capability instead of pretending publication happened.
+
+## Output
+
+Return:
+
+- consent and rights status
+- public package path/shape
+- export-safety verdict
+- contributor fork/branch when created
+- real pull request URL when created
+- status: awaiting maintainer review and merge
+
+A completed local package is not the same as a published community contribution.

--- a/submission/openai-plugin.json
+++ b/submission/openai-plugin.json
@@ -6,7 +6,7 @@
   "submission_type": "skills-only",
   "category": "Productivity",
   "developer": "Mamdouh Aboammar",
-  "description": "Create LinkedIn visual stories with evidence checks, concept exploration, macro-layout planning, still-first visual critique, disciplined motion, and final verification.",
+  "description": "Create LinkedIn visual stories with evidence checks, concept exploration, macro-layout planning, still-first visual critique, disciplined motion, focused QA, exact-SVG mascot handling, and verified community sharing.",
   "urls": {
     "website": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics",
     "support": "https://github.com/imMamdouhaboammar/linkedin-animated-infographics/blob/main/SUPPORT.md",
@@ -23,7 +23,7 @@
   "skills_bundle": "./openai-skills/",
   "manifest": ".codex-plugin/plugin.json",
   "test_cases": "submission/test-cases.json",
-  "release_notes": "Version 3.2.1 isolates the OpenAI skills distribution from the Claude worker runtime and adds a self-contained infographic studio workflow with macro-layout planning, still-before-motion blocking gates, measurable dead-space and containment checks, adversarial visual critique, and bounded repair loops. Claude's existing agent workflow remains behaviorally unchanged.",
+  "release_notes": "Version 3.2.1 isolates the OpenAI skills distribution from the Claude worker runtime, adds a self-contained infographic studio workflow with macro-layout planning and still-before-motion blocking gates, and preserves focused public capabilities through dedicated review, exact-SVG mascot, and community-sharing skills. Claude's existing agent workflow remains behaviorally unchanged.",
   "availability": "select-during-platform-submission",
   "external_prerequisites": [
     "Apps Management write access in the OpenAI organization used for publishing",

--- a/submission/test-cases.json
+++ b/submission/test-cases.json
@@ -4,56 +4,56 @@
     {
       "id": "create-post",
       "user_prompt": "Turn these supplied campaign notes into an animated LinkedIn infographic with a strong visual hook and a useful aha moment.",
-      "expected_behavior": "Route to create-post, inspect supplied evidence, generate multiple creative directions, resolve one story shape, build the artboard and motion, run render QA and independent story verification, then return the finished artifacts. Community sharing may be offered only after verified delivery.",
-      "expected_result_shape": "A verified final HTML/GIF package plus bounded reports and caption assets, or a clear HOLD if a blocking requirement cannot be satisfied.",
+      "expected_behavior": "Use linkedin-infographic-studio. Inspect supplied evidence, generate multiple structurally different creative directions, select a story shape and visual archetype, define macro layout before component styling, build a still, block motion until still critique passes, then implement motion and run final visual verification.",
+      "expected_result_shape": "A final static or animated artifact with the selected creative direction, visual archetype, still critique verdict, motion critique when applicable, and PASS/FAIL:fixable/HOLD verification status.",
       "fixture_data": "Use a short local Markdown brief containing a headline, three supported facts, and one CTA. No network dependency is required."
     },
     {
       "id": "info-story",
       "user_prompt": "Create an Info-story that explains why a product metric changed, and choose the story structure before designing it.",
-      "expected_behavior": "Route to info-story, use the merged Info-stories registry, generate evidence-safe concepts, select a story archetype and visual style, and preserve hook, creative-payoff, restrained-color, and center-first gates.",
-      "expected_result_shape": "A resolved story brief or concept package with the chosen archetype/style, copy hook, visual hook, aha mechanic, and evidence dependencies.",
+      "expected_behavior": "Use linkedin-infographic-studio. Build an evidence inventory, develop multiple story directions, choose a structure that fits the relationship, compress copy by visual slot, and apply the still-first visual quality contract before any motion.",
+      "expected_result_shape": "A resolved visual story with evidence-safe copy, chosen structure, useful reveal, macro layout, final artifact, and visual verification verdict.",
       "fixture_data": "Use a local brief with old metric, new metric, date range, and two evidence-backed drivers."
     },
     {
       "id": "qa",
       "user_prompt": "Review this finished LinkedIn infographic before I publish it. Check copy, hierarchy, evidence, motion, and rendering.",
-      "expected_behavior": "Route to qa, run render QA, adversarial post critique, and story verification without redesigning unrelated content. Report blocking findings separately from advisory polish.",
-      "expected_result_shape": "A bounded QA/verifier report with PASS, fixable failure, or blocking HOLD plus concrete evidence for every failure.",
-      "fixture_data": "Use a local finished HTML/GIF fixture and its evidence/verification inputs."
+      "expected_behavior": "Use linkedin-infographic-review. Inspect the whole composition before micro-details, run the visual failure taxonomy, check copy/evidence and motion, and report blocking findings separately from advisory polish without redesigning unrelated content.",
+      "expected_result_shape": "A bounded review with PASS, FAIL:fixable, or HOLD, the blocking findings, top three repair actions, evidence limitations, and motion/render notes when applicable.",
+      "fixture_data": "Use a local finished HTML/GIF or PNG fixture plus the source material needed to verify its claims."
     },
     {
       "id": "exact-svg-mascot",
       "user_prompt": "Use the exact mascot SVG I attached and animate it inside this infographic without changing its identity.",
-      "expected_behavior": "Activate the exact-SVG asset gate, verify the provided asset resolves to an SVG, preserve identity, and route mascot animation through the declared mascot skill/worker contract.",
-      "expected_result_shape": "A mascot motion contract integrated into the final artboard, or HOLD if the supplied SVG is invalid or unavailable.",
+      "expected_behavior": "Use exact-svg-mascot. Validate that the exact supplied asset is readable SVG, preserve an untouched identity source, animate existing geometry non-destructively where possible, and compare silhouette, proportions, colors, markings, face, and accessories before delivery.",
+      "expected_result_shape": "An asset-validation verdict, selected motion direction, identity-preservation notes, integrated artifact or implementation, and PASS/FAIL:fixable/HOLD status. Missing or invalid exact SVG must return HOLD.",
       "fixture_data": "Attach a local valid SVG file and a simple infographic brief."
     },
     {
       "id": "share-demo",
       "user_prompt": "Yes, share this verified demo with the community gallery under my GitHub account.",
-      "expected_behavior": "Only after explicit consent and final verification PASS, prepare exactly demo.gif, index.html, and demo.json, run export/privacy and gallery checks, then use authenticated GitHub contribution tooling to create or reuse the contributor fork, create a fresh community branch, commit the scoped package plus regenerated catalog, push, and open a PR. Stop at the PR.",
-      "expected_result_shape": "A real open PR URL targeting upstream main, contributor fork/branch, demo path, validation summary, and explicit status awaiting maintainer manual review and merge.",
-      "fixture_data": "Use a verified build directory containing final post.html, post.gif, verification-report.json with PASS, contributor metadata, and explicit rights confirmation."
+      "expected_behavior": "Use share-community-demo only after explicit consent, rights confirmation, and final verification PASS. Prepare exactly demo.gif, index.html, and demo.json, run export-safety checks, then use authenticated GitHub contribution tooling when available to create or reuse the contributor fork, create a fresh branch, commit the scoped contribution, push, and open a pull request targeting upstream main. Stop at the pull request.",
+      "expected_result_shape": "A consent/rights summary, export-safety verdict, contributor fork/branch and real pull request URL when tooling is available, or a precise HOLD when required GitHub contribution capability is unavailable.",
+      "fixture_data": "Use a verified demo package, contributor metadata, explicit rights confirmation, and an authenticated GitHub connection for the publication path."
     }
   ],
   "negative": [
     {
       "id": "missing-exact-svg",
       "user_prompt_or_scenario": "Animate our official named mascot, but no exact SVG asset is supplied or resolvable.",
-      "expected_safe_behavior": "Return HOLD and request the exact SVG. Do not redraw, substitute, approximate, or fabricate the mascot.",
+      "expected_safe_behavior": "The exact-svg-mascot skill returns HOLD and requests the exact SVG. Do not redraw, substitute, approximate, trace, or generate a lookalike mascot.",
       "why_not_complete": "Named or official mascot identity is protected by a blocking exact-SVG asset gate."
     },
     {
       "id": "unsafe-demo-export",
       "user_prompt_or_scenario": "Publish a community demo whose HTML or metadata contains a credential-like token, local absolute path, signed URL, or unreviewed remote executable script.",
-      "expected_safe_behavior": "Fail closed during submission/gallery validation and return HOLD with the named export-safety finding. Do not create or push the contribution PR until the unsafe content is removed or explicitly reviewed where the contract permits review.",
+      "expected_safe_behavior": "The share-community-demo skill returns HOLD before any GitHub write. Remove unsafe public content or complete the required explicit review before continuing.",
       "why_not_complete": "Public export must not leak credentials, private local paths, signed URLs, or bypass executable-resource review."
     },
     {
       "id": "share-without-consent",
       "user_prompt_or_scenario": "A demo passes QA, but the user has not explicitly agreed to share it or has declined the sharing offer.",
-      "expected_safe_behavior": "Do not invoke share-demo or community-publisher and perform zero GitHub publication writes. End after delivering the verified result.",
+      "expected_safe_behavior": "Do not invoke the publication flow and perform zero GitHub publication writes. End after delivering the verified result.",
       "why_not_complete": "Community publishing is optional and requires explicit user consent plus rights confirmation."
     }
   ]

--- a/tests/test_openai_focused_skills.py
+++ b/tests/test_openai_focused_skills.py
@@ -1,0 +1,89 @@
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OPENAI_ROOT = ROOT / "openai-skills"
+CASES = ROOT / "submission" / "test-cases.json"
+
+
+class OpenAIFocusedSkillTests(unittest.TestCase):
+    def test_expected_public_openai_skills_exist(self):
+        expected = {
+            "linkedin-infographic-studio": "linkedin-infographic-studio",
+            "linkedin-infographic-review": "linkedin-infographic-review",
+            "exact-svg-mascot": "exact-svg-mascot",
+            "share-community-demo": "share-community-demo",
+        }
+        for directory, skill_name in expected.items():
+            path = OPENAI_ROOT / directory / "SKILL.md"
+            self.assertTrue(path.is_file(), str(path.relative_to(ROOT)))
+            text = path.read_text()
+            self.assertTrue(text.startswith("---\n"), directory)
+            self.assertIn(f"name: {skill_name}", text)
+            self.assertIn("description:", text)
+
+    def test_studio_supporting_contracts_are_complete(self):
+        refs = OPENAI_ROOT / "linkedin-infographic-studio" / "references"
+        for filename in (
+            "openai-runtime.md",
+            "role-passes.md",
+            "visual-archetypes.md",
+            "copy-quality-contract.md",
+            "visual-quality-contract.md",
+            "motion-quality-contract.md",
+        ):
+            self.assertTrue((refs / filename).is_file(), filename)
+
+    def test_focused_review_preserves_visual_failure_taxonomy(self):
+        text = (OPENAI_ROOT / "linkedin-infographic-review" / "SKILL.md").read_text()
+        for marker in (
+            "120px",
+            "top-heavy-composition",
+            "bottom-dead-zone",
+            "nested-card-density",
+            "generic-ui-grammar",
+            "footer-detachment",
+            "motion-on-weak-still",
+            "decorative-motion",
+            "feed-scale-legibility",
+        ):
+            self.assertIn(marker, text)
+
+    def test_exact_svg_skill_fails_closed_without_identity_asset(self):
+        text = (OPENAI_ROOT / "exact-svg-mascot" / "SKILL.md").read_text()
+        for marker in (
+            "exact SVG",
+            "HOLD",
+            "redraw the mascot",
+            "generate a lookalike",
+            "silhouette",
+            "proportions",
+        ):
+            self.assertIn(marker, text)
+
+    def test_share_skill_requires_consent_safe_export_and_pr_stop(self):
+        text = (OPENAI_ROOT / "share-community-demo" / "SKILL.md").read_text()
+        for marker in (
+            "explicitly agreed",
+            "demo.gif",
+            "index.html",
+            "demo.json",
+            "Never merge",
+            "HOLD",
+            "pull request",
+        ):
+            self.assertIn(marker, text)
+
+    def test_openai_reviewer_cases_name_real_public_skills(self):
+        cases = json.loads(CASES.read_text())
+        positive = {case["id"]: case["expected_behavior"] for case in cases["positive"]}
+        self.assertIn("linkedin-infographic-studio", positive["create-post"])
+        self.assertIn("linkedin-infographic-studio", positive["info-story"])
+        self.assertIn("linkedin-infographic-review", positive["qa"])
+        self.assertIn("exact-svg-mascot", positive["exact-svg-mascot"])
+        self.assertIn("share-community-demo", positive["share-demo"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_submission.py
+++ b/tests/test_openai_submission.py
@@ -105,14 +105,15 @@ class OpenAISubmissionContractTests(unittest.TestCase):
         self.assertTrue({"create-post", "info-story", "qa", "exact-svg-mascot", "share-demo"}.issubset(positive_ids))
         self.assertTrue({"missing-exact-svg", "unsafe-demo-export", "share-without-consent"}.issubset(negative_ids))
 
-    def test_submission_readme_states_manual_external_submission(self):
+    def test_submission_readme_states_manual_external_update(self):
         self.assertTrue(README.is_file(), "missing submission/README.md")
         text = README.read_text().lower()
         self.assertIn("manual", text)
         self.assertIn("openai platform", text)
         self.assertIn("five positive", text)
         self.assertIn("three negative", text)
-        self.assertNotIn("already published", text)
+        self.assertIn("does not submit or publish a new plugin version automatically", text)
+        self.assertIn("a github commit alone does not update the package already published", text)
 
     def test_validator_rejects_wrong_reviewer_case_count(self):
         module = load_validator()


### PR DESCRIPTION
Verification-only PR over the completed 3.2.1 main state. Its purpose is to trigger the repository's PR validation against the exact OpenAI visual parity changes. Runtime changes are already on main; this PR adds only a verification marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added verification documentation covering visual parity CI validation, including regression, metadata, visual quality, motion, repair, and version consistency checks.
  * Clarified that the validation marker does not affect runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->