### PR TITLE
fix: support runtime directory artifacts

### DIFF
--- a/scripts/runtime_directory_digest.py
+++ b/scripts/runtime_directory_digest.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 
 def directory_descriptor(path):
+    path = Path(path)
+    if path.is_symlink():
+        raise ValueError(f"directory artifact contains symlink: {path}")
     digest = hashlib.sha256()
     files = 0
     total = 0

--- a/scripts/runtime_directory_digest.py
+++ b/scripts/runtime_directory_digest.py
@@ -10,6 +10,11 @@ def directory_descriptor(path):
     for root, directories, filenames in os.walk(path, followlinks=False):
         directories.sort()
         filenames.sort()
+        for directory in directories:
+            current = Path(root) / directory
+            if current.is_symlink():
+                relative = current.relative_to(path).as_posix()
+                raise ValueError(f"directory artifact contains symlink: {relative}")
         for filename in filenames:
             current = Path(root) / filename
             relative = current.relative_to(path).as_posix().encode()

--- a/scripts/runtime_directory_digest.py
+++ b/scripts/runtime_directory_digest.py
@@ -1,0 +1,27 @@
+import hashlib
+import os
+from pathlib import Path
+
+
+def directory_descriptor(path):
+    digest = hashlib.sha256()
+    files = 0
+    total = 0
+    for root, directories, filenames in os.walk(path, followlinks=False):
+        directories.sort()
+        filenames.sort()
+        for filename in filenames:
+            current = Path(root) / filename
+            relative = current.relative_to(path).as_posix().encode()
+            if current.is_symlink():
+                raise ValueError(f"directory artifact contains symlink: {relative.decode()}")
+            size = current.stat().st_size
+            digest.update(len(relative).to_bytes(8, "big"))
+            digest.update(relative)
+            digest.update(size.to_bytes(8, "big"))
+            with current.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(65536), b""):
+                    digest.update(chunk)
+            files += 1
+            total += size
+    return {"$directory_sha256": digest.hexdigest(), "$files": files, "$size": total}

--- a/scripts/runtime_kernel.py
+++ b/scripts/runtime_kernel.py
@@ -2,6 +2,8 @@
 import argparse, hashlib, json, shutil
 from pathlib import Path
 
+from runtime_directory_digest import directory_descriptor
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -43,6 +45,7 @@ def projection(value, view):
 TEXT_ARTIFACT_SUFFIXES = {".html", ".md"}
 
 def artifact_value(path):
+    if path.is_dir(): return directory_descriptor(path)
     if path.suffix in TEXT_ARTIFACT_SUFFIXES: return path.read_text()
     return {"$binary_sha256": file_sha(path), "$size": path.stat().st_size}
 

--- a/tests/test_runtime_directory_artifacts.py
+++ b/tests/test_runtime_directory_artifacts.py
@@ -1,0 +1,46 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "scripts" / "runtime_context.py"
+
+
+class RuntimeDirectoryArtifactTests(unittest.TestCase):
+    def test_community_publisher_hashes_directory_package(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            build = workspace / "build"
+            context = build / "runtime-context"
+            package = build / "community-demo-package"
+            context.mkdir(parents=True)
+            package.mkdir(parents=True)
+            (context / "request.json").write_text(json.dumps({"topic": "demo"}))
+            (package / "demo.json").write_text("{}")
+            (package / "index.html").write_text("<main>demo</main>")
+
+            first = subprocess.run(
+                [sys.executable, str(RUNTIME), "prepare", "--intent", "share-demo", "--stage", "community-publisher", "--workspace", str(workspace)],
+                cwd=ROOT, text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(0, first.returncode, first.stderr)
+            first_response = json.loads(first.stdout)
+            capsule = json.loads(Path(first_response["capsule_path"]).read_text())
+            value = capsule["inputs"]["build/community-demo-package"]
+            self.assertEqual(2, value["$files"])
+            self.assertEqual(64, len(value["$directory_sha256"]))
+
+            (package / "index.html").write_text("<main>changed</main>")
+            second = subprocess.run(
+                [sys.executable, str(RUNTIME), "prepare", "--intent", "share-demo", "--stage", "community-publisher", "--workspace", str(workspace)],
+                cwd=ROOT, text=True, capture_output=True, check=False,
+            )
+            self.assertEqual(0, second.returncode, second.stderr)
+            self.assertNotEqual(first_response["cache_key"], json.loads(second.stdout)["cache_key"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_directory_digest.py
+++ b/tests/test_runtime_directory_digest.py
@@ -1,0 +1,28 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.runtime_directory_digest import directory_descriptor
+
+
+class RuntimeDirectoryDigestTests(unittest.TestCase):
+    def test_rejects_symlinked_directories(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package = root / "package"
+            target = root / "outside"
+            package.mkdir()
+            target.mkdir()
+            (target / "secret.txt").write_text("outside")
+            link = package / "linked-dir"
+            try:
+                link.symlink_to(target, target_is_directory=True)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+
+            with self.assertRaisesRegex(ValueError, "symlink"):
+                directory_descriptor(package)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_directory_digest.py
+++ b/tests/test_runtime_directory_digest.py
@@ -23,6 +23,21 @@ class RuntimeDirectoryDigestTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "symlink"):
                 directory_descriptor(package)
 
+    def test_rejects_symlinked_root_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "outside"
+            target.mkdir()
+            (target / "secret.txt").write_text("outside")
+            link = root / "package"
+            try:
+                link.symlink_to(target, target_is_directory=True)
+            except OSError as exc:
+                self.skipTest(f"symlinks unavailable: {exc}")
+
+            with self.assertRaisesRegex(ValueError, "symlink"):
+                directory_descriptor(link)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Objective
Support registered directory artifacts in runtime context preparation without crashing.

## Changes
- Add deterministic streaming directory descriptors.
- Include directory changes in runtime cache identity.
- Reject linked directory entries, including the artifact root.
- Add end-to-end and unit regressions.

## Impact
No public CLI, schema, or route change. Four changed files.

## Validation
Final local head: 437 tests, 0 failures, 7 browser-only skips. Focused runtime tests: 13/13 pass. All repository deterministic validators pass, including compileall, Info-stories, reference intelligence, runtime, router, research gates, plugin graph, ecosystem doctor, demo gallery, marketplace, Codex plugin, JSON/shell syntax, and branch diff checks.

GitHub Actions on `56859d3`: Plugin Validation success, Security Gates success, Plugin Scanner success. Codex and Qodo review findings on the earlier head were fixed in `56859d3`; both threads are resolved. CodeRabbit was rate-limited and did not run.

## Risk
Directory identity covers relative file paths, byte sizes, and file contents. Empty directories and permission bits are not part of the digest.

## Commits
6 commits, current with `main`.

## Handoff
Independent review and merge required. No auto-merge and no merge performed by this agent.