### PR TITLE
qa: unify text overflow with final render evidence

### DIFF
--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -106,8 +106,13 @@ set -e
 
 echo
 echo "── merge evidence ───────────────────────────"
+set +e
 python3 "$HERE/render_report.py" merge \
-  --artboard "$ARTBOARD_JSON" --still "$STILL_JSON" --gif "$GIF_JSON" \
+  --artboard "$ARTBOARD_JSON" --text-overflow "$OVERFLOW_JSON" \
+  --still "$STILL_JSON" --gif "$GIF_JSON" \
   --input "$HTML" --output "$OUT" --out "$REPORT"
+REPORT_STATUS=$?
+set -e
+[[ "$REPORT_STATUS" -le 1 ]] || exit "$REPORT_STATUS"
 
-[[ "$ARTBOARD_STATUS" -eq 0 && "$OVERFLOW_STATUS" -eq 0 && "$STILL_STATUS" -eq 0 && "$GIF_STATUS" -eq 0 ]]
+[[ "$ARTBOARD_STATUS" -eq 0 && "$OVERFLOW_STATUS" -eq 0 && "$STILL_STATUS" -eq 0 && "$GIF_STATUS" -eq 0 && "$REPORT_STATUS" -eq 0 ]]

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Merge measured artboard, still, and GIF evidence into one fail-closed report."""
+"""Merge measured render evidence into one fail-closed report."""
 
 from __future__ import annotations
 
@@ -29,6 +29,7 @@ FRAGMENT_PRODUCERS = {
     "still": "scripts/check_render.py",
     "gif": "scripts/build_gif.py",
 }
+OVERFLOW_KIND = "text-overflow"
 ROW_FIELDS = {
     "threshold_id", "gate", "severity", "status", "measured", "threshold",
     "unit", "detail", "evidence",
@@ -115,11 +116,67 @@ def read_fragment(path: Path, kind: str, contract: VisualContract) -> dict:
     return fragment
 
 
-def merge_fragments(paths: dict[str, Path], input_path: Path, output_path: Path) -> dict:
+def read_overflow_fragment(path: Path) -> dict:
+    if not path.is_file():
+        raise ValueError(f"missing render fragment: {path}")
+    try:
+        fragment = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid render fragment {path}: {exc}") from exc
+    if fragment.get("schema_version") != 1:
+        raise ValueError(f"unsupported render fragment schema: {path}")
+    if fragment.get("stage") != OVERFLOW_KIND:
+        raise ValueError(f"render fragment stage is not {OVERFLOW_KIND}: {path}")
+    if not isinstance(fragment.get("artifact"), str) or not fragment["artifact"]:
+        raise ValueError(f"render fragment has no artifact metadata: {path}")
+    artifact_sha256 = fragment.get("artifact_sha256")
+    if not isinstance(artifact_sha256, str) or len(artifact_sha256) != 64:
+        raise ValueError(f"render fragment has no artifact digest: {path}")
+    violations = fragment.get("violations")
+    if not isinstance(violations, list):
+        raise ValueError(f"text-overflow fragment has no violations list: {path}")
+    expected = FAIL if violations else PASS
+    if fragment.get("verdict") != expected:
+        raise ValueError("text-overflow verdict does not match violations")
+    return fragment
+
+
+def overflow_finding(fragment: dict) -> dict:
+    violations = fragment["violations"]
+    evidence = [
+        {
+            "element": row.get("element"),
+            "sample": row.get("sample"),
+            "reasons": row.get("reasons", []),
+            "text_rect": row.get("text_rect"),
+        }
+        for row in violations[:8]
+        if isinstance(row, dict)
+    ]
+    return {
+        "threshold_id": "text.visible_nodes",
+        "gate": "text-overflow",
+        "severity": BLOCKING,
+        "status": FAIL if violations else PASS,
+        "measured": len(violations),
+        "threshold": 0,
+        "unit": "violations",
+        "detail": (
+            f"{len(violations)} rendered text node(s) clipped or outside the artboard"
+            if violations else "no clipped or overflowing rendered text detected"
+        ),
+        "evidence": evidence,
+    }
+
+
+def merge_fragments(
+    paths: dict[str, Path], overflow_path: Path, input_path: Path, output_path: Path
+) -> dict:
     contract = VisualContract()
     fragments = {
         kind: read_fragment(path, kind, contract) for kind, path in paths.items()
     }
+    overflow = read_overflow_fragment(overflow_path)
     expected_artifacts = {
         "artboard": input_path.resolve(),
         "still": input_path.resolve(),
@@ -130,6 +187,11 @@ def merge_fragments(paths: dict[str, Path], input_path: Path, output_path: Path)
             raise ValueError(f"stale artifact metadata in {kind} render fragment")
         if fragment["artifact_sha256"] != file_sha256(expected_artifacts[kind]):
             raise ValueError(f"stale artifact digest in {kind} render fragment")
+    if Path(overflow["artifact"]).resolve() != input_path.resolve():
+        raise ValueError("stale artifact metadata in text-overflow render fragment")
+    if overflow["artifact_sha256"] != file_sha256(input_path):
+        raise ValueError("stale artifact digest in text-overflow render fragment")
+
     findings = [row for fragment in fragments.values() for row in fragment["findings"]]
     for kind, producer in FRAGMENT_PRODUCERS.items():
         present = {row["threshold_id"] for row in fragments[kind]["findings"]}
@@ -137,21 +199,24 @@ def merge_fragments(paths: dict[str, Path], input_path: Path, output_path: Path)
             if threshold["measured_by"] == producer and threshold_id not in present:
                 findings.append(skipped(
                     contract, threshold_id, f"missing from {kind} render fragment"))
+    findings.append(overflow_finding(overflow))
 
     summary = summarize(findings)
+    all_sources = {**fragments, OVERFLOW_KIND: overflow}
+    all_paths = {**paths, OVERFLOW_KIND: overflow_path}
     return {
         "schema_version": 1,
         "verdict": summary["verdict"],
         "summary": summary,
         "findings": findings,
         "sources": {
-            kind: {"path": str(paths[kind].resolve()), "verdict": fragment.get("verdict")}
-            for kind, fragment in fragments.items()
+            kind: {"path": str(all_paths[kind].resolve()), "verdict": fragment.get("verdict")}
+            for kind, fragment in all_sources.items()
         },
         "digests": {
             "input": digest(input_path),
             "output": digest(output_path),
-            "fragments": {kind: digest(path) for kind, path in paths.items()},
+            "fragments": {kind: digest(path) for kind, path in all_paths.items()},
         },
     }
 
@@ -162,18 +227,20 @@ def main(argv=None) -> int:
     merge = commands.add_parser("merge")
     for kind in FRAGMENT_PRODUCERS:
         merge.add_argument(f"--{kind}", required=True)
+    merge.add_argument("--text-overflow", required=True)
     merge.add_argument("--input", required=True)
     merge.add_argument("--output", required=True)
     merge.add_argument("--out", default="build/render-report.json")
     args = parser.parse_args(argv)
 
     paths = {kind: Path(getattr(args, kind)) for kind in FRAGMENT_PRODUCERS}
+    overflow_path = Path(args.text_overflow)
     input_path, output_path = Path(args.input), Path(args.output)
     try:
         if not input_path.is_file() or not output_path.is_file():
             missing = input_path if not input_path.is_file() else output_path
             raise ValueError(f"missing render artifact: {missing}")
-        report = merge_fragments(paths, input_path, output_path)
+        report = merge_fragments(paths, overflow_path, input_path, output_path)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/tests/test_render_report.py
+++ b/tests/test_render_report.py
@@ -46,6 +46,17 @@ def passing_fragment(kind: str) -> dict:
     }
 
 
+def overflow_fragment(violations: list | None = None) -> dict:
+    violations = violations or []
+    return {
+        "schema_version": 1,
+        "stage": "text-overflow",
+        "artifact": "overflow.artifact",
+        "verdict": "FAIL" if violations else "PASS",
+        "violations": violations,
+    }
+
+
 def bind_fragment(fragment: dict, artifact: Path) -> dict:
     fragment["artifact"] = str(artifact)
     fragment["artifact_sha256"] = hashlib.sha256(artifact.read_bytes()).hexdigest()
@@ -68,6 +79,8 @@ class RenderReportMergeTests(unittest.TestCase):
             )
             path.write_text(json.dumps(fragment))
             self.fragments[kind] = path
+        self.overflow = self.root / "text-overflow.json"
+        self.overflow.write_text(json.dumps(bind_fragment(overflow_fragment(), self.html)))
         self.report = self.root / "render-report.json"
 
     def tearDown(self):
@@ -80,6 +93,7 @@ class RenderReportMergeTests(unittest.TestCase):
                 str(SCRIPT),
                 "merge",
                 "--artboard", str(self.fragments["artboard"]),
+                "--text-overflow", str(self.overflow),
                 "--still", str(self.fragments["still"]),
                 "--gif", str(self.fragments["gif"]),
                 "--input", str(self.html),
@@ -105,7 +119,43 @@ class RenderReportMergeTests(unittest.TestCase):
             hashlib.sha256(self.gif.read_bytes()).hexdigest(),
         )
         self.assertEqual(
-            set(report["digests"]["fragments"]), {"artboard", "still", "gif"})
+            set(report["digests"]["fragments"]),
+            {"artboard", "still", "gif", "text-overflow"},
+        )
+        overflow = next(row for row in report["findings"] if row["gate"] == "text-overflow")
+        self.assertEqual(overflow["status"], "PASS")
+        self.assertEqual(overflow["measured"], 0)
+
+    def test_text_overflow_is_a_blocking_final_report_failure(self):
+        violation = {
+            "element": '<div class="headline">',
+            "sample": "A clipped headline",
+            "reasons": ["clipped-x:<div class=\"card\">"],
+            "text_rect": {"left": 90, "top": 100, "right": 900, "bottom": 160},
+        }
+        self.overflow.write_text(json.dumps(bind_fragment(overflow_fragment([violation]), self.html)))
+
+        outcome = self.run_merge()
+
+        self.assertEqual(outcome.returncode, 1, outcome.stderr)
+        report = json.loads(self.report.read_text())
+        self.assertEqual(report["verdict"], "FAIL")
+        self.assertIn("text-overflow", report["summary"]["failed_gates"])
+        finding = next(row for row in report["findings"] if row["gate"] == "text-overflow")
+        self.assertEqual(finding["severity"], "blocking")
+        self.assertEqual(finding["measured"], 1)
+        self.assertEqual(finding["evidence"][0]["sample"], "A clipped headline")
+
+    def test_text_overflow_verdict_must_match_violations(self):
+        fragment = bind_fragment(overflow_fragment(), self.html)
+        fragment["verdict"] = "FAIL"
+        self.overflow.write_text(json.dumps(fragment))
+
+        outcome = self.run_merge()
+
+        self.assertEqual(outcome.returncode, 2)
+        self.assertIn("verdict does not match violations", outcome.stderr)
+        self.assertFalse(self.report.exists())
 
     def test_na_blocking_evidence_writes_a_failing_report(self):
         fragment = bind_fragment(passing_fragment("gif"), self.gif)
@@ -145,6 +195,14 @@ class RenderReportMergeTests(unittest.TestCase):
 
     def test_missing_fragment_stops_without_claiming_a_report(self):
         self.fragments["still"] = self.root / "missing.json"
+
+        outcome = self.run_merge()
+
+        self.assertEqual(outcome.returncode, 2)
+        self.assertFalse(self.report.exists())
+
+    def test_missing_overflow_fragment_stops_without_claiming_a_report(self):
+        self.overflow = self.root / "missing-overflow.json"
 
         outcome = self.run_merge()
 
@@ -209,6 +267,21 @@ class RenderReportMergeTests(unittest.TestCase):
 
         self.assertEqual(outcome.returncode, 2)
         self.assertIn("artifact digest", outcome.stderr)
+        self.assertFalse(self.report.exists())
+
+    def test_overflow_digest_must_match_current_artifact(self):
+        fragment = bind_fragment(overflow_fragment(), self.html)
+        self.html.write_bytes(b"<html>changed after overflow measurement</html>")
+        self.overflow.write_text(json.dumps(fragment))
+        for kind in ("artboard", "still"):
+            current = json.loads(self.fragments[kind].read_text())
+            bind_fragment(current, self.html)
+            self.fragments[kind].write_text(json.dumps(current))
+
+        outcome = self.run_merge()
+
+        self.assertEqual(outcome.returncode, 2)
+        self.assertIn("text-overflow render fragment", outcome.stderr)
         self.assertFalse(self.report.exists())
 
 


### PR DESCRIPTION
## Initiative
Make text clipping a first-class part of `render-report.json` instead of a sidecar-only gate.

## What changed
- merge the `text-overflow` fragment into the final render report
- synthesize a blocking `text-overflow` finding with bounded evidence
- include the overflow fragment in source metadata and fragment digests
- reject missing, stale, malformed, or contradictory overflow evidence
- make `render.sh` depend on the merged report verdict
- add deterministic tests for PASS, clipping failure, stale digest, missing evidence, and verdict mismatch

## Why
The render pipeline already blocked clipped text, but the final evidence artifact could still claim a clean report without containing that gate. This closes the evidence gap and keeps completion fail-closed.

## Verification
CI should run the repository test and validation suites on this branch. Merge only after fresh checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now include text-overflow audit results alongside existing rendering checks.
  * Text-overflow violations appear as blocking findings and are included in report sources and verification data.

* **Bug Fixes**
  * Report generation now validates merge results and stops when required checks fail.
  * Added validation for missing or mismatched text-overflow artifacts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->