### PR TITLE
qa: block hidden required content on the final exported frame

### DIFF
--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -115,6 +115,27 @@ AUDIT_FINAL = """
     if (rect.width <= 0.5 || rect.height <= 0.5) reasons.push('zero-area');
     if (!intersectsRoot) reasons.push('outside-export-root');
 
+    let ancestor = target.parentElement;
+    while (ancestor && ancestor !== root.parentElement) {
+      const ancestorStyle = getComputedStyle(ancestor);
+      const ancestorOpacity = Number.parseFloat(ancestorStyle.opacity);
+      if (ancestorStyle.display === 'none') {
+        reasons.push('ancestor-display-none');
+        break;
+      }
+      if (ancestorStyle.visibility === 'hidden' || ancestorStyle.visibility === 'collapse') {
+        reasons.push(`ancestor-visibility-${ancestorStyle.visibility}`);
+        break;
+      }
+      if (Number.isFinite(ancestorOpacity) && ancestorOpacity <= 0.01) {
+        reasons.push('ancestor-opacity-zero');
+        break;
+      }
+      if (ancestor === root) break;
+      ancestor = ancestor.parentElement;
+    }
+
+    const uniqueReasons = [...new Set(reasons)];
     const row = {
       element: describeTarget(target),
       opacity: Number.isFinite(opacity) ? Math.round(opacity * 1000) / 1000 : null,
@@ -126,11 +147,11 @@ AUDIT_FINAL = """
         width: Math.round(rect.width * 1000) / 1000,
         height: Math.round(rect.height * 1000) / 1000,
       },
-      reasons,
+      reasons: uniqueReasons,
     };
     requiredVisible.push(row);
 
-    if (reasons.length) {
+    if (uniqueReasons.length) {
       violations.push({
         ...row,
         reason: 'required-final-element-hidden',

--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail when finite browser animations are still in progress on the last exported frame."""
+"""Fail when exported final-frame motion or required final-state visibility is incomplete."""
 
 from __future__ import annotations
 
@@ -47,6 +47,7 @@ AUDIT_FINAL = """
 ({finalSampleMs, selector}) => {
   const violations = [];
   const finite = [];
+  const requiredVisible = [];
   const requestedRoot = document.querySelector(selector);
   const root = requestedRoot || document.documentElement;
   const selectorFound = Boolean(requestedRoot);
@@ -93,7 +94,51 @@ AUDIT_FINAL = """
     }
   });
 
-  return {finite, violations, selectorFound};
+  const visibilityTargets = [];
+  if (root instanceof Element && root.hasAttribute('data-final-visible')) visibilityTargets.push(root);
+  root.querySelectorAll('[data-final-visible]').forEach(node => visibilityTargets.push(node));
+  const rootRect = root.getBoundingClientRect();
+
+  visibilityTargets.forEach(target => {
+    const style = getComputedStyle(target);
+    const rect = target.getBoundingClientRect();
+    const opacity = Number.parseFloat(style.opacity);
+    const reasons = [];
+    const intersectsRoot = rect.right > rootRect.left + 0.5
+      && rect.left < rootRect.right - 0.5
+      && rect.bottom > rootRect.top + 0.5
+      && rect.top < rootRect.bottom - 0.5;
+
+    if (style.display === 'none') reasons.push('display-none');
+    if (style.visibility === 'hidden' || style.visibility === 'collapse') reasons.push(`visibility-${style.visibility}`);
+    if (Number.isFinite(opacity) && opacity <= 0.01) reasons.push('opacity-zero');
+    if (rect.width <= 0.5 || rect.height <= 0.5) reasons.push('zero-area');
+    if (!intersectsRoot) reasons.push('outside-export-root');
+
+    const row = {
+      element: describeTarget(target),
+      opacity: Number.isFinite(opacity) ? Math.round(opacity * 1000) / 1000 : null,
+      display: style.display,
+      visibility: style.visibility,
+      rect: {
+        x: Math.round(rect.x * 1000) / 1000,
+        y: Math.round(rect.y * 1000) / 1000,
+        width: Math.round(rect.width * 1000) / 1000,
+        height: Math.round(rect.height * 1000) / 1000,
+      },
+      reasons,
+    };
+    requiredVisible.push(row);
+
+    if (reasons.length) {
+      violations.push({
+        ...row,
+        reason: 'required-final-element-hidden',
+      });
+    }
+  });
+
+  return {finite, requiredVisible, violations, selectorFound};
 }
 """
 
@@ -187,21 +232,29 @@ def main(argv=None) -> int:
         "frames": frames,
         "final_sample_ms": round(final_sample_ms, 3),
         "finite_animations": measured["finite"],
+        "required_visible_elements": measured["requiredVisible"],
         "violations": violations,
         "verdict": "FAIL" if violations else "PASS",
     }
     write_report(report_path, report)
 
     if violations:
-        print(f"final-frame audit: FAIL ({len(violations)} unfinished finite animation(s))")
+        print(f"final-frame audit: FAIL ({len(violations)} final-state violation(s))")
         for row in violations[:8]:
-            print(
-                f"  {row['element']} {row['animation']}: "
-                f"{row['remaining_ms']:.1f}ms remains after last exported frame"
-            )
+            if row["reason"] == "finite-animation-incomplete":
+                print(
+                    f"  {row['element']} {row['animation']}: "
+                    f"{row['remaining_ms']:.1f}ms remains after last exported frame"
+                )
+            else:
+                print(f"  {row['element']}: hidden final state ({', '.join(row.get('reasons', []))})")
         return 1
 
-    print(f"final-frame audit: PASS ({len(measured['finite'])} finite animation(s) complete)")
+    print(
+        "final-frame audit: PASS "
+        f"({len(measured['finite'])} finite animation(s) complete, "
+        f"{len(measured['requiredVisible'])} required final element(s) visible)"
+    )
     return 0
 
 

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -109,12 +109,23 @@ def overflow_finding(fragment: dict) -> dict:
 
 def final_frame_finding(fragment: dict) -> dict:
     violations = fragment["violations"]
-    evidence = [{"element": r.get("element"), "animation": r.get("animation"), "remaining_ms": r.get("remaining_ms"), "reason": r.get("reason")} for r in violations[:8] if isinstance(r, dict)]
+    evidence = [
+        {
+            "element": r.get("element"),
+            "animation": r.get("animation"),
+            "remaining_ms": r.get("remaining_ms"),
+            "reason": r.get("reason"),
+            "reasons": r.get("reasons", []),
+            "rect": r.get("rect"),
+            "opacity": r.get("opacity"),
+        }
+        for r in violations[:8] if isinstance(r, dict)
+    ]
     return {
         "threshold_id": "motion.final_frame_complete", "gate": FINAL_FRAME_KIND, "severity": BLOCKING,
         "status": FAIL if violations else PASS, "measured": len(violations), "threshold": 0,
         "unit": "violations",
-        "detail": f"{len(violations)} finite animation(s) unfinished on the last exported frame" if violations else "all finite animations in the exported subtree complete by the last frame",
+        "detail": f"{len(violations)} final-frame completion or visibility violation(s)" if violations else "final-frame timing and required visibility checks passed",
         "evidence": evidence,
     }
 

--- a/tests/fixtures/final-frame-pass.html
+++ b/tests/fixtures/final-frame-pass.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <html><head><meta charset="utf-8"><style>
 html,body{margin:0}.artboard{width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{font:700 64px Arial;margin:120px;animation:enter 800ms ease-out both}.pulse{width:40px;height:40px;background:#222;margin:120px;animation:pulse 1s ease-in-out infinite}.outside-preview{animation:outside 8s linear both}@keyframes enter{from{opacity:0;transform:translateY(30px)}to{opacity:1;transform:none}}@keyframes pulse{50%{transform:scale(1.1)}}@keyframes outside{from{opacity:0}to{opacity:1}}
-</style></head><body><div id="artboard" class="artboard"><div class="headline">Final state is complete</div><div class="pulse"></div></div><div class="outside-preview">Not exported</div></body></html>
+</style></head><body><div id="artboard" class="artboard"><div class="headline" data-final-visible>Final state is complete</div><div class="pulse"></div></div><div class="outside-preview">Not exported</div></body></html>

--- a/tests/fixtures/final-state-hidden.html
+++ b/tests/fixtures/final-state-hidden.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body{margin:0}.artboard{width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{font:700 64px Arial;margin:120px;animation:leave 800ms ease-out both}.decorative{display:none}@keyframes leave{from{opacity:1;transform:none}to{opacity:0;transform:none}}
+</style></head><body><div class="artboard"><div class="headline" data-final-visible>Required final headline</div><div class="decorative">Intentional hidden decoration</div></div></body></html>

--- a/tests/test_final_frame_audit.py
+++ b/tests/test_final_frame_audit.py
@@ -55,6 +55,10 @@ class FinalFrameAuditTests(unittest.TestCase):
         self.assertEqual(data["final_sample_ms"], 3900.0)
         self.assertEqual(len(data["finite_animations"]), 1)
         self.assertNotIn("outside-preview", json.dumps(data["finite_animations"]))
+        self.assertEqual(len(data["required_visible_elements"]), 1)
+        required = data["required_visible_elements"][0]
+        self.assertEqual(required["reasons"], [])
+        self.assertGreater(required["opacity"], 0.99)
 
     def test_animation_that_only_finishes_at_loop_endpoint_fails(self):
         code, data = run_audit("final-frame-fail.html")
@@ -66,6 +70,19 @@ class FinalFrameAuditTests(unittest.TestCase):
         self.assertIn("headline", violation["element"])
         self.assertAlmostEqual(violation["remaining_ms"], 100.0, places=1)
         self.assertLess(violation["progress"], 1)
+
+    def test_required_final_element_that_finishes_hidden_fails(self):
+        code, data = run_audit("final-state-hidden.html")
+        self.assertEqual(code, 1, data)
+        self.assertEqual(data["verdict"], "FAIL")
+        self.assertEqual(len(data["finite_animations"]), 1)
+        self.assertEqual(len(data["required_visible_elements"]), 1)
+        self.assertEqual(len(data["violations"]), 1)
+        violation = data["violations"][0]
+        self.assertEqual(violation["reason"], "required-final-element-hidden")
+        self.assertIn("opacity-zero", violation["reasons"])
+        self.assertIn("headline", violation["element"])
+        self.assertNotEqual(violation["reason"], "finite-animation-incomplete")
 
     def test_missing_selector_falls_back_to_document_like_frame_capture(self):
         code, data = run_audit("final-frame-fail.html", ".missing-export-root")

--- a/tests/test_render_report.py
+++ b/tests/test_render_report.py
@@ -92,6 +92,25 @@ class RenderReportMergeTests(unittest.TestCase):
         finding = next(r for r in report["findings"] if r["gate"] == "final-frame")
         self.assertEqual(finding["severity"], "blocking"); self.assertEqual(finding["evidence"][0]["remaining_ms"], 100.0)
 
+    def test_hidden_required_final_state_is_preserved_as_blocking_evidence(self):
+        violation = {
+            "element": "div.headline",
+            "reason": "required-final-element-hidden",
+            "reasons": ["opacity-zero"],
+            "opacity": 0.0,
+            "rect": {"x": 120, "y": 120, "width": 500, "height": 80},
+        }
+        self.final_frame.write_text(json.dumps(bind_fragment(sidecar_fragment("final-frame", [violation]), self.html)))
+        outcome = self.run_merge(); self.assertEqual(outcome.returncode, 1, outcome.stderr)
+        report = json.loads(self.report.read_text()); self.assertEqual(report["verdict"], "FAIL")
+        finding = next(r for r in report["findings"] if r["gate"] == "final-frame")
+        self.assertIn("completion or visibility", finding["detail"])
+        evidence = finding["evidence"][0]
+        self.assertEqual(evidence["reason"], "required-final-element-hidden")
+        self.assertEqual(evidence["reasons"], ["opacity-zero"])
+        self.assertEqual(evidence["opacity"], 0.0)
+        self.assertEqual(evidence["rect"]["width"], 500)
+
     def test_sidecar_verdict_must_match_violations(self):
         fragment = bind_fragment(sidecar_fragment("final-frame"), self.html); fragment["verdict"] = "FAIL"
         self.final_frame.write_text(json.dumps(fragment)); outcome = self.run_merge()


### PR DESCRIPTION
Adds an explicit final-state visibility contract on top of the existing final-frame timing gate.

What changes:
- Elements marked `data-final-visible` must remain visibly present on the last sampled export frame.
- The browser audit catches hidden display/visibility, near-zero opacity, zero-area geometry, content fully outside the exported root, and hidden ancestors.
- Unmarked decorative elements remain outside this gate, so intentional exits do not become false failures.
- Final-state visibility evidence is preserved in the canonical render report.
- Browser regressions cover both a visible final state and a finite animation that completes on time but leaves required content hidden.

This stays scoped to final export QA and does not change visual styling or animation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Final-frame validation now confirms required elements remain visible in the exported result.
  * Reports include visibility details such as opacity, display state, geometry, and hiding reasons.
  * Console output identifies hidden required elements and summarizes successful visibility checks.

* **Bug Fixes**
  * Exports now fail when required final-state elements are hidden, preventing incomplete or misleading final renders.
  * Render reports preserve detailed evidence for hidden elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->