### PR TITLE
chore: ignore generated Codacy instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 .DS_Store
 research/upstreams/
 .plugin-state/reference-studies/
+
+# Ignore VS Code AI rules
+.github/instructions/codacy.instructions.md


### PR DESCRIPTION
Ignore generated `.github/instructions/codacy.instructions.md`. `git check-ignore` and `git diff --check` pass. PR-only, no auto-merge.