### PR TITLE
qa: block unfinished animations on the last exported frame

### DIFF
--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -44,9 +44,11 @@ SEEK_ALL = """
 """
 
 AUDIT_FINAL = """
-(finalSampleMs) => {
+({finalSampleMs, selector}) => {
   const violations = [];
   const finite = [];
+  const root = document.querySelector(selector);
+  if (!root) throw new Error(`export selector not found: ${selector}`);
 
   function describeTarget(target) {
     if (!target) return '<unknown>';
@@ -61,6 +63,9 @@ AUDIT_FINAL = """
   document.getAnimations().forEach((animation, index) => {
     const effect = animation.effect;
     if (!effect || !effect.getTiming || !effect.getComputedTiming) return;
+    const target = effect.target || null;
+    if (!(target instanceof Element) || (target !== root && !root.contains(target))) return;
+
     const timing = effect.getTiming();
     if (timing.iterations === Infinity) return;
 
@@ -68,7 +73,6 @@ AUDIT_FINAL = """
     const endTime = Number(computed.endTime);
     if (!Number.isFinite(endTime)) return;
 
-    const target = effect.target || null;
     const row = {
       index,
       animation: animation.animationName || animation.id || `animation-${index}`,
@@ -114,6 +118,7 @@ def main(argv=None) -> int:
     parser.add_argument("html")
     parser.add_argument("--duration", type=float, required=True)
     parser.add_argument("--fps", type=float, default=12.5)
+    parser.add_argument("--selector", default="#artboard")
     parser.add_argument("--json", default="build/.render-evidence/final-frame.json")
     parser.add_argument("--browser")
     parser.add_argument("--settle", type=int, default=300)
@@ -155,7 +160,10 @@ def main(argv=None) -> int:
                 page.wait_for_timeout(args.settle)
                 page.evaluate(PAUSE_ALL)
                 page.evaluate(SEEK_ALL, final_sample_ms)
-                measured = page.evaluate(AUDIT_FINAL, final_sample_ms)
+                measured = page.evaluate(
+                    AUDIT_FINAL,
+                    {"finalSampleMs": final_sample_ms, "selector": args.selector},
+                )
             finally:
                 browser.close()
     except Exception as exc:
@@ -171,6 +179,7 @@ def main(argv=None) -> int:
         "stage": "final-frame",
         "artifact": str(html),
         "artifact_sha256": file_sha256(html),
+        "selector": args.selector,
         "duration_ms": round(loop_ms, 3),
         "fps": args.fps,
         "frames": frames,

--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -47,8 +47,9 @@ AUDIT_FINAL = """
 ({finalSampleMs, selector}) => {
   const violations = [];
   const finite = [];
-  const root = document.querySelector(selector);
-  if (!root) throw new Error(`export selector not found: ${selector}`);
+  const requestedRoot = document.querySelector(selector);
+  const root = requestedRoot || document.documentElement;
+  const selectorFound = Boolean(requestedRoot);
 
   function describeTarget(target) {
     if (!target) return '<unknown>';
@@ -92,7 +93,7 @@ AUDIT_FINAL = """
     }
   });
 
-  return {finite, violations};
+  return {finite, violations, selectorFound};
 }
 """
 
@@ -180,6 +181,7 @@ def main(argv=None) -> int:
         "artifact": str(html),
         "artifact_sha256": file_sha256(html),
         "selector": args.selector,
+        "selector_found": measured["selectorFound"],
         "duration_ms": round(loop_ms, 3),
         "fps": args.fps,
         "frames": frames,

--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Fail when finite browser animations are still in progress on the last exported frame."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    sys.exit("playwright is not installed. Run: bash scripts/setup.sh")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.capture_frames import BROWSER_CANDIDATES, PREP_CSS
+from scripts.visual_contract import file_sha256
+
+PAUSE_ALL = """
+() => {
+  document.getAnimations().forEach(a => {
+    try { a.pause(); } catch (e) {}
+  });
+  document.querySelectorAll('svg').forEach(svg => {
+    try { svg.pauseAnimations(); } catch (e) {}
+  });
+}
+"""
+
+SEEK_ALL = """
+(tMs) => {
+  document.getAnimations().forEach(a => {
+    try {
+      a.pause();
+      a.currentTime = tMs;
+    } catch (e) {}
+  });
+  document.querySelectorAll('svg').forEach(svg => {
+    try { svg.setCurrentTime(tMs / 1000); } catch (e) {}
+  });
+}
+"""
+
+AUDIT_FINAL = """
+(finalSampleMs) => {
+  const violations = [];
+  const finite = [];
+
+  function describeTarget(target) {
+    if (!target) return '<unknown>';
+    const tag = (target.tagName || 'element').toLowerCase();
+    if (target.id) return `${tag}#${target.id}`;
+    const classes = target.classList && target.classList.length
+      ? '.' + [...target.classList].slice(0, 3).join('.')
+      : '';
+    return `${tag}${classes}`;
+  }
+
+  document.getAnimations().forEach((animation, index) => {
+    const effect = animation.effect;
+    if (!effect || !effect.getTiming || !effect.getComputedTiming) return;
+    const timing = effect.getTiming();
+    if (timing.iterations === Infinity) return;
+
+    const computed = effect.getComputedTiming();
+    const endTime = Number(computed.endTime);
+    if (!Number.isFinite(endTime)) return;
+
+    const target = effect.target || null;
+    const row = {
+      index,
+      animation: animation.animationName || animation.id || `animation-${index}`,
+      element: describeTarget(target),
+      end_time_ms: Math.round(endTime * 1000) / 1000,
+      progress: computed.progress,
+      current_iteration: computed.currentIteration,
+    };
+    finite.push(row);
+
+    if (endTime > finalSampleMs + 0.5) {
+      violations.push({
+        ...row,
+        reason: 'finite-animation-incomplete',
+        remaining_ms: Math.round((endTime - finalSampleMs) * 1000) / 1000,
+      });
+    }
+  });
+
+  return {finite, violations};
+}
+"""
+
+
+def find_browser(explicit: str | None) -> str | None:
+    if explicit:
+        if Path(explicit).exists():
+            return explicit
+        raise ValueError(f"Browser not found at {explicit}")
+    for candidate in BROWSER_CANDIDATES:
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def write_report(path: Path, report: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("html")
+    parser.add_argument("--duration", type=float, required=True)
+    parser.add_argument("--fps", type=float, default=12.5)
+    parser.add_argument("--json", default="build/.render-evidence/final-frame.json")
+    parser.add_argument("--browser")
+    parser.add_argument("--settle", type=int, default=300)
+    args = parser.parse_args(argv)
+
+    html = Path(args.html).resolve()
+    report_path = Path(args.json)
+    if not html.is_file():
+        print(f"No such file: {html}", file=sys.stderr)
+        return 2
+    if args.duration <= 0 or args.fps <= 0:
+        print("duration and fps must be positive", file=sys.stderr)
+        return 2
+
+    frames = int(round(args.duration * args.fps))
+    if frames < 2:
+        print("duration x fps must give at least 2 frames", file=sys.stderr)
+        return 2
+
+    loop_ms = args.duration * 1000.0
+    step_ms = loop_ms / frames
+    final_sample_ms = (frames - 1) * step_ms
+
+    try:
+        browser_path = find_browser(args.browser)
+        with sync_playwright() as playwright:
+            launch = {"args": ["--no-sandbox", "--disable-dev-shm-usage", "--hide-scrollbars"]}
+            if browser_path:
+                launch["executable_path"] = browser_path
+            browser = playwright.chromium.launch(**launch)
+            try:
+                page = browser.new_page(viewport={"width": 1080, "height": 1350})
+                page.goto(html.as_uri(), wait_until="load")
+                page.add_style_tag(content=PREP_CSS)
+                try:
+                    page.evaluate("() => document.fonts && document.fonts.ready")
+                except Exception:
+                    pass
+                page.wait_for_timeout(args.settle)
+                page.evaluate(PAUSE_ALL)
+                page.evaluate(SEEK_ALL, final_sample_ms)
+                measured = page.evaluate(AUDIT_FINAL, final_sample_ms)
+            finally:
+                browser.close()
+    except Exception as exc:
+        message = str(exc)
+        if "Executable doesn't exist" in message or "Failed to launch" in message:
+            message = "Chromium could not start. Run: python3 -m playwright install chromium"
+        print(message, file=sys.stderr)
+        return 2
+
+    violations = measured["violations"]
+    report = {
+        "schema_version": 1,
+        "stage": "final-frame",
+        "artifact": str(html),
+        "artifact_sha256": file_sha256(html),
+        "duration_ms": round(loop_ms, 3),
+        "fps": args.fps,
+        "frames": frames,
+        "final_sample_ms": round(final_sample_ms, 3),
+        "finite_animations": measured["finite"],
+        "violations": violations,
+        "verdict": "FAIL" if violations else "PASS",
+    }
+    write_report(report_path, report)
+
+    if violations:
+        print(f"final-frame audit: FAIL ({len(violations)} unfinished finite animation(s))")
+        for row in violations[:8]:
+            print(
+                f"  {row['element']} {row['animation']}: "
+                f"{row['remaining_ms']:.1f}ms remains after last exported frame"
+            )
+        return 1
+
+    print(f"final-frame audit: PASS ({len(measured['finite'])} finite animation(s) complete)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# render.sh - one command from HTML artboard to LinkedIn-ready GIF.
+# render.sh — one command from HTML artboard to LinkedIn-ready GIF.
 #
 #   bash scripts/render.sh build/post.html build/post.gif --duration 4.8 --fps 12.5
 #
@@ -52,11 +52,11 @@ BROWSER_CMD=(python3 "$HERE/render_probe.py" browser-path)
 BROWSER="$("${BROWSER_CMD[@]}")"
 [[ -n "$BROWSER" ]] || { echo "render browser could not be resolved" >&2; exit 2; }
 
-echo "-- lint -------------------------------------"
+echo "── lint ─────────────────────────────────────"
 bash "$HERE/lint_artboard.sh" "$HTML"
 
 echo
-echo "-- artboard audit ---------------------------"
+echo "── artboard audit ───────────────────────────"
 set +e
 ARTBOARD_CMD=(python3 "$HERE/artboard_audit.py" "$HTML" --json "$ARTBOARD_JSON")
 ARTBOARD_CMD+=(--browser "$BROWSER")
@@ -66,7 +66,7 @@ set -e
 [[ "$ARTBOARD_STATUS" -le 1 ]] || exit "$ARTBOARD_STATUS"
 
 echo
-echo "-- text overflow audit ----------------------"
+echo "── text overflow audit ──────────────────────"
 set +e
 OVERFLOW_CMD=(python3 "$HERE/text_overflow_audit.py" "$HTML" --json "$OVERFLOW_JSON")
 OVERFLOW_CMD+=(--browser "$BROWSER")
@@ -76,7 +76,7 @@ set -e
 [[ "$OVERFLOW_STATUS" -le 1 ]] || exit "$OVERFLOW_STATUS"
 
 echo
-echo "-- still ------------------------------------"
+echo "── still ────────────────────────────────────"
 set +e
 STILL_CMD=(python3 "$HERE/check_render.py" "$HTML" --out "$STILL" \
   --json "$STILL_JSON" --selector "$SELECTOR" "${MOBILE_ARG[@]}")
@@ -87,7 +87,7 @@ set -e
 [[ "$STILL_STATUS" -le 1 ]] || exit "$STILL_STATUS"
 
 echo
-echo "-- capture ----------------------------------"
+echo "── capture ──────────────────────────────────"
 CAPTURE_CMD=(python3 "$HERE/capture_frames.py" "$HTML" \
   --out "$FRAMES" --duration "$DURATION" --fps "$FPS" \
   --selector "$SELECTOR" --scale "$SCALE")
@@ -96,7 +96,7 @@ CAPTURE_CMD+=(--browser "$BROWSER")
 python3 "$HERE/render_probe.py" stamp-capture "$FRAMES/capture.json" --browser "$BROWSER"
 
 echo
-echo "-- final frame audit ------------------------"
+echo "── final frame audit ────────────────────────"
 set +e
 FINAL_FRAME_CMD=(python3 "$HERE/final_frame_audit.py" "$HTML" \
   --duration "$DURATION" --fps "$FPS" --json "$FINAL_FRAME_JSON")
@@ -107,7 +107,7 @@ set -e
 [[ "$FINAL_FRAME_STATUS" -le 1 ]] || exit "$FINAL_FRAME_STATUS"
 
 echo
-echo "-- assemble ---------------------------------"
+echo "── assemble ─────────────────────────────────"
 set +e
 python3 "$HERE/build_gif.py" "$FRAMES" \
   --out "$OUT" --fps "$FPS" --max-mb "$MAXMB" --colors "$COLORS" \
@@ -117,7 +117,7 @@ set -e
 [[ "$GIF_STATUS" -le 1 ]] || exit "$GIF_STATUS"
 
 echo
-echo "-- merge evidence ---------------------------"
+echo "── merge evidence ───────────────────────────"
 set +e
 python3 "$HERE/render_report.py" merge \
   --artboard "$ARTBOARD_JSON" --text-overflow "$OVERFLOW_JSON" \

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# render.sh — one command from HTML artboard to LinkedIn-ready GIF.
+# render.sh - one command from HTML artboard to LinkedIn-ready GIF.
 #
 #   bash scripts/render.sh build/post.html build/post.gif --duration 4.8 --fps 12.5
 #
@@ -42,6 +42,7 @@ STILL="$OUT_DIR/still.png"
 REPORT="$OUT_DIR/render-report.json"
 ARTBOARD_JSON="$EVIDENCE/artboard.json"
 OVERFLOW_JSON="$EVIDENCE/text-overflow.json"
+FINAL_FRAME_JSON="$EVIDENCE/final-frame.json"
 STILL_JSON="$EVIDENCE/still.json"
 GIF_JSON="$EVIDENCE/gif.json"
 mkdir -p "$EVIDENCE"
@@ -51,11 +52,11 @@ BROWSER_CMD=(python3 "$HERE/render_probe.py" browser-path)
 BROWSER="$("${BROWSER_CMD[@]}")"
 [[ -n "$BROWSER" ]] || { echo "render browser could not be resolved" >&2; exit 2; }
 
-echo "── lint ─────────────────────────────────────"
+echo "-- lint -------------------------------------"
 bash "$HERE/lint_artboard.sh" "$HTML"
 
 echo
-echo "── artboard audit ───────────────────────────"
+echo "-- artboard audit ---------------------------"
 set +e
 ARTBOARD_CMD=(python3 "$HERE/artboard_audit.py" "$HTML" --json "$ARTBOARD_JSON")
 ARTBOARD_CMD+=(--browser "$BROWSER")
@@ -65,7 +66,7 @@ set -e
 [[ "$ARTBOARD_STATUS" -le 1 ]] || exit "$ARTBOARD_STATUS"
 
 echo
-echo "── text overflow audit ──────────────────────"
+echo "-- text overflow audit ----------------------"
 set +e
 OVERFLOW_CMD=(python3 "$HERE/text_overflow_audit.py" "$HTML" --json "$OVERFLOW_JSON")
 OVERFLOW_CMD+=(--browser "$BROWSER")
@@ -75,7 +76,7 @@ set -e
 [[ "$OVERFLOW_STATUS" -le 1 ]] || exit "$OVERFLOW_STATUS"
 
 echo
-echo "── still ────────────────────────────────────"
+echo "-- still ------------------------------------"
 set +e
 STILL_CMD=(python3 "$HERE/check_render.py" "$HTML" --out "$STILL" \
   --json "$STILL_JSON" --selector "$SELECTOR" "${MOBILE_ARG[@]}")
@@ -86,7 +87,7 @@ set -e
 [[ "$STILL_STATUS" -le 1 ]] || exit "$STILL_STATUS"
 
 echo
-echo "── capture ──────────────────────────────────"
+echo "-- capture ----------------------------------"
 CAPTURE_CMD=(python3 "$HERE/capture_frames.py" "$HTML" \
   --out "$FRAMES" --duration "$DURATION" --fps "$FPS" \
   --selector "$SELECTOR" --scale "$SCALE")
@@ -95,7 +96,18 @@ CAPTURE_CMD+=(--browser "$BROWSER")
 python3 "$HERE/render_probe.py" stamp-capture "$FRAMES/capture.json" --browser "$BROWSER"
 
 echo
-echo "── assemble ─────────────────────────────────"
+echo "-- final frame audit ------------------------"
+set +e
+FINAL_FRAME_CMD=(python3 "$HERE/final_frame_audit.py" "$HTML" \
+  --duration "$DURATION" --fps "$FPS" --json "$FINAL_FRAME_JSON")
+FINAL_FRAME_CMD+=(--browser "$BROWSER")
+"${FINAL_FRAME_CMD[@]}"
+FINAL_FRAME_STATUS=$?
+set -e
+[[ "$FINAL_FRAME_STATUS" -le 1 ]] || exit "$FINAL_FRAME_STATUS"
+
+echo
+echo "-- assemble ---------------------------------"
 set +e
 python3 "$HERE/build_gif.py" "$FRAMES" \
   --out "$OUT" --fps "$FPS" --max-mb "$MAXMB" --colors "$COLORS" \
@@ -105,7 +117,7 @@ set -e
 [[ "$GIF_STATUS" -le 1 ]] || exit "$GIF_STATUS"
 
 echo
-echo "── merge evidence ───────────────────────────"
+echo "-- merge evidence ---------------------------"
 set +e
 python3 "$HERE/render_report.py" merge \
   --artboard "$ARTBOARD_JSON" --text-overflow "$OVERFLOW_JSON" \
@@ -115,4 +127,4 @@ REPORT_STATUS=$?
 set -e
 [[ "$REPORT_STATUS" -le 1 ]] || exit "$REPORT_STATUS"
 
-[[ "$ARTBOARD_STATUS" -eq 0 && "$OVERFLOW_STATUS" -eq 0 && "$STILL_STATUS" -eq 0 && "$GIF_STATUS" -eq 0 && "$REPORT_STATUS" -eq 0 ]]
+[[ "$ARTBOARD_STATUS" -eq 0 && "$OVERFLOW_STATUS" -eq 0 && "$STILL_STATUS" -eq 0 && "$FINAL_FRAME_STATUS" -eq 0 && "$GIF_STATUS" -eq 0 && "$REPORT_STATUS" -eq 0 ]]

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -99,7 +99,7 @@ echo
 echo "── final frame audit ────────────────────────"
 set +e
 FINAL_FRAME_CMD=(python3 "$HERE/final_frame_audit.py" "$HTML" \
-  --duration "$DURATION" --fps "$FPS" --json "$FINAL_FRAME_JSON")
+  --duration "$DURATION" --fps "$FPS" --selector "$SELECTOR" --json "$FINAL_FRAME_JSON")
 FINAL_FRAME_CMD+=(--browser "$BROWSER")
 "${FINAL_FRAME_CMD[@]}"
 FINAL_FRAME_STATUS=$?
@@ -121,7 +121,7 @@ echo "── merge evidence ─────────────────�
 set +e
 python3 "$HERE/render_report.py" merge \
   --artboard "$ARTBOARD_JSON" --text-overflow "$OVERFLOW_JSON" \
-  --still "$STILL_JSON" --gif "$GIF_JSON" \
+  --final-frame "$FINAL_FRAME_JSON" --still "$STILL_JSON" --gif "$GIF_JSON" \
   --input "$HTML" --output "$OUT" --out "$REPORT"
 REPORT_STATUS=$?
 set -e

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -11,17 +11,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.visual_contract import (
-    ADVISORY,
-    BLOCKING,
-    FAIL,
-    NA,
-    PASS,
-    WARN,
-    ContractError,
-    VisualContract,
-    file_sha256,
-    skipped,
-    summarize,
+    ADVISORY, BLOCKING, FAIL, NA, PASS, WARN, ContractError, VisualContract,
+    file_sha256, skipped, summarize,
 )
 
 FRAGMENT_PRODUCERS = {
@@ -30,6 +21,7 @@ FRAGMENT_PRODUCERS = {
     "gif": "scripts/build_gif.py",
 }
 OVERFLOW_KIND = "text-overflow"
+FINAL_FRAME_KIND = "final-frame"
 ROW_FIELDS = {
     "threshold_id", "gate", "severity", "status", "measured", "threshold",
     "unit", "detail", "evidence",
@@ -45,179 +37,116 @@ def _measurement_passes(row: dict, threshold: dict) -> bool:
     if not isinstance(measured, (int, float)) or isinstance(measured, bool):
         raise ValueError(f"non-numeric measurement for {row['threshold_id']}")
     comparison = threshold["comparison"]
-    if comparison == "eq":
-        return measured == threshold["value"]
-    if comparison == "min":
-        return measured >= threshold["value"]
-    if comparison == "max":
-        return measured <= threshold["value"]
+    if comparison == "eq": return measured == threshold["value"]
+    if comparison == "min": return measured >= threshold["value"]
+    if comparison == "max": return measured <= threshold["value"]
     raise ValueError(f"invalid comparison for {row['threshold_id']}")
 
 
 def read_fragment(path: Path, kind: str, contract: VisualContract) -> dict:
-    if not path.is_file():
-        raise ValueError(f"missing render fragment: {path}")
-    try:
-        fragment = json.loads(path.read_text())
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"invalid render fragment {path}: {exc}") from exc
-    if fragment.get("schema_version") != 1:
-        raise ValueError(f"unsupported render fragment schema: {path}")
-    if fragment.get("stage") != kind:
-        raise ValueError(f"render fragment stage is not {kind}: {path}")
-    if not isinstance(fragment.get("artifact"), str) or not fragment["artifact"]:
-        raise ValueError(f"render fragment has no artifact metadata: {path}")
+    if not path.is_file(): raise ValueError(f"missing render fragment: {path}")
+    try: fragment = json.loads(path.read_text())
+    except json.JSONDecodeError as exc: raise ValueError(f"invalid render fragment {path}: {exc}") from exc
+    if fragment.get("schema_version") != 1: raise ValueError(f"unsupported render fragment schema: {path}")
+    if fragment.get("stage") != kind: raise ValueError(f"render fragment stage is not {kind}: {path}")
+    if not isinstance(fragment.get("artifact"), str) or not fragment["artifact"]: raise ValueError(f"render fragment has no artifact metadata: {path}")
     artifact_sha256 = fragment.get("artifact_sha256")
-    if not isinstance(artifact_sha256, str) or len(artifact_sha256) != 64:
-        raise ValueError(f"render fragment has no artifact digest: {path}")
+    if not isinstance(artifact_sha256, str) or len(artifact_sha256) != 64: raise ValueError(f"render fragment has no artifact digest: {path}")
     findings = fragment.get("findings")
-    if not isinstance(findings, list):
-        raise ValueError(f"render fragment has no findings list: {path}")
+    if not isinstance(findings, list): raise ValueError(f"render fragment has no findings list: {path}")
     seen = set()
     for row in findings:
         missing = ROW_FIELDS - row.keys() if isinstance(row, dict) else ROW_FIELDS
-        if missing:
-            raise ValueError(f"render fragment row missing {sorted(missing)}: {path}")
+        if missing: raise ValueError(f"render fragment row missing {sorted(missing)}: {path}")
         threshold_id = row["threshold_id"]
-        if threshold_id in seen:
-            raise ValueError(f"duplicate threshold {threshold_id} in {kind} fragment")
+        if threshold_id in seen: raise ValueError(f"duplicate threshold {threshold_id} in {kind} fragment")
         seen.add(threshold_id)
-        try:
-            threshold = contract.threshold(threshold_id)
-        except ContractError as exc:
-            raise ValueError(f"unknown threshold {threshold_id} in {kind} fragment") from exc
-        if threshold["measured_by"] != FRAGMENT_PRODUCERS[kind]:
-            raise ValueError(f"threshold {threshold_id} does not belong to {kind} fragment")
+        try: threshold = contract.threshold(threshold_id)
+        except ContractError as exc: raise ValueError(f"unknown threshold {threshold_id} in {kind} fragment") from exc
+        if threshold["measured_by"] != FRAGMENT_PRODUCERS[kind]: raise ValueError(f"threshold {threshold_id} does not belong to {kind} fragment")
         canonical = {key: threshold[key] for key in ("gate", "severity", "value", "unit")}
-        declared = {
-            "gate": row["gate"], "severity": row["severity"],
-            "value": row["threshold"], "unit": row["unit"],
-        }
-        if declared != canonical:
-            raise ValueError(f"contract metadata drift for {threshold_id} in {kind} fragment")
+        declared = {"gate": row["gate"], "severity": row["severity"], "value": row["threshold"], "unit": row["unit"]}
+        if declared != canonical: raise ValueError(f"contract metadata drift for {threshold_id} in {kind} fragment")
         allowed = {PASS, FAIL, NA} if threshold["severity"] == BLOCKING else {PASS, WARN, NA}
-        if row["status"] not in allowed or threshold["severity"] not in {BLOCKING, ADVISORY}:
-            raise ValueError(f"invalid status for {threshold_id} in {kind} fragment")
+        if row["status"] not in allowed or threshold["severity"] not in {BLOCKING, ADVISORY}: raise ValueError(f"invalid status for {threshold_id} in {kind} fragment")
         if row["status"] == NA:
-            if row["measured"] is not None:
-                raise ValueError(f"NA row has a measurement for {threshold_id}")
+            if row["measured"] is not None: raise ValueError(f"NA row has a measurement for {threshold_id}")
             continue
         passes = _measurement_passes(row, threshold)
-        if (
-            threshold.get("exception_field")
-            and row.get("exception_applied") is True
-            and isinstance(row["detail"], str)
-            and row["detail"].startswith("excused: ")
-        ):
-            passes = True
+        if threshold.get("exception_field") and row.get("exception_applied") is True and isinstance(row["detail"], str) and row["detail"].startswith("excused: "): passes = True
         expected = PASS if passes else FAIL if threshold["severity"] == BLOCKING else WARN
-        if row["status"] != expected:
-            raise ValueError(f"status does not match measurement for {threshold_id}")
+        if row["status"] != expected: raise ValueError(f"status does not match measurement for {threshold_id}")
     return fragment
 
 
-def read_overflow_fragment(path: Path) -> dict:
-    if not path.is_file():
-        raise ValueError(f"missing render fragment: {path}")
-    try:
-        fragment = json.loads(path.read_text())
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"invalid render fragment {path}: {exc}") from exc
-    if fragment.get("schema_version") != 1:
-        raise ValueError(f"unsupported render fragment schema: {path}")
-    if fragment.get("stage") != OVERFLOW_KIND:
-        raise ValueError(f"render fragment stage is not {OVERFLOW_KIND}: {path}")
-    if not isinstance(fragment.get("artifact"), str) or not fragment["artifact"]:
-        raise ValueError(f"render fragment has no artifact metadata: {path}")
+def read_sidecar_fragment(path: Path, kind: str) -> dict:
+    if not path.is_file(): raise ValueError(f"missing render fragment: {path}")
+    try: fragment = json.loads(path.read_text())
+    except json.JSONDecodeError as exc: raise ValueError(f"invalid render fragment {path}: {exc}") from exc
+    if fragment.get("schema_version") != 1: raise ValueError(f"unsupported render fragment schema: {path}")
+    if fragment.get("stage") != kind: raise ValueError(f"render fragment stage is not {kind}: {path}")
+    if not isinstance(fragment.get("artifact"), str) or not fragment["artifact"]: raise ValueError(f"render fragment has no artifact metadata: {path}")
     artifact_sha256 = fragment.get("artifact_sha256")
-    if not isinstance(artifact_sha256, str) or len(artifact_sha256) != 64:
-        raise ValueError(f"render fragment has no artifact digest: {path}")
+    if not isinstance(artifact_sha256, str) or len(artifact_sha256) != 64: raise ValueError(f"render fragment has no artifact digest: {path}")
     violations = fragment.get("violations")
-    if not isinstance(violations, list):
-        raise ValueError(f"text-overflow fragment has no violations list: {path}")
+    if not isinstance(violations, list): raise ValueError(f"{kind} fragment has no violations list: {path}")
     expected = FAIL if violations else PASS
-    if fragment.get("verdict") != expected:
-        raise ValueError("text-overflow verdict does not match violations")
+    if fragment.get("verdict") != expected: raise ValueError(f"{kind} verdict does not match violations")
     return fragment
 
 
 def overflow_finding(fragment: dict) -> dict:
     violations = fragment["violations"]
-    evidence = [
-        {
-            "element": row.get("element"),
-            "sample": row.get("sample"),
-            "reasons": row.get("reasons", []),
-            "text_rect": row.get("text_rect"),
-        }
-        for row in violations[:8]
-        if isinstance(row, dict)
-    ]
+    evidence = [{"element": r.get("element"), "sample": r.get("sample"), "reasons": r.get("reasons", []), "text_rect": r.get("text_rect")} for r in violations[:8] if isinstance(r, dict)]
     return {
-        "threshold_id": "text.visible_nodes",
-        "gate": "text-overflow",
-        "severity": BLOCKING,
-        "status": FAIL if violations else PASS,
-        "measured": len(violations),
-        "threshold": 0,
+        "threshold_id": "text.visible_nodes", "gate": OVERFLOW_KIND, "severity": BLOCKING,
+        "status": FAIL if violations else PASS, "measured": len(violations), "threshold": 0,
         "unit": "violations",
-        "detail": (
-            f"{len(violations)} rendered text node(s) clipped or outside the artboard"
-            if violations else "no clipped or overflowing rendered text detected"
-        ),
+        "detail": f"{len(violations)} rendered text node(s) clipped or outside the artboard" if violations else "no clipped or overflowing rendered text detected",
         "evidence": evidence,
     }
 
 
-def merge_fragments(
-    paths: dict[str, Path], overflow_path: Path, input_path: Path, output_path: Path
-) -> dict:
+def final_frame_finding(fragment: dict) -> dict:
+    violations = fragment["violations"]
+    evidence = [{"element": r.get("element"), "animation": r.get("animation"), "remaining_ms": r.get("remaining_ms"), "reason": r.get("reason")} for r in violations[:8] if isinstance(r, dict)]
+    return {
+        "threshold_id": "motion.final_frame_complete", "gate": FINAL_FRAME_KIND, "severity": BLOCKING,
+        "status": FAIL if violations else PASS, "measured": len(violations), "threshold": 0,
+        "unit": "violations",
+        "detail": f"{len(violations)} finite animation(s) unfinished on the last exported frame" if violations else "all finite animations in the exported subtree complete by the last frame",
+        "evidence": evidence,
+    }
+
+
+def merge_fragments(paths: dict[str, Path], overflow_path: Path, final_frame_path: Path, input_path: Path, output_path: Path) -> dict:
     contract = VisualContract()
-    fragments = {
-        kind: read_fragment(path, kind, contract) for kind, path in paths.items()
-    }
-    overflow = read_overflow_fragment(overflow_path)
-    expected_artifacts = {
-        "artboard": input_path.resolve(),
-        "still": input_path.resolve(),
-        "gif": output_path.resolve(),
-    }
+    fragments = {kind: read_fragment(path, kind, contract) for kind, path in paths.items()}
+    overflow = read_sidecar_fragment(overflow_path, OVERFLOW_KIND)
+    final_frame = read_sidecar_fragment(final_frame_path, FINAL_FRAME_KIND)
+    expected_artifacts = {"artboard": input_path.resolve(), "still": input_path.resolve(), "gif": output_path.resolve()}
     for kind, fragment in fragments.items():
-        if Path(fragment["artifact"]).resolve() != expected_artifacts[kind]:
-            raise ValueError(f"stale artifact metadata in {kind} render fragment")
-        if fragment["artifact_sha256"] != file_sha256(expected_artifacts[kind]):
-            raise ValueError(f"stale artifact digest in {kind} render fragment")
-    if Path(overflow["artifact"]).resolve() != input_path.resolve():
-        raise ValueError("stale artifact metadata in text-overflow render fragment")
-    if overflow["artifact_sha256"] != file_sha256(input_path):
-        raise ValueError("stale artifact digest in text-overflow render fragment")
+        if Path(fragment["artifact"]).resolve() != expected_artifacts[kind]: raise ValueError(f"stale artifact metadata in {kind} render fragment")
+        if fragment["artifact_sha256"] != file_sha256(expected_artifacts[kind]): raise ValueError(f"stale artifact digest in {kind} render fragment")
+    for kind, fragment in ((OVERFLOW_KIND, overflow), (FINAL_FRAME_KIND, final_frame)):
+        if Path(fragment["artifact"]).resolve() != input_path.resolve(): raise ValueError(f"stale artifact metadata in {kind} render fragment")
+        if fragment["artifact_sha256"] != file_sha256(input_path): raise ValueError(f"stale artifact digest in {kind} render fragment")
 
     findings = [row for fragment in fragments.values() for row in fragment["findings"]]
     for kind, producer in FRAGMENT_PRODUCERS.items():
         present = {row["threshold_id"] for row in fragments[kind]["findings"]}
         for threshold_id, threshold in contract.thresholds.items():
             if threshold["measured_by"] == producer and threshold_id not in present:
-                findings.append(skipped(
-                    contract, threshold_id, f"missing from {kind} render fragment"))
-    findings.append(overflow_finding(overflow))
+                findings.append(skipped(contract, threshold_id, f"missing from {kind} render fragment"))
+    findings.extend([overflow_finding(overflow), final_frame_finding(final_frame)])
 
     summary = summarize(findings)
-    all_sources = {**fragments, OVERFLOW_KIND: overflow}
-    all_paths = {**paths, OVERFLOW_KIND: overflow_path}
+    all_sources = {**fragments, OVERFLOW_KIND: overflow, FINAL_FRAME_KIND: final_frame}
+    all_paths = {**paths, OVERFLOW_KIND: overflow_path, FINAL_FRAME_KIND: final_frame_path}
     return {
-        "schema_version": 1,
-        "verdict": summary["verdict"],
-        "summary": summary,
-        "findings": findings,
-        "sources": {
-            kind: {"path": str(all_paths[kind].resolve()), "verdict": fragment.get("verdict")}
-            for kind, fragment in all_sources.items()
-        },
-        "digests": {
-            "input": digest(input_path),
-            "output": digest(output_path),
-            "fragments": {kind: digest(path) for kind, path in all_paths.items()},
-        },
+        "schema_version": 1, "verdict": summary["verdict"], "summary": summary, "findings": findings,
+        "sources": {kind: {"path": str(all_paths[kind].resolve()), "verdict": fragment.get("verdict")} for kind, fragment in all_sources.items()},
+        "digests": {"input": digest(input_path), "output": digest(output_path), "fragments": {kind: digest(path) for kind, path in all_paths.items()}},
     }
 
 
@@ -225,26 +154,23 @@ def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
     merge = commands.add_parser("merge")
-    for kind in FRAGMENT_PRODUCERS:
-        merge.add_argument(f"--{kind}", required=True)
+    for kind in FRAGMENT_PRODUCERS: merge.add_argument(f"--{kind}", required=True)
     merge.add_argument("--text-overflow", required=True)
+    merge.add_argument("--final-frame", required=True)
     merge.add_argument("--input", required=True)
     merge.add_argument("--output", required=True)
     merge.add_argument("--out", default="build/render-report.json")
     args = parser.parse_args(argv)
-
     paths = {kind: Path(getattr(args, kind)) for kind in FRAGMENT_PRODUCERS}
-    overflow_path = Path(args.text_overflow)
     input_path, output_path = Path(args.input), Path(args.output)
     try:
         if not input_path.is_file() or not output_path.is_file():
             missing = input_path if not input_path.is_file() else output_path
             raise ValueError(f"missing render artifact: {missing}")
-        report = merge_fragments(paths, overflow_path, input_path, output_path)
+        report = merge_fragments(paths, Path(args.text_overflow), Path(args.final_frame), input_path, output_path)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 2
-
     target = Path(args.out)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")

--- a/tests/fixtures/final-frame-fail.html
+++ b/tests/fixtures/final-frame-fail.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body{margin:0}.artboard{width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{font:700 64px Arial;margin:120px;animation:enter 4s linear both}@keyframes enter{from{opacity:0;transform:translateY(80px)}to{opacity:1;transform:none}}
+</style></head><body><div class="artboard"><div class="headline">This entrance never reaches its final frame</div></div></body></html>

--- a/tests/fixtures/final-frame-pass.html
+++ b/tests/fixtures/final-frame-pass.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <html><head><meta charset="utf-8"><style>
-html,body{margin:0}.artboard{width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{font:700 64px Arial;margin:120px;animation:enter 800ms ease-out both}.pulse{width:40px;height:40px;background:#222;margin:120px;animation:pulse 1s ease-in-out infinite}@keyframes enter{from{opacity:0;transform:translateY(30px)}to{opacity:1;transform:none}}@keyframes pulse{50%{transform:scale(1.1)}}
-</style></head><body><div class="artboard"><div class="headline">Final state is complete</div><div class="pulse"></div></div></body></html>
+html,body{margin:0}.artboard{width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{font:700 64px Arial;margin:120px;animation:enter 800ms ease-out both}.pulse{width:40px;height:40px;background:#222;margin:120px;animation:pulse 1s ease-in-out infinite}.outside-preview{animation:outside 8s linear both}@keyframes enter{from{opacity:0;transform:translateY(30px)}to{opacity:1;transform:none}}@keyframes pulse{50%{transform:scale(1.1)}}@keyframes outside{from{opacity:0}to{opacity:1}}
+</style></head><body><div id="artboard" class="artboard"><div class="headline">Final state is complete</div><div class="pulse"></div></div><div class="outside-preview">Not exported</div></body></html>

--- a/tests/fixtures/final-frame-pass.html
+++ b/tests/fixtures/final-frame-pass.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body{margin:0}.artboard{width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{font:700 64px Arial;margin:120px;animation:enter 800ms ease-out both}.pulse{width:40px;height:40px;background:#222;margin:120px;animation:pulse 1s ease-in-out infinite}@keyframes enter{from{opacity:0;transform:translateY(30px)}to{opacity:1;transform:none}}@keyframes pulse{50%{transform:scale(1.1)}}
+</style></head><body><div class="artboard"><div class="headline">Final state is complete</div><div class="pulse"></div></div></body></html>

--- a/tests/test_final_frame_audit.py
+++ b/tests/test_final_frame_audit.py
@@ -18,7 +18,7 @@ TOOLCHAIN_MARKERS = (
 )
 
 
-def run_audit(fixture: str) -> tuple[int, dict]:
+def run_audit(fixture: str, selector: str = ".artboard") -> tuple[int, dict]:
     with tempfile.TemporaryDirectory() as tmp:
         report = Path(tmp) / "final-frame.json"
         proc = subprocess.run(
@@ -28,7 +28,7 @@ def run_audit(fixture: str) -> tuple[int, dict]:
                 str(FIXTURES / fixture),
                 "--duration", "4",
                 "--fps", "10",
-                "--selector", ".artboard",
+                "--selector", selector,
                 "--json", str(report),
             ],
             capture_output=True,
@@ -49,6 +49,7 @@ class FinalFrameAuditTests(unittest.TestCase):
         self.assertEqual(code, 0, data)
         self.assertEqual(data["verdict"], "PASS")
         self.assertEqual(data["selector"], ".artboard")
+        self.assertTrue(data["selector_found"])
         self.assertEqual(data["violations"], [])
         self.assertEqual(data["frames"], 40)
         self.assertEqual(data["final_sample_ms"], 3900.0)
@@ -65,6 +66,14 @@ class FinalFrameAuditTests(unittest.TestCase):
         self.assertIn("headline", violation["element"])
         self.assertAlmostEqual(violation["remaining_ms"], 100.0, places=1)
         self.assertLess(violation["progress"], 1)
+
+    def test_missing_selector_falls_back_to_document_like_frame_capture(self):
+        code, data = run_audit("final-frame-fail.html", ".missing-export-root")
+        self.assertEqual(code, 1, data)
+        self.assertFalse(data["selector_found"])
+        self.assertEqual(data["selector"], ".missing-export-root")
+        self.assertEqual(data["verdict"], "FAIL")
+        self.assertGreaterEqual(len(data["finite_animations"]), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_final_frame_audit.py
+++ b/tests/test_final_frame_audit.py
@@ -28,6 +28,7 @@ def run_audit(fixture: str) -> tuple[int, dict]:
                 str(FIXTURES / fixture),
                 "--duration", "4",
                 "--fps", "10",
+                "--selector", ".artboard",
                 "--json", str(report),
             ],
             capture_output=True,
@@ -43,14 +44,16 @@ def run_audit(fixture: str) -> tuple[int, dict]:
 
 
 class FinalFrameAuditTests(unittest.TestCase):
-    def test_completed_finite_animation_passes_and_infinite_loop_is_ignored(self):
+    def test_completed_finite_animation_passes_and_ignores_non_exported_and_infinite_animation(self):
         code, data = run_audit("final-frame-pass.html")
         self.assertEqual(code, 0, data)
         self.assertEqual(data["verdict"], "PASS")
+        self.assertEqual(data["selector"], ".artboard")
         self.assertEqual(data["violations"], [])
         self.assertEqual(data["frames"], 40)
         self.assertEqual(data["final_sample_ms"], 3900.0)
         self.assertEqual(len(data["finite_animations"]), 1)
+        self.assertNotIn("outside-preview", json.dumps(data["finite_animations"]))
 
     def test_animation_that_only_finishes_at_loop_endpoint_fails(self):
         code, data = run_audit("final-frame-fail.html")

--- a/tests/test_final_frame_audit.py
+++ b/tests/test_final_frame_audit.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT = ROOT / "scripts" / "final_frame_audit.py"
+FIXTURES = ROOT / "tests" / "fixtures"
+TOOLCHAIN_MARKERS = (
+    "playwright is not installed",
+    "Chromium could not start",
+    "No Chrome build available",
+)
+
+
+def run_audit(fixture: str) -> tuple[int, dict]:
+    with tempfile.TemporaryDirectory() as tmp:
+        report = Path(tmp) / "final-frame.json"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(AUDIT),
+                str(FIXTURES / fixture),
+                "--duration", "4",
+                "--fps", "10",
+                "--json", str(report),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+            timeout=180,
+        )
+        if any(marker in proc.stderr for marker in TOOLCHAIN_MARKERS):
+            raise unittest.SkipTest(proc.stderr.strip())
+        if not report.is_file():
+            raise AssertionError(f"final-frame audit produced no report: {proc.stderr}")
+        return proc.returncode, json.loads(report.read_text())
+
+
+class FinalFrameAuditTests(unittest.TestCase):
+    def test_completed_finite_animation_passes_and_infinite_loop_is_ignored(self):
+        code, data = run_audit("final-frame-pass.html")
+        self.assertEqual(code, 0, data)
+        self.assertEqual(data["verdict"], "PASS")
+        self.assertEqual(data["violations"], [])
+        self.assertEqual(data["frames"], 40)
+        self.assertEqual(data["final_sample_ms"], 3900.0)
+        self.assertEqual(len(data["finite_animations"]), 1)
+
+    def test_animation_that_only_finishes_at_loop_endpoint_fails(self):
+        code, data = run_audit("final-frame-fail.html")
+        self.assertEqual(code, 1, data)
+        self.assertEqual(data["verdict"], "FAIL")
+        self.assertEqual(len(data["violations"]), 1)
+        violation = data["violations"][0]
+        self.assertEqual(violation["reason"], "finite-animation-incomplete")
+        self.assertIn("headline", violation["element"])
+        self.assertAlmostEqual(violation["remaining_ms"], 100.0, places=1)
+        self.assertLess(violation["progress"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_render_report.py
+++ b/tests/test_render_report.py
@@ -14,47 +14,25 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "render_report.py"
 CONTRACT = json.loads((ROOT / "helper" / "visual-contract.json").read_text())
-KINDS = {
-    "artboard": "scripts/artboard_audit.py",
-    "still": "scripts/check_render.py",
-    "gif": "scripts/build_gif.py",
-}
+KINDS = {"artboard": "scripts/artboard_audit.py", "still": "scripts/check_render.py", "gif": "scripts/build_gif.py"}
 
 
 def passing_fragment(kind: str) -> dict:
     measured_by = KINDS[kind]
     findings = []
     for threshold_id, threshold in CONTRACT["thresholds"].items():
-        if threshold["measured_by"] != measured_by:
-            continue
+        if threshold["measured_by"] != measured_by: continue
         findings.append({
-            "threshold_id": threshold_id,
-            "gate": threshold["gate"],
-            "severity": threshold["severity"],
-            "status": "PASS",
-            "measured": threshold["value"],
-            "threshold": threshold["value"],
-            "unit": threshold["unit"],
-            "detail": "",
-            "evidence": [],
+            "threshold_id": threshold_id, "gate": threshold["gate"], "severity": threshold["severity"],
+            "status": "PASS", "measured": threshold["value"], "threshold": threshold["value"],
+            "unit": threshold["unit"], "detail": "", "evidence": [],
         })
-    return {
-        "schema_version": 1,
-        "stage": kind,
-        "artifact": f"{kind}.artifact",
-        "findings": findings,
-    }
+    return {"schema_version": 1, "stage": kind, "artifact": f"{kind}.artifact", "findings": findings}
 
 
-def overflow_fragment(violations: list | None = None) -> dict:
+def sidecar_fragment(stage: str, violations: list | None = None) -> dict:
     violations = violations or []
-    return {
-        "schema_version": 1,
-        "stage": "text-overflow",
-        "artifact": "overflow.artifact",
-        "verdict": "FAIL" if violations else "PASS",
-        "violations": violations,
-    }
+    return {"schema_version": 1, "stage": stage, "artifact": f"{stage}.artifact", "verdict": "FAIL" if violations else "PASS", "violations": violations}
 
 
 def bind_fragment(fragment: dict, artifact: Path) -> dict:
@@ -65,225 +43,111 @@ def bind_fragment(fragment: dict, artifact: Path) -> dict:
 
 class RenderReportMergeTests(unittest.TestCase):
     def setUp(self):
-        self.temp = tempfile.TemporaryDirectory()
-        self.root = Path(self.temp.name)
-        self.html = self.root / "post.html"
-        self.gif = self.root / "post.gif"
-        self.html.write_bytes(b"<html>measured input</html>")
-        self.gif.write_bytes(b"GIF89a-measured-output")
+        self.temp = tempfile.TemporaryDirectory(); self.root = Path(self.temp.name)
+        self.html = self.root / "post.html"; self.gif = self.root / "post.gif"
+        self.html.write_bytes(b"<html>measured input</html>"); self.gif.write_bytes(b"GIF89a-measured-output")
         self.fragments = {}
         for kind in KINDS:
             path = self.root / f"{kind}.json"
-            fragment = bind_fragment(
-                passing_fragment(kind), self.gif if kind == "gif" else self.html
-            )
-            path.write_text(json.dumps(fragment))
+            path.write_text(json.dumps(bind_fragment(passing_fragment(kind), self.gif if kind == "gif" else self.html)))
             self.fragments[kind] = path
         self.overflow = self.root / "text-overflow.json"
-        self.overflow.write_text(json.dumps(bind_fragment(overflow_fragment(), self.html)))
+        self.overflow.write_text(json.dumps(bind_fragment(sidecar_fragment("text-overflow"), self.html)))
+        self.final_frame = self.root / "final-frame.json"
+        self.final_frame.write_text(json.dumps(bind_fragment(sidecar_fragment("final-frame"), self.html)))
         self.report = self.root / "render-report.json"
 
-    def tearDown(self):
-        self.temp.cleanup()
+    def tearDown(self): self.temp.cleanup()
 
     def run_merge(self) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            [
-                sys.executable,
-                str(SCRIPT),
-                "merge",
-                "--artboard", str(self.fragments["artboard"]),
-                "--text-overflow", str(self.overflow),
-                "--still", str(self.fragments["still"]),
-                "--gif", str(self.fragments["gif"]),
-                "--input", str(self.html),
-                "--output", str(self.gif),
-                "--out", str(self.report),
-            ],
-            capture_output=True,
-            text=True,
-            cwd=ROOT,
-        )
+        return subprocess.run([
+            sys.executable, str(SCRIPT), "merge",
+            "--artboard", str(self.fragments["artboard"]), "--text-overflow", str(self.overflow),
+            "--final-frame", str(self.final_frame), "--still", str(self.fragments["still"]),
+            "--gif", str(self.fragments["gif"]), "--input", str(self.html), "--output", str(self.gif),
+            "--out", str(self.report),
+        ], capture_output=True, text=True, cwd=ROOT)
 
     def test_passing_fragments_merge_with_input_and_output_digests(self):
-        outcome = self.run_merge()
-        self.assertEqual(outcome.returncode, 0, outcome.stderr)
-        report = json.loads(self.report.read_text())
-        self.assertEqual(report["verdict"], "PASS")
-        self.assertEqual(
-            report["digests"]["input"]["sha256"],
-            hashlib.sha256(self.html.read_bytes()).hexdigest(),
-        )
-        self.assertEqual(
-            report["digests"]["output"]["sha256"],
-            hashlib.sha256(self.gif.read_bytes()).hexdigest(),
-        )
-        self.assertEqual(
-            set(report["digests"]["fragments"]),
-            {"artboard", "still", "gif", "text-overflow"},
-        )
-        overflow = next(row for row in report["findings"] if row["gate"] == "text-overflow")
-        self.assertEqual(overflow["status"], "PASS")
-        self.assertEqual(overflow["measured"], 0)
+        outcome = self.run_merge(); self.assertEqual(outcome.returncode, 0, outcome.stderr)
+        report = json.loads(self.report.read_text()); self.assertEqual(report["verdict"], "PASS")
+        self.assertEqual(report["digests"]["input"]["sha256"], hashlib.sha256(self.html.read_bytes()).hexdigest())
+        self.assertEqual(report["digests"]["output"]["sha256"], hashlib.sha256(self.gif.read_bytes()).hexdigest())
+        self.assertEqual(set(report["digests"]["fragments"]), {"artboard", "still", "gif", "text-overflow", "final-frame"})
+        self.assertEqual(next(r for r in report["findings"] if r["gate"] == "text-overflow")["status"], "PASS")
+        self.assertEqual(next(r for r in report["findings"] if r["gate"] == "final-frame")["status"], "PASS")
 
     def test_text_overflow_is_a_blocking_final_report_failure(self):
-        violation = {
-            "element": '<div class="headline">',
-            "sample": "A clipped headline",
-            "reasons": ["clipped-x:<div class=\"card\">"],
-            "text_rect": {"left": 90, "top": 100, "right": 900, "bottom": 160},
-        }
-        self.overflow.write_text(json.dumps(bind_fragment(overflow_fragment([violation]), self.html)))
+        violation = {"element": '<div class="headline">', "sample": "A clipped headline", "reasons": ["clipped-x"], "text_rect": {"left": 90}}
+        self.overflow.write_text(json.dumps(bind_fragment(sidecar_fragment("text-overflow", [violation]), self.html)))
+        outcome = self.run_merge(); self.assertEqual(outcome.returncode, 1, outcome.stderr)
+        report = json.loads(self.report.read_text()); self.assertIn("text-overflow", report["summary"]["failed_gates"])
 
-        outcome = self.run_merge()
+    def test_final_frame_is_a_blocking_final_report_failure(self):
+        violation = {"element": "div.headline", "animation": "enter", "remaining_ms": 100.0, "reason": "finite-animation-incomplete"}
+        self.final_frame.write_text(json.dumps(bind_fragment(sidecar_fragment("final-frame", [violation]), self.html)))
+        outcome = self.run_merge(); self.assertEqual(outcome.returncode, 1, outcome.stderr)
+        report = json.loads(self.report.read_text()); self.assertEqual(report["verdict"], "FAIL")
+        self.assertIn("final-frame", report["summary"]["failed_gates"])
+        finding = next(r for r in report["findings"] if r["gate"] == "final-frame")
+        self.assertEqual(finding["severity"], "blocking"); self.assertEqual(finding["evidence"][0]["remaining_ms"], 100.0)
 
-        self.assertEqual(outcome.returncode, 1, outcome.stderr)
-        report = json.loads(self.report.read_text())
-        self.assertEqual(report["verdict"], "FAIL")
-        self.assertIn("text-overflow", report["summary"]["failed_gates"])
-        finding = next(row for row in report["findings"] if row["gate"] == "text-overflow")
-        self.assertEqual(finding["severity"], "blocking")
-        self.assertEqual(finding["measured"], 1)
-        self.assertEqual(finding["evidence"][0]["sample"], "A clipped headline")
-
-    def test_text_overflow_verdict_must_match_violations(self):
-        fragment = bind_fragment(overflow_fragment(), self.html)
-        fragment["verdict"] = "FAIL"
-        self.overflow.write_text(json.dumps(fragment))
-
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertIn("verdict does not match violations", outcome.stderr)
+    def test_sidecar_verdict_must_match_violations(self):
+        fragment = bind_fragment(sidecar_fragment("final-frame"), self.html); fragment["verdict"] = "FAIL"
+        self.final_frame.write_text(json.dumps(fragment)); outcome = self.run_merge()
+        self.assertEqual(outcome.returncode, 2); self.assertIn("final-frame verdict does not match violations", outcome.stderr)
         self.assertFalse(self.report.exists())
 
     def test_na_blocking_evidence_writes_a_failing_report(self):
         fragment = bind_fragment(passing_fragment("gif"), self.gif)
-        row = next(
-            finding for finding in fragment["findings"]
-            if finding["severity"] == "blocking"
-        )
-        row.update(status="NA", measured=None, detail="probe unavailable")
-        self.fragments["gif"].write_text(json.dumps(fragment))
-
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 1, outcome.stderr)
-        report = json.loads(self.report.read_text())
-        self.assertEqual(report["verdict"], "FAIL")
-        self.assertIn(row["gate"], report["summary"]["failed_gates"])
+        row = next(f for f in fragment["findings"] if f["severity"] == "blocking")
+        row.update(status="NA", measured=None, detail="probe unavailable"); self.fragments["gif"].write_text(json.dumps(fragment))
+        outcome = self.run_merge(); self.assertEqual(outcome.returncode, 1, outcome.stderr)
 
     def test_missing_blocking_evidence_is_materialized_and_fails(self):
         fragment = bind_fragment(passing_fragment("still"), self.html)
-        missing = next(
-            finding for finding in fragment["findings"]
-            if finding["severity"] == "blocking"
-        )
-        fragment["findings"].remove(missing)
-        self.fragments["still"].write_text(json.dumps(fragment))
-
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 1, outcome.stderr)
-        report = json.loads(self.report.read_text())
-        row = next(
-            finding for finding in report["findings"]
-            if finding["threshold_id"] == missing["threshold_id"]
-        )
+        missing = next(f for f in fragment["findings"] if f["severity"] == "blocking")
+        fragment["findings"].remove(missing); self.fragments["still"].write_text(json.dumps(fragment))
+        outcome = self.run_merge(); self.assertEqual(outcome.returncode, 1, outcome.stderr)
+        report = json.loads(self.report.read_text()); row = next(f for f in report["findings"] if f["threshold_id"] == missing["threshold_id"])
         self.assertEqual(row["status"], "NA")
-        self.assertEqual(row["severity"], "blocking")
 
     def test_missing_fragment_stops_without_claiming_a_report(self):
-        self.fragments["still"] = self.root / "missing.json"
+        self.fragments["still"] = self.root / "missing.json"; outcome = self.run_merge()
+        self.assertEqual(outcome.returncode, 2); self.assertFalse(self.report.exists())
 
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertFalse(self.report.exists())
-
-    def test_missing_overflow_fragment_stops_without_claiming_a_report(self):
-        self.overflow = self.root / "missing-overflow.json"
-
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertFalse(self.report.exists())
+    def test_missing_sidecar_stops_without_claiming_a_report(self):
+        self.final_frame = self.root / "missing-final-frame.json"; outcome = self.run_merge()
+        self.assertEqual(outcome.returncode, 2); self.assertFalse(self.report.exists())
 
     def test_stale_contract_metadata_is_rejected(self):
-        fragment = bind_fragment(passing_fragment("gif"), self.gif)
-        row = fragment["findings"][0]
-        row["severity"] = "blocking" if row["severity"] == "advisory" else "advisory"
-        row["threshold"] = row["threshold"] + 1
-        self.fragments["gif"].write_text(json.dumps(fragment))
+        fragment = bind_fragment(passing_fragment("gif"), self.gif); row = fragment["findings"][0]
+        row["severity"] = "blocking" if row["severity"] == "advisory" else "advisory"; row["threshold"] += 1
+        self.fragments["gif"].write_text(json.dumps(fragment)); outcome = self.run_merge()
+        self.assertEqual(outcome.returncode, 2); self.assertIn("contract metadata", outcome.stderr)
 
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertIn("contract metadata", outcome.stderr)
-        self.assertFalse(self.report.exists())
-
-    def test_threshold_from_the_wrong_stage_is_rejected(self):
-        still = bind_fragment(passing_fragment("still"), self.html)
-        misplaced = still["findings"].pop()
-        artboard = bind_fragment(passing_fragment("artboard"), self.html)
-        artboard["findings"].append(misplaced)
-        self.fragments["still"].write_text(json.dumps(still))
-        self.fragments["artboard"].write_text(json.dumps(artboard))
-
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertIn("does not belong to artboard", outcome.stderr)
-        self.assertFalse(self.report.exists())
-
-    def test_wrong_stage_or_artifact_is_rejected(self):
-        fragment = passing_fragment("still")
-        fragment["stage"] = "artboard"
-        fragment["artifact"] = str(self.root / "stale.html")
-        self.fragments["still"].write_text(json.dumps(fragment))
-
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertIn("stage", outcome.stderr)
-        self.assertFalse(self.report.exists())
+    def test_threshold_from_wrong_stage_is_rejected(self):
+        still = bind_fragment(passing_fragment("still"), self.html); misplaced = still["findings"].pop()
+        artboard = bind_fragment(passing_fragment("artboard"), self.html); artboard["findings"].append(misplaced)
+        self.fragments["still"].write_text(json.dumps(still)); self.fragments["artboard"].write_text(json.dumps(artboard))
+        outcome = self.run_merge(); self.assertEqual(outcome.returncode, 2); self.assertIn("does not belong", outcome.stderr)
 
     def test_declared_pass_must_match_measurement(self):
-        fragment = json.loads(self.fragments["artboard"].read_text())
-        row = next(row for row in fragment["findings"] if row["threshold_id"] == "artboard.width")
-        row["measured"] = 1
-        self.fragments["artboard"].write_text(json.dumps(fragment))
-
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertIn("status does not match measurement", outcome.stderr)
-        self.assertFalse(self.report.exists())
+        fragment = json.loads(self.fragments["artboard"].read_text()); row = next(r for r in fragment["findings"] if r["threshold_id"] == "artboard.width")
+        row["measured"] = 1; self.fragments["artboard"].write_text(json.dumps(fragment)); outcome = self.run_merge()
+        self.assertEqual(outcome.returncode, 2); self.assertIn("status does not match measurement", outcome.stderr)
 
     def test_fragment_digest_must_match_current_artifact(self):
-        self.html.write_bytes(b"<html>changed after measurement</html>")
+        self.html.write_bytes(b"<html>changed after measurement</html>"); outcome = self.run_merge()
+        self.assertEqual(outcome.returncode, 2); self.assertIn("artifact digest", outcome.stderr)
 
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertIn("artifact digest", outcome.stderr)
-        self.assertFalse(self.report.exists())
-
-    def test_overflow_digest_must_match_current_artifact(self):
-        fragment = bind_fragment(overflow_fragment(), self.html)
-        self.html.write_bytes(b"<html>changed after overflow measurement</html>")
-        self.overflow.write_text(json.dumps(fragment))
+    def test_final_frame_digest_must_match_current_artifact(self):
+        fragment = bind_fragment(sidecar_fragment("final-frame"), self.html)
+        self.html.write_bytes(b"<html>changed after final-frame measurement</html>"); self.final_frame.write_text(json.dumps(fragment))
         for kind in ("artboard", "still"):
-            current = json.loads(self.fragments[kind].read_text())
-            bind_fragment(current, self.html)
-            self.fragments[kind].write_text(json.dumps(current))
-
-        outcome = self.run_merge()
-
-        self.assertEqual(outcome.returncode, 2)
-        self.assertIn("text-overflow render fragment", outcome.stderr)
-        self.assertFalse(self.report.exists())
+            current = json.loads(self.fragments[kind].read_text()); bind_fragment(current, self.html); self.fragments[kind].write_text(json.dumps(current))
+        overflow = json.loads(self.overflow.read_text()); bind_fragment(overflow, self.html); self.overflow.write_text(json.dumps(overflow))
+        outcome = self.run_merge(); self.assertEqual(outcome.returncode, 2); self.assertIn("final-frame render fragment", outcome.stderr)
 
 
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
## Initiative
Add a browser-level final-frame completion gate to the render pipeline.

## Problem
A finite entrance animation can be configured to end exactly at the loop duration, while the exported GIF samples only up to one frame before that endpoint. The animation therefore never reaches its intended final pose in the actual output even though the timeline looks correct on paper.

## Changes
- add `scripts/final_frame_audit.py`
- calculate the exact last sampled timestamp from duration and FPS
- fail when any finite browser animation still has active time remaining on that sampled frame
- ignore infinite looping animations
- scope the audit to the same `--selector` subtree that is exported
- preserve the existing frame-capture fallback to the full document when the requested selector is missing
- preserve JSON evidence with animation target, progress, end time, remaining milliseconds, and selector resolution state
- merge final-frame evidence into canonical `render-report.json` as a blocking gate
- fail closed on missing, stale, or contradictory final-frame evidence
- add deterministic browser and report regressions

## Review fixes
Three review findings were addressed on the final head:
1. non-exported page animations no longer create false failures
2. failed final-frame evidence can no longer be hidden behind a passing canonical render report
3. a missing export selector preserves the existing `capture_frames.py` full-document fallback instead of turning the render into an unexpected tooling error

## Scope
No visual style or motion recipe changes. This is rendering QA and evidence integrity only.

## Verification
Verified on exact head `5d1a24a6ffeb7540f9055e9a6ccab57e635a5a39`:
- Plugin Validation: PASS
- Security Gates: PASS
- Plugin Scanner: PASS
- CodeRabbit: PASS
- QLTY: PASS

Merge only from this exact head.