### PR TITLE
Add LinkedIn caption narrative skill

### DIFF
--- a/openai-skills/linkedin-caption-narrative/SKILL.md
+++ b/openai-skills/linkedin-caption-narrative/SKILL.md
@@ -1,0 +1,594 @@
+---
+name: linkedin-caption-narrative
+description: Use when writing or rewriting LinkedIn captions for repos, plugins, AI workflows, GIFs, infographics, technical ideas, curated collections, tool explainers, belief-correction posts, or first-comment link payloads that need a strong mobile hook and mechanism-first narrative
+---
+
+# LinkedIn Caption Narrative
+
+## Purpose
+
+Write high-signal LinkedIn captions that read like a useful explanation someone would stop to read, not launch copy pretending to be conversational
+
+Core principle
+
+**Hook with a real tension, name the thing early, explain the mechanism with concrete nouns, let the visual carry part of the story, and move link-heavy utility into the first comment when that improves the read**
+
+This Skill is designed for technical and AI-adjacent posts where the artifact itself matters: repositories, Plugins, Skills, workflows, models, research methods, animated infographics, GIFs, catalogues, and practical belief corrections
+
+## Use when
+
+Use this Skill when the user asks for any of the following
+
+- a hooky or stop-scroll LinkedIn caption
+- a caption for a GitHub repo, Plugin, Skill, workflow, AI tool, model, or technical resource
+- a caption that accompanies a GIF or animated infographic
+- a curated list or catalogue of repos, tools, or workflows
+- a belief-correction educational post
+- a recent-signal or research-process post
+- a caption plus first comment
+- a rewrite inspired by high-signal AI, developer, marketing, GTM, or technical LinkedIn posts
+
+Do not use this as a generic thought-leadership template when there is no real mechanism, artifact, evidence, or practical idea to explain
+
+## Inputs
+
+Resolve these from the user material before drafting
+
+1. **Thing**: what exactly is being shown or discussed
+2. **Reader**: who would care and why
+3. **Tension**: what friction, misconception, repeated task, or missing context creates interest
+4. **Mechanism**: what actually happens
+5. **Specifics**: names, commands, steps, inputs, outputs, limits, categories, or verified numbers
+6. **Proof**: only evidence supplied or verified
+7. **Visual job**: what the GIF or infographic already communicates
+8. **CTA**: one useful next action
+9. **First-comment payload**: links, setup steps, sources, install commands, or long catalogue entries
+10. **House style**: punctuation, banned language, dialect, capitalization, formatting, or other explicit user rules
+
+If a factual claim, number, benchmark, price, star count, license, compatibility statement, performance claim, testimonial, or product behavior is not supported, do not invent it
+
+## Outputs
+
+Return the finished caption first
+
+Return a finished first comment when the user requests one or when links, commands, sources, or a long catalogue would make the caption harder to read
+
+Do not expose pattern names, scoring, internal routing, or drafting notes unless the user asks for them
+
+## Core narrative grammar
+
+The dominant transferable pattern is
+
+**Tension → Named Thing → Mechanism → Specifics → Why It Matters → Visual Bridge → Action**
+
+Not every post needs every stage
+
+The important rule is that each block must advance the idea instead of restating the hook
+
+### 1. Tension
+
+Open on something recognizable and concrete
+
+Strong tension types
+
+- a tool behaves badly in a specific way
+- a repeated task has become annoying
+- a common assumption is incomplete
+- a category changes faster than the research process
+- a metric looks good but hides the real problem
+- too many resources create a coordination problem
+- a technical constraint blocks a practical outcome
+
+Good shapes
+
+- `Most OCR tools choke on messy documents`
+- `Most AI tools talk too much`
+- `Your page can rank first and still never become the answer`
+- `I built so many AI Skills that using them became its own workflow`
+
+Weak shapes
+
+- `AI is changing everything`
+- `This tool is amazing`
+- `The future of work is here`
+- `I found a game-changing repo`
+
+Reject a hook if another product name can be swapped in without changing the meaning
+
+### 2. Named Thing
+
+Name the artifact early
+
+Useful forms
+
+- `Meet {repo-name}`
+- `The {repo-name} GitHub repo`
+- `This Skill`
+- `This Plugin`
+- `The stack`
+- `The visual below`
+
+Named things reduce vagueness and make the post inspectable
+
+### 3. Mechanism
+
+Explain what happens using plain verbs
+
+Prefer
+
+`A hook grabs Claude's reply after it finishes`
+
+Over
+
+`It improves communication with AI`
+
+Prefer
+
+`Searches recent activity across Reddit, X, YouTube, Hacker News, GitHub and prediction markets`
+
+Over
+
+`It gives you better research`
+
+Mechanism is the credibility layer
+
+### 4. Specifics
+
+Use details that can be checked or acted on
+
+- exact commands
+- repo names
+- model names
+- supported inputs
+- output format
+- licenses
+- hardware
+- pricing
+- benchmark scores
+- star counts
+- steps
+- concrete use cases
+
+Specificity must serve the decision, not decorate the copy
+
+### 5. Why it matters
+
+Translate the mechanism into one or two practical consequences
+
+Examples
+
+- `If Ollama is down, Claude still works normally`
+- `The useful answer can be extracted without decoding four paragraphs first`
+- `You stop reopening the same context every session`
+
+### 6. Visual bridge
+
+When a GIF or infographic is attached, use one short bridge at most
+
+Examples
+
+- `The GIF below is how I think about the handoff`
+- `The visual shows where each specialist enters`
+- `The animation makes the sequence easier to see`
+- `The page inside the GIF is an example, not a client result`
+
+Do not narrate every frame
+
+### 7. Action
+
+Choose one practical next action
+
+- open the repo
+- install the Skill
+- try one Plugin
+- save the setup
+- inspect the first comment
+- answer one practical question
+
+Avoid vague asks such as `Thoughts?`
+
+## Caption archetypes
+
+Choose one primary archetype and stay in it
+
+### A. Repo Explainer
+
+Use when one repo, tool, Skill, model, or Plugin is the subject
+
+Shape
+
+```text
+{specific friction}
+
+{one-line solution}
+
+Meet {name}
+
+{verified free/open-source/local/license line when relevant}
+
+Here's what it does:
+
+{mechanism}
+↳ {practical consequence}
+
+{mechanism}
+↳ {practical consequence}
+
+Why it matters:
+
+{one concrete consequence}
+
+{link location}
+
+P.S. {easy practical question}
+```
+
+### B. Stack Catalogue
+
+Use when the value comes from a collection
+
+Shape
+
+```text
+{how the collection became necessary}
+
+{count + collection + what unifies it}
+
+{CATEGORY}, {what the category controls}
+
+✦ {item}
+✦ {item}
+✦ {item}
+
+{one-line category payoff}
+
+{next category}
+
+{compounding line}
+
+{link location}
+
+P.S. {which one would you use first}
+```
+
+Critical rule
+
+The collection needs an organizing model
+
+A raw list is not a catalogue story
+
+### C. Operating Story
+
+Use when the interesting part is how work moves
+
+Shape
+
+```text
+{repeated workflow problem}
+
+{what changed in the way the work is handled}
+
+{specialist 1}
+↳ {job}
+
+{specialist 2}
+↳ {job}
+
+{specialist 3}
+↳ {job}
+
+The interesting part is the handoff
+
+{how the work moves between them}
+
+{visual bridge}
+
+{first comment}
+
+{question}
+```
+
+Good for Plugin stacks, agent workflows, multi-step research, and production pipelines
+
+### D. Belief Correction
+
+Use when a familiar metric or assumption is incomplete
+
+Shape
+
+```text
+{strong belief correction}
+
+{why the normal interpretation is incomplete}
+
+That usually comes down to {N} things
+
+1. {factor}
+↳ {specific behavior}
+
+2. {factor}
+↳ {specific behavior}
+
+3. {factor}
+↳ {specific behavior}
+
+{diagnostic question}
+
+{visual disclaimer when needed}
+
+{reader question}
+```
+
+### E. Recent-Signal Story
+
+Use when freshness is the problem
+
+Shape
+
+```text
+{what goes stale}
+
+{how quickly the category changes}
+
+{named sources and what each contributes}
+
+The interesting part is {comparison or synthesis}
+
+↳ collect
+↳ compare
+↳ filter
+↳ synthesize
+
+{practical use cases}
+
+{visual bridge}
+
+{question about manual source checking}
+```
+
+### F. Visual Companion
+
+Use when the visual already carries much of the narrative
+
+Shape
+
+```text
+{one-line tension}
+
+{one-line frame for the visual}
+
+{2 to 5 points the viewer should notice}
+
+{what the animation makes easier to understand}
+
+{link or source location}
+
+{one question}
+```
+
+Keep this shorter than the visual's information density would suggest
+
+## Hook procedure
+
+Before drafting the body, generate 8 to 12 hook candidates silently
+
+Use at least three different hook mechanisms
+
+- friction
+- belief correction
+- concrete curiosity
+- catalogue scale
+- direct utility
+- operating problem
+
+Reject hooks that
+
+- could introduce almost any AI product
+- depend on hype adjectives
+- need the next line to explain what the first line meant
+- create suspense around a trivial fact
+- promise an unsupported result
+- sound written to impress rather than clarify
+
+Keep line 1 compact enough to survive mobile truncation when the language allows it
+
+Roughly 55 characters is a useful default, not a hard law
+
+## Scan rhythm
+
+- keep most paragraphs to one or two short lines
+- allow uneven paragraph lengths
+- put one main idea in each block
+- use whitespace deliberately
+- do not turn every sentence into a standalone paragraph when it damages flow
+- use section labels only when they make a dense technical post easier to scan
+- use `↳` for mechanism, clarification, consequence, or sub-step
+- do not use `↳` as decoration
+- keep emoji sparse and structural when the writer uses them
+
+## First comment
+
+The first comment has a separate job
+
+It carries utility without slowing the main caption
+
+Use it for
+
+- repo or Plugin links
+- installation commands
+- setup steps
+- source references
+- long resource catalogues
+- exact paths or technical instructions
+
+### Link index pattern
+
+```text
+All links from the visual 👇
+
+1. {Name}
+{one-line job}
+{URL}
+
+2. {Name}
+{one-line job}
+{URL}
+
+Start with the one closest to a task you already repeat
+```
+
+### Install guide pattern
+
+```text
+Setup:
+
+Step 1
+↳ {command}
+
+Step 2
+↳ {command}
+
+Step 3
+↳ {command}
+
+Repo:
+{URL}
+```
+
+### Source note pattern
+
+```text
+Sources / references:
+
+↳ {source}
+↳ {source}
+↳ {source}
+
+The visual simplifies the idea, so use the sources above for the full context
+```
+
+First-comment rules
+
+- do not repeat the whole caption
+- do not add a second sales pitch
+- do not hide a material limitation in the comment
+- preserve exact URLs
+- keep names in the same order as the visual when order matters
+- if two links use the same display name, distinguish the variants when known
+
+## Visual companion contract
+
+Caption and visual should divide the communication job
+
+Caption owns
+
+- reason to care
+- tension
+- interpretation
+- mechanism that is not obvious visually
+- practical consequence
+- CTA
+
+Visual owns
+
+- sequence
+- topology
+- handoff
+- comparison
+- hierarchy
+- before and after
+- category grouping
+- spatial relationships
+
+Ask two questions before finalizing
+
+1. If the GIF disappears, what useful information is missing from the caption
+2. If the caption disappears, what useful information is missing from the GIF
+
+Both answers should contain something important
+
+If the caption merely narrates the animation, compress it
+
+A visual can illustrate a process without proving it
+
+Use `shows`, `maps`, `illustrates`, or `explains`
+
+Do not imply case-study evidence unless the supplied evidence supports it
+
+## Voice and anti-slop rules
+
+- plain English over polished corporate prose
+- specific nouns over adjectives
+- mechanism before praise
+- useful roughness over suspiciously perfect symmetry
+- preserve normal technical vocabulary
+- no fake urgency
+- no invented anecdotes
+- no invented proof
+- no generic motivational conclusion
+- no repeated recap
+- no empty superlatives
+- no em dash
+- avoid repeated `not X, but Y` constructions
+- avoid generic transition phrases
+- avoid engagement bait disguised as a question
+
+House style outranks this Skill
+
+If the user bans terminal periods, remove terminal periods from visible copy while preserving dots required inside URLs, version numbers, decimals, commands, filenames, domains, and other technical literals
+
+If the user supplies a voice sample, derive cadence and vocabulary from that sample instead of copying example phrasing from this Skill
+
+## Procedure
+
+1. Resolve the inputs and evidence boundary
+2. Read `references/reference-examples.md` when the user asks to match the supplied style family or when pattern choice is uncertain
+3. Pick one archetype
+4. Generate and filter hook candidates
+5. Draft the narrative around one primary idea
+6. Name the real artifact early
+7. Explain mechanism before praise
+8. Add only supported specifics
+9. Divide the communication job between caption and visual
+10. Move link-heavy utility into the first comment when useful
+11. Apply the user's house style as hard constraints
+12. Read `references/quality-gates.md`
+13. Revise until every hard gate passes
+14. Return only the requested caption and first comment unless critique is requested
+
+## HOLD conditions
+
+Return a HOLD only when the requested output depends on a claim that cannot be supported without inventing or materially changing the user's approved premise
+
+Examples
+
+- unsupported benchmark or result must remain in the hook
+- exact product behavior is unknown and cannot be safely generalized
+- a visual is described as a client result but the evidence says it is only an example
+- a link or product identity cannot be resolved and exactness is required
+
+Otherwise remove unsupported precision and continue
+
+## Related components
+
+Inside the source repository, this Skill complements the canonical `caption` Skill and its broader caption archetype reference
+
+When the host provides the repository tools, run the existing copy-slop checker where appropriate
+
+```bash
+python3 tools/copy_slop_check.py --file <caption.txt>
+```
+
+This checker is supplemental
+
+The final narrative judgment, evidence boundary, first-comment split, and visual-caption division remain the responsibility of this Skill
+
+## Research gates
+
+Apply these conceptual gates to every visible draft
+
+- **prose-specificity**: prefer checkable names and mechanisms over generic language
+- **voice-preservation**: preserve the writer's natural vocabulary and useful cadence
+- **evidence-traceability**: every factual precision must come from supplied or verified evidence
+- **visual-alignment**: caption and visual must not contradict each other
+- **house-style-compliance**: explicit user rules are hard constraints

--- a/openai-skills/linkedin-caption-narrative/agents/openai.yaml
+++ b/openai-skills/linkedin-caption-narrative/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LinkedIn Caption Narrative"
+  short_description: "Write high-signal LinkedIn captions"
+  default_prompt: "Turn the supplied topic, proof, links, and visual into a high-signal LinkedIn caption with a matching first comment when useful, following the Skill's mechanism-first narrative, evidence rules, visual alignment, and house-style constraints"

--- a/openai-skills/linkedin-caption-narrative/references/quality-gates.md
+++ b/openai-skills/linkedin-caption-narrative/references/quality-gates.md
@@ -1,0 +1,104 @@
+# Quality Gates
+
+Run these before returning a caption
+
+## Gate 1: Mobile hook
+
+PASS when line 1
+
+- is understandable alone
+- contains a real tension, claim, object, or behavior
+- earns attention without fake suspense
+- is compact enough to survive mobile truncation when practical
+
+FAIL when it begins with generic context or requires line 2 to explain what line 1 means
+
+## Gate 2: Named specificity
+
+PASS when the caption uses real names, mechanisms, categories, commands, metrics, or use cases where available
+
+FAIL when generic nouns such as `tool`, `solution`, `platform`, or `workflow` replace the real thing without a reason
+
+## Gate 3: Mechanism
+
+PASS when the reader can explain what happens
+
+FAIL when the caption only explains how to feel about the product
+
+## Gate 4: Evidence
+
+PASS when every number, benchmark, star count, price, license, compatibility claim, and performance claim is supplied or verified
+
+FAIL when precision was invented to make the post stronger
+
+## Gate 5: Narrative movement
+
+PASS when every section advances the idea
+
+FAIL when the body repeatedly restates the opening tension
+
+## Gate 6: Visual alignment
+
+PASS when caption and visual have distinct communication jobs
+
+FAIL when the caption narrates every frame or describes something that is not present
+
+## Gate 7: First comment
+
+PASS when link-heavy or setup-heavy detail is separated when separation improves readability
+
+FAIL when the first comment merely repeats the post
+
+## Gate 8: Anti-slop
+
+Hard fail on
+
+- generic motivational close
+- fake urgency
+- empty superlatives
+- repeated `not X, but Y` constructions
+- mechanical paragraph symmetry
+- performative phrases such as `here's the game changer`
+- dramatic punctuation with no information
+- generic CTA such as `Thoughts?`
+- em dash when the active house style forbids it or when a simpler punctuation choice works
+
+## Gate 9: Sayability
+
+Read the caption aloud mentally
+
+If a sentence sounds like it belongs in a brand deck instead of something the writer would actually say, rewrite it
+
+## Gate 10: House style
+
+User-specific rules outrank this Skill
+
+Examples
+
+- banned punctuation
+- banned vocabulary
+- required dialect
+- no terminal periods
+- no em dash
+- specific capitalization
+- preferred code-switching
+
+Treat explicit house-style instructions as hard constraints
+
+## Gate 11: URL integrity
+
+PASS when every supplied URL is preserved exactly unless the user asks to shorten or replace it
+
+FAIL when a link is rewritten, reordered incorrectly, duplicated accidentally, or attached to the wrong item
+
+## Gate 12: Visual claim safety
+
+PASS when the visual is described as an illustration, map, sequence, or example when that is what it is
+
+FAIL when an example visual is described as a client result, benchmark proof, or real product state without evidence
+
+## Release threshold
+
+A caption is ready only when all hard gates pass
+
+Do not ship a draft with a known house-style violation, unsupported claim, wrong URL, wrong product name, or visual mismatch

--- a/openai-skills/linkedin-caption-narrative/references/reference-examples.md
+++ b/openai-skills/linkedin-caption-narrative/references/reference-examples.md
@@ -1,0 +1,117 @@
+# Reference Examples
+
+These examples describe transferable mechanics from the supplied style references
+
+Do not copy their wording mechanically
+
+## claudish-to-english
+
+Observed pattern
+
+- opens on one precise weakness: Claude explanations can feel academic
+- names the repo immediately
+- gives a compact access strip: free, open-source, local
+- explains the mechanism in sequence
+- includes exact install commands
+- shows two operating modes
+- closes with privacy and failure behavior
+
+Transferable lesson
+
+**A technical repo becomes readable when the caption explains the background process in plain verbs**
+
+## 100+ Claude repos catalogue
+
+Observed pattern
+
+- opens with collection scale
+- groups resources by job instead of ranking everything
+- category labels such as HARNESS, SKILLS, MEMORY, TOOLS, and COST create a mental map
+- each category ends with one consequence line
+- named repos do most of the credibility work
+
+Transferable lesson
+
+**Large lists need an organizing model and category-level consequences**
+
+## olmOCR
+
+Observed pattern
+
+- opens with a specific category failure
+- names the inputs the tool handles
+- uses capability then consequence pairs
+- includes benchmark, cost, hardware, and license details
+- lets operational facts carry the persuasion
+
+Transferable lesson
+
+**For technical tools, constraints and operating details often do more work than adjectives**
+
+## i-have-adhd
+
+Observed pattern
+
+- hook is behavioral rather than architectural
+- product behavior is shown as a compact checklist
+- every rule maps to a recognizable usage consequence
+- architecture is intentionally secondary
+
+Transferable lesson
+
+**When a product changes behavior rather than infrastructure, show the behavior directly**
+
+## /last30days
+
+Observed pattern
+
+- starts from research staleness
+- names multiple sources and gives each source a distinct signal role
+- reframes the value from searching more to comparing signals
+- shows the process as a short chain
+- ends with practical pre-work use cases
+- bridges directly into the visual
+
+Transferable lesson
+
+**For multi-source research, synthesis is the story, not source count**
+
+## GEO and AEO page example
+
+Observed pattern
+
+- belief correction appears in the first line
+- the broad concept becomes three practical criteria
+- the post contains a diagnostic question the reader can run immediately
+- the visual is explicitly labeled as an example instead of a client result
+
+Transferable lesson
+
+**A strong educational caption converts a broad idea into a concrete check**
+
+## Shared mechanics across the reference set
+
+1. short opening tension
+2. named artifact or claim early
+3. one main idea per paragraph
+4. mechanism before praise
+5. specifics as credibility
+6. `↳` for consequence or explanation
+7. category labels when a list is long
+8. practical why-it-matters line
+9. one visual bridge when applicable
+10. first comment for links or setup
+11. one answerable closing question
+
+## What not to imitate
+
+Do not copy
+
+- exact hook wording
+- exact category names when the new material needs a different taxonomy
+- decorative bolding everywhere
+- link placement that hurts the new caption's readability
+- unsupported numbers or star counts
+- a CTA just because the reference used one
+
+Transfer the communication logic, not the surface pattern

--- a/skills/caption/SKILL.md
+++ b/skills/caption/SKILL.md
@@ -11,6 +11,8 @@ Write or evaluate the post caption and opening hook without weakening evidence o
 
 Read `helper/GUIDE.md` first. For Info-stories, also read `skills/info-stories/references/hook-driven-design-copy.md`.
 
+For repo explainers, Plugin or Skill stacks, technical tools, curated catalogues, belief-correction posts, recent-signal stories, GIF captions, animated infographic companions, or link-heavy first comments, also read `references/linkedin-caption-narrative.md` before drafting.
+
 ## Use when
 
 Use for a new caption, hook, opening line, CTA, first comment, caption rewrite, or caption QA. Use the `caption-writer` worker inside the full parent workflow.
@@ -30,15 +32,17 @@ Return finished caption copy, first-comment copy when applicable, selected capti
 ## Procedure
 
 1. Read `references/caption-patterns.md` and the active helper gates.
-2. Pick one caption archetype and stay in it: Numbered Inventory, Result Case Study, Bundle Manifest, Setup Walkthrough, Operating Story, Belief Correction, or Catalogue Tease.
-3. Apply `hooked-design-copy` to line 1. Use specificity, supported tension, concrete outcome, recognizable problem, useful surprise, or strong framing. A portable generic opening fails.
-4. Keep line 1 compact enough to survive the mobile truncation cut; under roughly 55 characters is a strong default when the language allows it.
-5. Keep one idea per line and use deliberate whitespace. Do not let a short-form caption collapse into dense paragraphs.
-6. Use specific names and numbers only when evidence supports them. Unsupported precision is removed, not approximated.
-7. Use one CTA at the end unless the chosen archetype intentionally has none.
-8. Run anti-slop checks. Reject denial-then-reveal constructions, generic puffery, faux insight, repetitive recap, and buzzword substitution. No em dashes.
-9. Preserve useful voice and concrete mechanisms. Do not make every line clever; one strong opening and a clear progression are enough.
-10. For Arabic/bilingual output, use the `arabic` skill before finalizing rhythm, bidi, and truncation behavior.
+2. When the subject is a repo, Plugin, Skill, workflow, technical tool, curated collection, belief correction, recent-signal research story, GIF, or animated infographic, read `references/linkedin-caption-narrative.md` and let it own the mechanism-first narrative, visual-caption division of labor, and first-comment utility split.
+3. Pick one caption archetype and stay in it: Numbered Inventory, Result Case Study, Bundle Manifest, Setup Walkthrough, Operating Story, Belief Correction, or Catalogue Tease.
+4. Apply `hooked-design-copy` to line 1. Use specificity, supported tension, concrete outcome, recognizable problem, useful surprise, or strong framing. A portable generic opening fails.
+5. Keep line 1 compact enough to survive the mobile truncation cut; under roughly 55 characters is a strong default when the language allows it.
+6. Keep one idea per line and use deliberate whitespace. Do not let a short-form caption collapse into dense paragraphs.
+7. Use specific names and numbers only when evidence supports them. Unsupported precision is removed, not approximated.
+8. Use one CTA at the end unless the chosen archetype intentionally has none.
+9. Run anti-slop checks. Reject denial-then-reveal constructions, generic puffery, faux insight, repetitive recap, and buzzword substitution. No em dashes.
+10. Preserve useful voice and concrete mechanisms. Do not make every line clever; one strong opening and a clear progression are enough.
+11. Apply explicit user house-style rules as hard output constraints. They outrank generic LinkedIn punctuation or formatting conventions.
+12. For Arabic/bilingual output, use the `arabic` skill before finalizing rhythm, bidi, and truncation behavior.
 
 ## HOLD conditions
 
@@ -50,8 +54,10 @@ Return a HOLD when the requested hook, result, price, metric, testimonial, produ
 - local hook gate: `helper/quality-gates.json`
 - design-copy reference: `skills/info-stories/references/hook-driven-design-copy.md`
 - detailed patterns: `references/caption-patterns.md`
+- technical narrative specialist: `references/linkedin-caption-narrative.md`
 - worker: `agents/caption-writer.md`
 - copy compression: `agents/copy-compressor.md`
+- deterministic copy-pattern checker: `tools/copy_slop_check.py`
 
 ## Research gates
 

--- a/skills/caption/references/linkedin-caption-narrative.md
+++ b/skills/caption/references/linkedin-caption-narrative.md
@@ -1,0 +1,283 @@
+# LinkedIn Caption Narrative
+
+Use this reference when the caption is about a repo, Plugin, Skill, workflow, AI tool, technical resource, curated collection, belief correction, recent-signal research story, GIF, or animated infographic
+
+The broader `caption-patterns.md` remains the canonical archetype library
+
+This reference adds a narrower production pattern for technical storytelling and first-comment utility payloads
+
+## Narrative grammar
+
+The dominant pattern is
+
+**Tension → Named Thing → Mechanism → Specifics → Why It Matters → Visual Bridge → Action**
+
+Not every caption needs every stage
+
+Each block must advance the idea instead of repeating the opening
+
+## Hook rules
+
+Open on one concrete tension
+
+Useful tension types
+
+- a specific tool failure
+- a repeated task that became annoying
+- an incomplete assumption
+- a stale research process
+- a metric that hides the real outcome
+- a coordination problem created by too many tools or Skills
+- a technical constraint that blocks a practical result
+
+Strong shapes
+
+- `Most OCR tools choke on messy documents`
+- `Most AI tools talk too much`
+- `Your page can rank first and still never become the answer`
+- `I built so many AI Skills that using them became its own workflow`
+
+Reject a hook when another product name could replace the real one without changing the meaning
+
+Generate several hook candidates silently before selecting line 1
+
+## Name the artifact early
+
+Prefer the real noun
+
+- repo name
+- Plugin name
+- Skill name
+- model name
+- command
+- workflow
+- source category
+
+Generic `tool`, `solution`, or `platform` language should not replace the real name when the real name is available
+
+## Mechanism before praise
+
+Explain what happens using plain verbs
+
+Prefer
+
+`A hook grabs Claude's reply after it finishes`
+
+Over
+
+`It improves communication with AI`
+
+Prefer
+
+`Searches recent activity across Reddit, X, YouTube, Hacker News, GitHub and prediction markets`
+
+Over
+
+`It gives you better research`
+
+## Specificity as credibility
+
+Use checkable details when supplied or verified
+
+- commands
+- repo names
+- model names
+- inputs and outputs
+- license
+- hardware
+- pricing
+- benchmarks
+- stars
+- steps
+- categories
+- concrete use cases
+
+Never invent precision to strengthen a post
+
+## Archetype selection
+
+### Repo Explainer
+
+Use for one repo, tool, Skill, model, or Plugin
+
+Flow
+
+```text
+specific friction
+one-line solution
+named artifact
+mechanism
+↳ consequence
+mechanism
+↳ consequence
+why it matters
+link location
+one practical question
+```
+
+### Stack Catalogue
+
+Use for a large collection
+
+Organize by job rather than dumping a list
+
+Each category gets
+
+- category name
+- what the category controls
+- named items
+- one consequence line
+
+A raw list is not a catalogue story
+
+### Operating Story
+
+Use when the interesting part is the handoff between specialists, Plugins, agents, or stages
+
+Flow
+
+```text
+repeated workflow problem
+what changed
+specialist 1
+↳ job
+specialist 2
+↳ job
+specialist 3
+↳ job
+handoff explanation
+visual bridge
+first-comment links
+question
+```
+
+### Belief Correction
+
+Use when a familiar metric or assumption is incomplete
+
+Turn the correction into a practical diagnostic the reader can run
+
+### Recent-Signal Story
+
+Use when freshness is the problem
+
+Name the source roles, then make synthesis and comparison the story rather than source count
+
+### Visual Companion
+
+Use when the GIF or infographic already carries much of the explanation
+
+Keep the caption shorter and explain why the visual matters instead of narrating each frame
+
+## Scan rhythm
+
+- most paragraphs should be one or two short lines
+- allow uneven paragraph length
+- one main idea per block
+- section labels only when they improve scanning
+- `↳` means mechanism, clarification, consequence, or sub-step
+- do not use `↳` decoratively
+- sparse structural emoji only when it fits the writer
+
+## First comment
+
+Use the first comment for material that would slow the caption
+
+- repo links
+- Plugin links
+- setup commands
+- install steps
+- sources
+- long catalogue entries
+
+Do not repeat the caption
+
+Preserve exact URLs and item order when the visual establishes an order
+
+## Visual division of labor
+
+Caption owns
+
+- why the reader should care
+- interpretation
+- non-obvious mechanism
+- practical consequence
+- CTA
+
+Visual owns
+
+- sequence
+- topology
+- handoff
+- comparison
+- hierarchy
+- category grouping
+- spatial relationships
+
+Use one visual bridge at most
+
+A visual can illustrate a process without proving it
+
+Do not imply case-study evidence when the asset is only an example
+
+## Reference-derived lessons
+
+### claudish-to-english
+
+Technical repo explanation works when the background process is explained in plain verbs
+
+### Claude repo catalogue
+
+Large collections need an organizing model and category-level payoff lines
+
+### olmOCR
+
+Operational facts such as supported inputs, benchmark, cost, hardware, and license can carry more weight than adjectives
+
+### i-have-adhd
+
+When a product changes output behavior, show the behavior directly instead of over-explaining architecture
+
+### /last30days
+
+For multi-source research, synthesis is the story, not source count
+
+### GEO/AEO example
+
+A broad educational idea becomes useful when it becomes a diagnostic check the reader can run immediately
+
+## Anti-slop rules
+
+Reject
+
+- generic motivational closes
+- fake urgency
+- empty superlatives
+- repeated `not X, but Y`
+- mechanical paragraph symmetry
+- generic `Thoughts?` CTA
+- repeated recap
+- dramatic punctuation without information
+- generic AI-product hooks
+- unsupported claims
+
+House style outranks this reference
+
+If the user bans terminal periods, remove terminal periods from visible copy except where dots are required inside URLs, version numbers, decimals, commands, filenames, domains, or other technical literals
+
+If the user bans em dashes, use none
+
+## Quality check
+
+Before shipping, verify
+
+1. mobile hook is concrete
+2. real nouns appear early
+3. mechanism is understandable
+4. every precise claim is supported
+5. each section advances the narrative
+6. visual and caption have distinct jobs
+7. first comment carries utility instead of repetition
+8. the draft sounds sayable
+9. all active house-style rules pass
+10. every URL and product name is exact

--- a/tests/test_caption_narrative_skill.py
+++ b/tests/test_caption_narrative_skill.py
@@ -1,0 +1,69 @@
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OPENAI_SKILL = ROOT / "openai-skills" / "linkedin-caption-narrative"
+CANONICAL_CAPTION = ROOT / "skills" / "caption" / "SKILL.md"
+CANONICAL_REFERENCE = ROOT / "skills" / "caption" / "references" / "linkedin-caption-narrative.md"
+
+
+class CaptionNarrativeSkillTests(unittest.TestCase):
+    def test_openai_skill_package_exists(self):
+        required = (
+            OPENAI_SKILL / "SKILL.md",
+            OPENAI_SKILL / "agents" / "openai.yaml",
+            OPENAI_SKILL / "references" / "reference-examples.md",
+            OPENAI_SKILL / "references" / "quality-gates.md",
+        )
+        missing = [str(path.relative_to(ROOT)) for path in required if not path.is_file()]
+        self.assertEqual([], missing)
+
+    def test_openai_skill_has_discovery_frontmatter(self):
+        text = (OPENAI_SKILL / "SKILL.md").read_text(encoding="utf-8")
+        self.assertTrue(text.startswith("---\n"))
+        frontmatter = text.split("---", 2)[1]
+        self.assertIn("name: linkedin-caption-narrative", frontmatter)
+        self.assertIn("description: Use when", frontmatter)
+
+    def test_openai_default_prompt_is_a_string(self):
+        text = (OPENAI_SKILL / "agents" / "openai.yaml").read_text(encoding="utf-8")
+        self.assertRegex(text, r'(?m)^\s*default_prompt:\s*".+"\s*$')
+        self.assertNotRegex(text, r'(?m)^\s*default_prompt:\s*$')
+
+    def test_canonical_caption_routes_matching_work_to_narrative_reference(self):
+        caption = CANONICAL_CAPTION.read_text(encoding="utf-8")
+        self.assertIn("references/linkedin-caption-narrative.md", caption)
+        self.assertIn("Plugin or Skill stacks", caption)
+        self.assertIn("first-comment utility split", caption)
+
+    def test_reference_preserves_pattern_and_house_style_contract(self):
+        text = CANONICAL_REFERENCE.read_text(encoding="utf-8")
+        for marker in (
+            "Tension → Named Thing → Mechanism → Specifics → Why It Matters → Visual Bridge → Action",
+            "Repo Explainer",
+            "Stack Catalogue",
+            "Operating Story",
+            "Belief Correction",
+            "Recent-Signal Story",
+            "Visual Companion",
+            "House style outranks this reference",
+            "If the user bans terminal periods",
+        ):
+            self.assertIn(marker, text)
+
+    def test_reference_examples_cover_supplied_style_family(self):
+        text = (OPENAI_SKILL / "references" / "reference-examples.md").read_text(encoding="utf-8")
+        for marker in (
+            "claudish-to-english",
+            "100+ Claude repos catalogue",
+            "olmOCR",
+            "i-have-adhd",
+            "/last30days",
+            "GEO and AEO page example",
+        ):
+            self.assertIn(marker, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a standalone OpenAI/Codex skill for mechanism-first LinkedIn captions, plus canonical caption routing for repo/tool/plugin/GIF/catalogue stories

Includes

- `openai-skills/linkedin-caption-narrative/SKILL.md`
- OpenAI interface metadata with string `default_prompt`
- reference-derived examples and quality gates
- canonical `skills/caption` narrative reference and routing
- tests for packaging, discovery metadata, house-style precedence, and reference coverage

The new skill preserves the existing broader caption archetypes while specializing technical storytelling, visual-caption division of labor, and first-comment utility payloads