### PR TITLE
chore: harden supply-chain and security gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      render-runtime:
+        patterns:
+          - "Pillow"
+          - "playwright"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+    commit-message:
+      prefix: "chore(actions)"

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -33,8 +33,11 @@ jobs:
           python3 -m pip install --disable-pip-version-check -r requirements-runtime.txt
           python3 -m pip check
 
-      - name: Install render browser
-        run: python3 -m playwright install --with-deps chromium
+      - name: Install render browser dependencies
+        run: |
+          python3 -m playwright install --with-deps chromium
+          sudo apt-get install -y ffmpeg
+          ffmpeg -version | head -1
 
       - name: Python unit tests
         run: python3 -m unittest discover -s tests -v

--- a/.github/workflows/claude-plugin-validation.yml
+++ b/.github/workflows/claude-plugin-validation.yml
@@ -28,8 +28,10 @@ jobs:
         with:
           node-version: "24"
 
-      - name: Install Python runtime dependencies
-        run: python3 -m pip install Pillow playwright
+      - name: Install pinned Python runtime dependencies
+        run: |
+          python3 -m pip install --disable-pip-version-check -r requirements-runtime.txt
+          python3 -m pip check
 
       - name: Install render browser
         run: python3 -m playwright install --with-deps chromium
@@ -88,8 +90,8 @@ jobs:
       - name: Whitespace integrity
         run: git diff --check HEAD^ HEAD
 
-      - name: Install current Claude Code
-        run: npm install -g @anthropic-ai/claude-code@latest
+      - name: Install pinned Claude Code validator
+        run: npm install -g @anthropic-ai/claude-code@2.1.220
 
       - name: Run official Claude plugin validator
         run: claude plugin validate .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,46 @@
+name: Security Gates
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+
+  codeql:
+    name: CodeQL (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: "/language:python"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,17 +11,24 @@ permissions:
   contents: read
 
 jobs:
-  dependency-review:
-    if: github.event_name == 'pull_request'
+  dependency-audit:
+    name: Dependency Audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
     steps:
-      - name: Review dependency changes
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          fail-on-severity: moderate
+          python-version: "3.12"
+
+      - name: Install pinned audit tooling
+        run: python3 -m pip install --disable-pip-version-check -r requirements-security.txt
+
+      - name: Audit pinned runtime dependencies
+        run: python3 -m pip_audit -r requirements-runtime.txt
 
   codeql:
     name: CodeQL (Python)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   dependency-audit:
     name: Dependency Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
 
   codeql:
     name: CodeQL (Python)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,0 +1,4 @@
+# Runtime dependencies used by the render pipeline.
+# Keep exact pins in sync with CI and update them through reviewed dependency PRs.
+Pillow==12.3.0
+playwright==1.61.0

--- a/requirements-security.txt
+++ b/requirements-security.txt
@@ -1,0 +1,3 @@
+# Security tooling used by GitHub Actions.
+# Keep exact pins reviewed through Dependabot PRs.
+pip-audit==2.10.1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,9 +8,18 @@ if ! python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) e
   exit 1
 fi
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
+RUNTIME_REQUIREMENTS="$REPO_ROOT/requirements-runtime.txt"
+
+if [[ ! -f "$RUNTIME_REQUIREMENTS" ]]; then
+  echo "Missing runtime dependency lock: $RUNTIME_REQUIREMENTS" >&2
+  exit 1
+fi
+
 echo "── python deps ──────────────────────────────"
-python3 -m pip install --quiet --break-system-packages playwright pillow 2>/dev/null \
-  || python3 -m pip install --quiet playwright pillow
+python3 -m pip install --quiet --break-system-packages -r "$RUNTIME_REQUIREMENTS" 2>/dev/null \
+  || python3 -m pip install --quiet -r "$RUNTIME_REQUIREMENTS"
 
 echo "── browser ──────────────────────────────────"
 BROWSER=""

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -1,0 +1,50 @@
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATION_WORKFLOW = ROOT / ".github" / "workflows" / "claude-plugin-validation.yml"
+SECURITY_WORKFLOW = ROOT / ".github" / "workflows" / "security.yml"
+DEPENDABOT = ROOT / ".github" / "dependabot.yml"
+REQUIREMENTS = ROOT / "requirements-runtime.txt"
+SETUP = ROOT / "scripts" / "setup.sh"
+
+
+class SupplyChainPolicyTests(unittest.TestCase):
+    def test_runtime_dependencies_are_exactly_pinned(self):
+        dependencies = [
+            line.strip()
+            for line in REQUIREMENTS.read_text().splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        self.assertEqual(["Pillow==12.3.0", "playwright==1.61.0"], dependencies)
+        self.assertTrue(all("==" in dependency for dependency in dependencies))
+
+    def test_setup_and_ci_install_from_the_same_runtime_lock(self):
+        setup = SETUP.read_text()
+        workflow = VALIDATION_WORKFLOW.read_text()
+        self.assertIn('requirements-runtime.txt', setup)
+        self.assertIn('-r "$RUNTIME_REQUIREMENTS"', setup)
+        self.assertIn("-r requirements-runtime.txt", workflow)
+        self.assertIn("python3 -m pip check", workflow)
+        self.assertNotIn("pip install Pillow playwright", workflow)
+        self.assertNotIn("@latest", workflow)
+
+    def test_security_actions_are_commit_pinned(self):
+        workflow = SECURITY_WORKFLOW.read_text()
+        self.assertIn("fail-on-severity: moderate", workflow)
+        self.assertIn("queries: security-extended", workflow)
+        action_refs = re.findall(r"uses:\s+[^@\s]+@([^\s]+)", workflow)
+        self.assertGreaterEqual(len(action_refs), 3)
+        for ref in action_refs:
+            self.assertRegex(ref, r"^[0-9a-f]{40}$", ref)
+
+    def test_dependabot_maintains_runtime_and_action_dependencies(self):
+        text = DEPENDABOT.read_text()
+        self.assertIn('package-ecosystem: "pip"', text)
+        self.assertIn('package-ecosystem: "github-actions"', text)
+        self.assertIn('target-branch: "main"', text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -36,6 +36,8 @@ class SupplyChainPolicyTests(unittest.TestCase):
         self.assertIn('-r "$RUNTIME_REQUIREMENTS"', setup)
         self.assertIn("-r requirements-runtime.txt", workflow)
         self.assertIn("python3 -m pip check", workflow)
+        self.assertIn("runs-on: ubuntu-24.04", workflow)
+        self.assertIn("sudo apt-get install -y ffmpeg", workflow)
         self.assertNotIn("pip install Pillow playwright", workflow)
         self.assertNotIn("@latest", workflow)
 
@@ -44,6 +46,7 @@ class SupplyChainPolicyTests(unittest.TestCase):
         self.assertIn("-r requirements-security.txt", workflow)
         self.assertIn("python3 -m pip_audit -r requirements-runtime.txt", workflow)
         self.assertIn("queries: security-extended", workflow)
+        self.assertEqual(2, workflow.count("runs-on: ubuntu-24.04"))
         action_refs = re.findall(r"uses:\s+[^@\s]+@([^\s]+)", workflow)
         self.assertGreaterEqual(len(action_refs), 5)
         for ref in action_refs:

--- a/tests/test_supply_chain_policy.py
+++ b/tests/test_supply_chain_policy.py
@@ -6,7 +6,8 @@ ROOT = Path(__file__).resolve().parents[1]
 VALIDATION_WORKFLOW = ROOT / ".github" / "workflows" / "claude-plugin-validation.yml"
 SECURITY_WORKFLOW = ROOT / ".github" / "workflows" / "security.yml"
 DEPENDABOT = ROOT / ".github" / "dependabot.yml"
-REQUIREMENTS = ROOT / "requirements-runtime.txt"
+RUNTIME_REQUIREMENTS = ROOT / "requirements-runtime.txt"
+SECURITY_REQUIREMENTS = ROOT / "requirements-security.txt"
 SETUP = ROOT / "scripts" / "setup.sh"
 
 
@@ -14,28 +15,37 @@ class SupplyChainPolicyTests(unittest.TestCase):
     def test_runtime_dependencies_are_exactly_pinned(self):
         dependencies = [
             line.strip()
-            for line in REQUIREMENTS.read_text().splitlines()
+            for line in RUNTIME_REQUIREMENTS.read_text().splitlines()
             if line.strip() and not line.lstrip().startswith("#")
         ]
         self.assertEqual(["Pillow==12.3.0", "playwright==1.61.0"], dependencies)
         self.assertTrue(all("==" in dependency for dependency in dependencies))
 
+    def test_security_tooling_is_exactly_pinned(self):
+        dependencies = [
+            line.strip()
+            for line in SECURITY_REQUIREMENTS.read_text().splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        self.assertEqual(["pip-audit==2.10.1"], dependencies)
+
     def test_setup_and_ci_install_from_the_same_runtime_lock(self):
         setup = SETUP.read_text()
         workflow = VALIDATION_WORKFLOW.read_text()
-        self.assertIn('requirements-runtime.txt', setup)
+        self.assertIn("requirements-runtime.txt", setup)
         self.assertIn('-r "$RUNTIME_REQUIREMENTS"', setup)
         self.assertIn("-r requirements-runtime.txt", workflow)
         self.assertIn("python3 -m pip check", workflow)
         self.assertNotIn("pip install Pillow playwright", workflow)
         self.assertNotIn("@latest", workflow)
 
-    def test_security_actions_are_commit_pinned(self):
+    def test_security_workflow_audits_dependencies_and_pins_actions(self):
         workflow = SECURITY_WORKFLOW.read_text()
-        self.assertIn("fail-on-severity: moderate", workflow)
+        self.assertIn("-r requirements-security.txt", workflow)
+        self.assertIn("python3 -m pip_audit -r requirements-runtime.txt", workflow)
         self.assertIn("queries: security-extended", workflow)
         action_refs = re.findall(r"uses:\s+[^@\s]+@([^\s]+)", workflow)
-        self.assertGreaterEqual(len(action_refs), 3)
+        self.assertGreaterEqual(len(action_refs), 5)
         for ref in action_refs:
             self.assertRegex(ref, r"^[0-9a-f]{40}$", ref)
 


### PR DESCRIPTION
## Objective

Make the repository's validation and dependency pipeline more reproducible and add automated security gates without changing infographic generation behavior.

## Evidence

The existing validation workflow installed unpinned `Pillow` / `playwright` packages and `@anthropic-ai/claude-code@latest`, so identical commits could validate against different toolchains over time. The repository also had no automated dependency vulnerability audit, Dependabot policy, or CodeQL workflow.

Current reviewed pins were checked against upstream package/release sources before this PR was created:

- Pillow `12.3.0`
- Playwright `1.61.0`
- pip-audit `2.10.1`
- Claude Code `2.1.220`
- CodeQL Action `v4.37.3` at commit `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`

## File-level changes

- `requirements-runtime.txt`: adds exact render-runtime dependency pins.
- `requirements-security.txt`: pins dependency-audit tooling.
- `scripts/setup.sh`: installs from the shared runtime requirements file and fails clearly when it is missing.
- `.github/workflows/claude-plugin-validation.yml`: uses the same pinned Python dependency file, runs `pip check`, pins the Claude Code validator, pins the runner family to Ubuntu 24.04, and provisions system `ffmpeg` required by the render regression path.
- `.github/dependabot.yml`: schedules reviewed weekly updates for Python requirements and GitHub Actions.
- `.github/workflows/security.yml`: audits committed runtime dependencies with pinned pip-audit, runs CodeQL `security-extended` analysis for Python, and pins the runner family to Ubuntu 24.04.
- `tests/test_supply_chain_policy.py`: prevents silent regression to floating dependencies, unpinned audit tooling/actions, missing ffmpeg provisioning, or floating runner-family configuration.

## Architecture / state / API impact

No runtime API, schema, routing, artifact, skill, agent, or product workflow behavior changes. This PR affects installation reproducibility, CI policy, and repository security automation only.

## Validation

Static review completed against repository governance (`AGENTS.md`, `helper/GUIDE.md`) and the full branch diff.

Expected repository-defined CI commands on this PR:

```bash
python3 -m unittest discover -s tests -v
python3 -m compileall -q scripts tools skills/svg-mascot-animator/scripts
python3 scripts/info_stories.py check
python3 scripts/ecosystem_router.py check
python3 scripts/research_gates.py check
python3 scripts/plugin_graph.py check
python3 scripts/ecosystem_doctor.py check
python3 scripts/demo_gallery.py check
python3 scripts/validate_marketplace.py
python3 scripts/validate_codex_plugin.py
claude plugin validate .
```

New CI security gates:

```text
Dependency Audit: pip-audit against requirements-runtime.txt
CodeQL: Python + security-extended queries
```

### Repair evidence

The first security workflow attempt used GitHub's Dependency Review Action. Its run failed with `Dependency review is not supported on this repository` because Dependency graph is disabled in repository settings. The branch was repaired to use pinned `pip-audit==2.10.1`, which audits the committed dependency set directly and does not require that repository setting.

A subsequent Plugin Validation run reached the real render regression test and exposed a missing CI system dependency: `ffmpeg not found on PATH`. Playwright's private FFmpeg bundle does not satisfy the repository's render CLI contract. The validation job now provisions the system `ffmpeg` package before the test suite and explicitly reports its version.

## Unavailable checks

This ChatGPT session could not clone the repository into a local execution environment because the container has no outbound DNS/network access. Therefore I am not claiming local unit, browser, shell, or validator execution. GitHub Actions on the PR is the authoritative execution environment for those checks.

CodeRabbit CLI review is not executable locally for the same reason. A GitHub CodeRabbit check is attached to the PR and its status should be treated as the CodeRabbit review signal; manual diff review is not labeled as CodeRabbit output.

The Codex Security workflow was used to define the security-review boundary, but a host-backed full repository scan is unavailable without a local authorized source workspace. CodeQL and pip-audit on this PR provide fresh automated security evidence for the changed boundary.

## Risks

- Exact pins intentionally trade automatic latest-version uptake for reproducibility. Dependabot is configured to keep updates flowing through reviewable PRs.
- `pip-audit` queries vulnerability data during CI, so an upstream advisory-service outage can fail or block that security job.
- Ubuntu package repositories still supply `ffmpeg`; pinning the GitHub runner family reduces but does not eliminate OS-package drift.
- CodeQL depends on GitHub code-scanning capability and should be treated as required independent verification before merge.
- `scripts/setup.sh` now expects `requirements-runtime.txt` to remain present at the repository root; the contract test guards this relationship.

## Independent verification

1. Confirm `Plugin Validation` passes on the final PR head.
2. Confirm `Security Gates / Dependency Audit` passes.
3. Confirm `Security Gates / CodeQL (Python)` passes and does not introduce reportable alerts.
4. Confirm the CodeRabbit and Qlty checks reach non-failing final states and address actionable comments.
5. Run `python3 -m unittest -v tests.test_supply_chain_policy` locally if desired.
6. Run `bash -n scripts/setup.sh` and then `scripts/setup.sh` in a clean supported environment to confirm the pinned runtime installs and Chromium/ffmpeg setup.
7. Review Dependabot configuration after merge to confirm both `pip` and `github-actions` update streams are recognized.

## Commits

Twelve focused Conventional Commits, including two CI repairs prompted by real GitHub Actions evidence.

## Handoff

Independent review, full-environment verification, approval, and merging are intentionally left to a separate maintainer or coding agent. This PR must not be auto-merged.