### PR TITLE
release: verify integrated 3.7.0 public package

### DIFF
--- a/docs/releases/3.7.0.md
+++ b/docs/releases/3.7.0.md
@@ -5,6 +5,7 @@ Codex/ChatGPT release candidate for the strengthened LinkedIn Animated Infograph
 ## Release highlights
 
 - canonical public install layout with `.codex-plugin/plugin.json` and immediate `skills/<skill>/SKILL.md` children
+- nine packaged Skills on the integrated mainline, including `linkedin-caption-narrative` for mechanism-first LinkedIn captions and first-comment utility
 - first-class narrative taste before layout, with Reader questions, beat-to-visual mapping, story turns, payoff logic, and rejection of list-to-card storytelling
 - bounded repository demo inspiration through abstract mechanism transfer instead of source imitation
 - blocking perception preflight before still construction
@@ -37,6 +38,18 @@ SUPPORT.md
 ```
 
 The packaged manifest is rewritten deterministically to `"skills": "./skills/"`. Every immediate packaged Skill directory must contain `SKILL.md`; loose files directly under `skills/` fail packaging. Only `plugin.json` may exist inside `.codex-plugin/`.
+
+The integrated mainline package includes these public Skill entrypoints:
+
+- `masterone`
+- `linkedin-infographic-autopilot`
+- `linkedin-infographic-studio`
+- `linkedin-infographic-review`
+- `exact-svg-mascot`
+- `share-community-demo`
+- `linkedin-caption-narrative`
+- `host-workspace-operator`
+- `sandbox-python-executor`
 
 The package also enforces Plugin Directory-facing metadata limits for display name, short description, and starter-prompt length before bytes are written.
 

--- a/tests/test_public_plugin_installability.py
+++ b/tests/test_public_plugin_installability.py
@@ -40,13 +40,17 @@ class PublicPluginInstallabilityTests(unittest.TestCase):
         for slug in skill_dirs:
             self.assertIn(f"skills/{slug}/SKILL.md", names)
 
-    def test_workspace_and_python_baseline_skills_are_packaged(self):
+    def test_workspace_python_and_mainline_caption_skills_are_packaged(self):
         output, _ = self.build_archive()
         with zipfile.ZipFile(output) as archive:
             names = set(archive.namelist())
 
         self.assertIn("skills/host-workspace-operator/SKILL.md", names)
         self.assertIn("skills/sandbox-python-executor/SKILL.md", names)
+        self.assertIn("skills/linkedin-caption-narrative/SKILL.md", names)
+        self.assertIn("skills/linkedin-caption-narrative/agents/openai.yaml", names)
+        self.assertIn("skills/linkedin-caption-narrative/references/quality-gates.md", names)
+        self.assertIn("skills/linkedin-caption-narrative/references/reference-examples.md", names)
 
     def test_public_brand_pack_is_complete_and_declared_icon_is_present(self):
         output, _ = self.build_archive()


### PR DESCRIPTION
## Purpose
Verify the already-merged 3.7.0 release against current `main`, including the independently added `linkedin-caption-narrative` Skill that landed while PR #42 was open.

## Changes
- lock `linkedin-caption-narrative` and its packaged support files into the public installability contract
- document the integrated nine-Skill public package

## Why this follow-up exists
PR #42 was fully green on its exact head, but `main` advanced during the PR lifetime. The only independent `openai-skills/` addition was `linkedin-caption-narrative`; demos/images and canonical caption files are outside the public release allowlist. This PR forces the complete release CI to run on current-main content so the final artifact can be inspected rather than inferred.

## Merge gate
Require Plugin Validation, Security Gates, Plugin Scanner, Codex Release Package, deterministic ZIP identity, and archive-boundary checks to pass on one exact head before merge.