### PR TITLE
test(typography): add Arabic RTL overflow regressions

### DIFF
--- a/tests/fixtures/text-overflow-rtl-fail.html
+++ b/tests/fixtures/text-overflow-rtl-fail.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<title>Fixture: RTL text clipped</title>
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: #222; }
+  #artboard {
+    position: relative;
+    width: 1080px;
+    height: 1350px;
+    overflow: hidden;
+    background: #faf8f4;
+    color: #171717;
+    font-family: Arial, "Noto Sans Arabic", sans-serif;
+    direction: rtl;
+  }
+  .card {
+    position: absolute;
+    top: 120px;
+    right: 96px;
+    width: 520px;
+    height: 150px;
+    overflow: hidden;
+    border: 1px solid #bbb;
+    padding: 20px;
+  }
+  .headline {
+    width: 900px;
+    white-space: nowrap;
+    font-size: 50px;
+    line-height: 1.4;
+    font-weight: 700;
+    text-align: right;
+  }
+</style>
+</head>
+<body>
+<div id="artboard">
+  <div class="card">
+    <div class="headline">هذا عنوان عربي طويل جدًا يجب أن يخرج من البطاقة ويُكتشف كحالة قص فعلية في الاتجاه من اليمين إلى اليسار</div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/fixtures/text-overflow-rtl-pass.html
+++ b/tests/fixtures/text-overflow-rtl-pass.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<title>Fixture: RTL text fits</title>
+<style>
+  * { box-sizing: border-box; }
+  html, body { margin: 0; background: #222; }
+  #artboard {
+    position: relative;
+    width: 1080px;
+    height: 1350px;
+    overflow: hidden;
+    background: #faf8f4;
+    color: #171717;
+    font-family: Arial, "Noto Sans Arabic", sans-serif;
+    direction: rtl;
+  }
+  .headline {
+    position: absolute;
+    top: 110px;
+    right: 96px;
+    width: 888px;
+    font-size: 60px;
+    line-height: 1.35;
+    font-weight: 700;
+    text-align: right;
+  }
+  .body {
+    position: absolute;
+    top: 330px;
+    right: 96px;
+    width: 888px;
+    font-size: 30px;
+    line-height: 1.7;
+    text-align: right;
+  }
+  .metric {
+    position: absolute;
+    top: 690px;
+    right: 96px;
+    width: 888px;
+    font-size: 42px;
+    line-height: 1.5;
+    text-align: right;
+  }
+</style>
+</head>
+<body>
+<div id="artboard">
+  <div class="headline">الوضوح يبدأ من ترتيب المعلومة قبل إضافة الحركة</div>
+  <div class="body">اختبار عربي باتجاه من اليمين إلى اليسار مع نص طويل نسبيًا، ومسافات طبيعية، ومزيج من الكلمات العربية والإنجليزية مثل LinkedIn وAI بدون خروج النص من مساحة التصميم</div>
+  <div class="metric">معدل التحويل 19.24% مقابل 6.87%</div>
+</div>
+</body>
+</html>

--- a/tests/test_text_overflow_audit.py
+++ b/tests/test_text_overflow_audit.py
@@ -45,6 +45,23 @@ class TextOverflowAuditTests(unittest.TestCase):
         self.assertEqual(data['verdict'], 'PASS')
         self.assertEqual(data['violations'], [])
 
+    def test_compliant_arabic_rtl_copy_has_no_false_positive(self):
+        code, data = run_audit('text-overflow-rtl-pass.html')
+        self.assertEqual(code, 0, data['violations'])
+        self.assertEqual(data['verdict'], 'PASS')
+        self.assertEqual(data['violations'], [])
+
+    def test_clipped_arabic_rtl_headline_fails_with_horizontal_evidence(self):
+        code, data = run_audit('text-overflow-rtl-fail.html')
+        self.assertEqual(code, 1)
+        self.assertEqual(data['verdict'], 'FAIL')
+        self.assertGreaterEqual(len(data['violations']), 1)
+        headline = [v for v in data['violations'] if 'headline' in v['element']]
+        self.assertTrue(headline, data['violations'])
+        reasons = ' '.join(r for v in headline for r in v['reasons'])
+        self.assertIn('clipped-x', reasons)
+        self.assertIn('عنوان عربي', headline[0]['sample'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Initiative
Add deterministic browser regression coverage for Arabic and mixed RTL typography in the rendered text overflow gate.

## Why
The current browser QA had English clipping fixtures, but no Arabic RTL case. That left a blind spot around right-to-left layout, Arabic shaping, mixed Arabic/English copy, and horizontal clipping evidence.

## Changes
- add a compliant Arabic RTL artboard fixture with mixed Arabic/English text and percentages
- add a deliberately clipped Arabic RTL headline fixture
- require the compliant fixture to produce zero overflow findings
- require the clipped fixture to fail with `clipped-x` evidence and preserve an Arabic text sample

## Scope
Testing and browser QA only. No production visual styling, motion, or rendering behavior changed.

## Verification
GitHub Actions browser validation is the authoritative runtime evidence for this branch because the connected local execution device is unavailable in this run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added RTL Arabic coverage for text-overflow auditing.
  * Verified compliant Arabic layouts pass without false positives.
  * Verified clipped RTL headlines are detected with horizontal overflow evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->