### PR TITLE
qa: block clipped text in render pipeline

### DIFF
--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -41,6 +41,7 @@ FRAMES="$EVIDENCE/frames"
 STILL="$OUT_DIR/still.png"
 REPORT="$OUT_DIR/render-report.json"
 ARTBOARD_JSON="$EVIDENCE/artboard.json"
+OVERFLOW_JSON="$EVIDENCE/text-overflow.json"
 STILL_JSON="$EVIDENCE/still.json"
 GIF_JSON="$EVIDENCE/gif.json"
 mkdir -p "$EVIDENCE"
@@ -62,6 +63,16 @@ ARTBOARD_CMD+=(--browser "$BROWSER")
 ARTBOARD_STATUS=$?
 set -e
 [[ "$ARTBOARD_STATUS" -le 1 ]] || exit "$ARTBOARD_STATUS"
+
+echo
+echo "── text overflow audit ──────────────────────"
+set +e
+OVERFLOW_CMD=(python3 "$HERE/text_overflow_audit.py" "$HTML" --json "$OVERFLOW_JSON")
+OVERFLOW_CMD+=(--browser "$BROWSER")
+"${OVERFLOW_CMD[@]}"
+OVERFLOW_STATUS=$?
+set -e
+[[ "$OVERFLOW_STATUS" -le 1 ]] || exit "$OVERFLOW_STATUS"
 
 echo
 echo "── still ────────────────────────────────────"
@@ -98,3 +109,5 @@ echo "── merge evidence ─────────────────�
 python3 "$HERE/render_report.py" merge \
   --artboard "$ARTBOARD_JSON" --still "$STILL_JSON" --gif "$GIF_JSON" \
   --input "$HTML" --output "$OUT" --out "$REPORT"
+
+[[ "$ARTBOARD_STATUS" -eq 0 && "$OVERFLOW_STATUS" -eq 0 && "$STILL_STATUS" -eq 0 && "$GIF_STATUS" -eq 0 ]]

--- a/scripts/text_overflow_audit.py
+++ b/scripts/text_overflow_audit.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from scripts.render_probe import open_artboard
+from scripts.visual_contract import ContractError, VisualContract, file_sha256
 
 PROBE_JS = r"""
 () => {
@@ -90,8 +91,20 @@ def main(argv=None) -> int:
     ap.add_argument('--at', type=float, default=0.0)
     args = ap.parse_args(argv)
 
-    with open_artboard(args.html, width=1080, height=1350, at=args.at,
-                       browser=args.browser) as (page, capture):
+    try:
+        contract = VisualContract()
+    except ContractError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    artifact = Path(args.html)
+    with open_artboard(
+        args.html,
+        width=contract.int_value('artboard.width'),
+        height=contract.int_value('artboard.height'),
+        at=args.at,
+        browser=args.browser,
+    ) as (page, capture):
         result = page.evaluate(PROBE_JS)
 
     if result.get('error'):
@@ -102,7 +115,8 @@ def main(argv=None) -> int:
     report = {
         'schema_version': 1,
         'stage': 'text-overflow',
-        'artifact': str(Path(args.html).resolve()),
+        'artifact': str(artifact.resolve()),
+        'artifact_sha256': file_sha256(artifact),
         'capture': capture,
         'verdict': 'FAIL' if violations else 'PASS',
         'violations': violations,

--- a/scripts/text_overflow_audit.py
+++ b/scripts/text_overflow_audit.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Fail when rendered text is clipped or overflows a bounded container."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.render_probe import open_artboard
+
+PROBE_JS = r"""
+() => {
+  const board = document.querySelector('#artboard');
+  if (!board) return {error: 'no #artboard element', violations: []};
+  const br = board.getBoundingClientRect();
+  const violations = [];
+  const visible = el => {
+    const cs = getComputedStyle(el);
+    return cs.display !== 'none' && cs.visibility !== 'hidden' &&
+           parseFloat(cs.opacity || '1') > 0.01;
+  };
+  const label = el => `<${el.tagName.toLowerCase()} class="${
+    (el.className && el.className.baseVal !== undefined ? el.className.baseVal : el.className || '')
+      .toString().slice(0, 50)}">`;
+
+  board.querySelectorAll('*').forEach(el => {
+    if (!visible(el)) return;
+    const text = [...el.childNodes]
+      .filter(n => n.nodeType === 3).map(n => n.textContent).join('').trim();
+    if (!text) return;
+    const cs = getComputedStyle(el);
+    const r = el.getBoundingClientRect();
+    if (!r.width || !r.height) return;
+
+    const horizontal = el.scrollWidth > el.clientWidth + 1;
+    const vertical = el.scrollHeight > el.clientHeight + 1;
+    const clipsX = ['hidden', 'clip'].includes(cs.overflowX);
+    const clipsY = ['hidden', 'clip'].includes(cs.overflowY);
+    const outsideBoard = r.left < br.left - 1 || r.right > br.right + 1 ||
+                         r.top < br.top - 1 || r.bottom > br.bottom + 1;
+
+    if ((horizontal && clipsX) || (vertical && clipsY) || outsideBoard) {
+      violations.push({
+        element: label(el),
+        sample: text.slice(0, 70),
+        horizontal, vertical, outsideBoard,
+        client: [el.clientWidth, el.clientHeight],
+        scroll: [el.scrollWidth, el.scrollHeight],
+      });
+    }
+  });
+  return {error: null, violations};
+}
+"""
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('html')
+    ap.add_argument('--json', dest='json_out', default=None)
+    ap.add_argument('--browser', default=None)
+    ap.add_argument('--at', type=float, default=0.0)
+    args = ap.parse_args(argv)
+
+    with open_artboard(args.html, width=1080, height=1350, at=args.at,
+                       browser=args.browser) as (page, capture):
+        result = page.evaluate(PROBE_JS)
+
+    if result.get('error'):
+        print(result['error'], file=sys.stderr)
+        return 2
+
+    violations = result['violations']
+    report = {
+        'schema_version': 1,
+        'stage': 'text-overflow',
+        'artifact': str(Path(args.html).resolve()),
+        'capture': capture,
+        'verdict': 'FAIL' if violations else 'PASS',
+        'violations': violations,
+    }
+    if args.json_out:
+        target = Path(args.json_out)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(report, indent=2, sort_keys=True) + '\n')
+
+    print('── text overflow audit ──────────────────────')
+    if not violations:
+        print('  ok    no clipped or overflowing text detected')
+        return 0
+    print(f'  FAIL  {len(violations)} text node(s) clipped or outside the artboard')
+    for row in violations[:8]:
+        print(f"        {row['element']} {row['sample']!r}")
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/text_overflow_audit.py
+++ b/scripts/text_overflow_audit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail when rendered text is clipped or overflows a bounded container."""
+"""Fail when rendered text is clipped or escapes the artboard."""
 
 from __future__ import annotations
 
@@ -25,30 +25,55 @@ PROBE_JS = r"""
   const label = el => `<${el.tagName.toLowerCase()} class="${
     (el.className && el.className.baseVal !== undefined ? el.className.baseVal : el.className || '')
       .toString().slice(0, 50)}">`;
+  const clips = (el, axis) => {
+    const cs = getComputedStyle(el);
+    const value = axis === 'x' ? cs.overflowX : cs.overflowY;
+    return value === 'hidden' || value === 'clip';
+  };
+  const outside = (inner, outer, axis) => axis === 'x'
+    ? inner.left < outer.left - 1 || inner.right > outer.right + 1
+    : inner.top < outer.top - 1 || inner.bottom > outer.bottom + 1;
 
   board.querySelectorAll('*').forEach(el => {
     if (!visible(el)) return;
-    const text = [...el.childNodes]
-      .filter(n => n.nodeType === 3).map(n => n.textContent).join('').trim();
-    if (!text) return;
-    const cs = getComputedStyle(el);
-    const r = el.getBoundingClientRect();
-    if (!r.width || !r.height) return;
+    const textNodes = [...el.childNodes]
+      .filter(n => n.nodeType === 3 && n.textContent.trim().length > 0);
+    if (!textNodes.length) return;
 
-    const horizontal = el.scrollWidth > el.clientWidth + 1;
-    const vertical = el.scrollHeight > el.clientHeight + 1;
-    const clipsX = ['hidden', 'clip'].includes(cs.overflowX);
-    const clipsY = ['hidden', 'clip'].includes(cs.overflowY);
-    const outsideBoard = r.left < br.left - 1 || r.right > br.right + 1 ||
-                         r.top < br.top - 1 || r.bottom > br.bottom + 1;
+    const range = document.createRange();
+    range.setStartBefore(textNodes[0]);
+    range.setEndAfter(textNodes[textNodes.length - 1]);
+    const tr = range.getBoundingClientRect();
+    if (!tr.width || !tr.height) return;
 
-    if ((horizontal && clipsX) || (vertical && clipsY) || outsideBoard) {
+    const reasons = [];
+    if (outside(tr, br, 'x') || outside(tr, br, 'y')) reasons.push('outside-artboard');
+
+    for (let ancestor = el; ancestor && ancestor !== board.parentElement;
+         ancestor = ancestor.parentElement) {
+      if (!visible(ancestor)) continue;
+      const ar = ancestor.getBoundingClientRect();
+      if (clips(ancestor, 'x') && outside(tr, ar, 'x')) {
+        reasons.push(`clipped-x:${label(ancestor)}`);
+      }
+      if (clips(ancestor, 'y') && outside(tr, ar, 'y')) {
+        reasons.push(`clipped-y:${label(ancestor)}`);
+      }
+      if (ancestor === board) break;
+    }
+
+    if (reasons.length) {
+      const text = textNodes.map(n => n.textContent).join('').trim();
       violations.push({
         element: label(el),
         sample: text.slice(0, 70),
-        horizontal, vertical, outsideBoard,
-        client: [el.clientWidth, el.clientHeight],
-        scroll: [el.scrollWidth, el.scrollHeight],
+        reasons: [...new Set(reasons)],
+        text_rect: {
+          left: Math.round((tr.left - br.left) * 10) / 10,
+          top: Math.round((tr.top - br.top) * 10) / 10,
+          right: Math.round((tr.right - br.left) * 10) / 10,
+          bottom: Math.round((tr.bottom - br.top) * 10) / 10,
+        },
       });
     }
   });
@@ -93,7 +118,7 @@ def main(argv=None) -> int:
         return 0
     print(f'  FAIL  {len(violations)} text node(s) clipped or outside the artboard')
     for row in violations[:8]:
-        print(f"        {row['element']} {row['sample']!r}")
+        print(f"        {row['element']} {row['sample']!r}: {', '.join(row['reasons'])}")
     return 1
 
 

--- a/tests/fixtures/text-overflow.html
+++ b/tests/fixtures/text-overflow.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Fixture: clipped text</title>
+<style>
+* { box-sizing: border-box; }
+html, body { margin: 0; background: #222; }
+#artboard { position: relative; width: 1080px; height: 1350px; overflow: hidden; background: #fff; color: #111; font-family: sans-serif; }
+.card { position: absolute; left: 96px; top: 180px; width: 520px; height: 120px; overflow: hidden; border: 1px solid #ddd; }
+.headline { width: 500px; height: 48px; overflow: hidden; white-space: nowrap; font-size: 40px; line-height: 48px; font-weight: 700; }
+.safe { position: absolute; left: 96px; top: 420px; width: 760px; font-size: 28px; line-height: 36px; }
+</style>
+</head>
+<body>
+<div id="artboard">
+  <div class="card"><div class="headline">This intentionally long headline must be detected when clipped inside its box</div></div>
+  <div class="safe">This line fits and should not be reported.</div>
+</div>
+</body>
+</html>

--- a/tests/test_text_overflow_audit.py
+++ b/tests/test_text_overflow_audit.py
@@ -10,27 +10,40 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 AUDIT = ROOT / 'scripts' / 'text_overflow_audit.py'
-FIXTURE = ROOT / 'tests' / 'fixtures' / 'text-overflow.html'
+FIXTURES = ROOT / 'tests' / 'fixtures'
 TOOLCHAIN_MARKERS = ('playwright is not installed', 'Chromium could not start', 'No Chrome build available')
+
+
+def run_audit(fixture: str) -> tuple[int, dict]:
+    with tempfile.TemporaryDirectory() as tmp:
+        report = Path(tmp) / 'overflow.json'
+        proc = subprocess.run(
+            [sys.executable, str(AUDIT), str(FIXTURES / fixture), '--json', str(report)],
+            capture_output=True, text=True, cwd=ROOT, timeout=180,
+        )
+        if any(marker in proc.stderr for marker in TOOLCHAIN_MARKERS):
+            raise unittest.SkipTest(proc.stderr.strip())
+        if not report.is_file():
+            raise AssertionError(f'overflow audit produced no report: {proc.stderr}')
+        return proc.returncode, json.loads(report.read_text())
 
 
 class TextOverflowAuditTests(unittest.TestCase):
     def test_clipped_headline_fails_with_evidence(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            report = Path(tmp) / 'overflow.json'
-            proc = subprocess.run(
-                [sys.executable, str(AUDIT), str(FIXTURE), '--json', str(report)],
-                capture_output=True, text=True, cwd=ROOT, timeout=180,
-            )
-            if any(marker in proc.stderr for marker in TOOLCHAIN_MARKERS):
-                self.skipTest(proc.stderr.strip())
-            self.assertTrue(report.is_file(), proc.stderr)
-            data = json.loads(report.read_text())
-            self.assertEqual(proc.returncode, 1)
-            self.assertEqual(data['verdict'], 'FAIL')
-            self.assertGreaterEqual(len(data['violations']), 1)
-            joined = ' '.join(v['element'] for v in data['violations'])
-            self.assertIn('headline', joined)
+        code, data = run_audit('text-overflow.html')
+        self.assertEqual(code, 1)
+        self.assertEqual(data['verdict'], 'FAIL')
+        self.assertGreaterEqual(len(data['violations']), 1)
+        joined = ' '.join(v['element'] for v in data['violations'])
+        self.assertIn('headline', joined)
+        reasons = ' '.join(r for v in data['violations'] for r in v['reasons'])
+        self.assertIn('clipped-x', reasons)
+
+    def test_compliant_artboard_has_no_overflow_false_positive(self):
+        code, data = run_audit('artboard-min.html')
+        self.assertEqual(code, 0, data['violations'])
+        self.assertEqual(data['verdict'], 'PASS')
+        self.assertEqual(data['violations'], [])
 
 
 if __name__ == '__main__':

--- a/tests/test_text_overflow_audit.py
+++ b/tests/test_text_overflow_audit.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT = ROOT / 'scripts' / 'text_overflow_audit.py'
+FIXTURE = ROOT / 'tests' / 'fixtures' / 'text-overflow.html'
+TOOLCHAIN_MARKERS = ('playwright is not installed', 'Chromium could not start', 'No Chrome build available')
+
+
+class TextOverflowAuditTests(unittest.TestCase):
+    def test_clipped_headline_fails_with_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = Path(tmp) / 'overflow.json'
+            proc = subprocess.run(
+                [sys.executable, str(AUDIT), str(FIXTURE), '--json', str(report)],
+                capture_output=True, text=True, cwd=ROOT, timeout=180,
+            )
+            if any(marker in proc.stderr for marker in TOOLCHAIN_MARKERS):
+                self.skipTest(proc.stderr.strip())
+            self.assertTrue(report.is_file(), proc.stderr)
+            data = json.loads(report.read_text())
+            self.assertEqual(proc.returncode, 1)
+            self.assertEqual(data['verdict'], 'FAIL')
+            self.assertGreaterEqual(len(data['violations']), 1)
+            joined = ' '.join(v['element'] for v in data['violations'])
+            self.assertIn('headline', joined)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a browser-level text overflow gate before still capture. The new audit detects text clipped by bounded containers or positioned outside the 1080x1350 artboard, records evidence, and blocks the render pipeline. Includes a deterministic regression fixture and unittest coverage.