### PR TITLE
qa: block clipped required final-frame content

### DIFF
--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -62,6 +62,10 @@ AUDIT_FINAL = """
     return `${tag}${classes}`;
   }
 
+  function rounded(value) {
+    return Math.round(value * 1000) / 1000;
+  }
+
   document.getAnimations().forEach((animation, index) => {
     const effect = animation.effect;
     if (!effect || !effect.getTiming || !effect.getComputedTiming) return;
@@ -108,12 +112,28 @@ AUDIT_FINAL = """
       && rect.left < rootRect.right - 0.5
       && rect.bottom > rootRect.top + 0.5
       && rect.top < rootRect.bottom - 0.5;
+    const fullyInsideRoot = rect.left >= rootRect.left - 0.5
+      && rect.right <= rootRect.right + 0.5
+      && rect.top >= rootRect.top - 0.5
+      && rect.bottom <= rootRect.bottom + 0.5;
+    const intersectionWidth = Math.max(0, Math.min(rect.right, rootRect.right) - Math.max(rect.left, rootRect.left));
+    const intersectionHeight = Math.max(0, Math.min(rect.bottom, rootRect.bottom) - Math.max(rect.top, rootRect.top));
+    const area = Math.max(0, rect.width) * Math.max(0, rect.height);
+    const visibleArea = intersectionWidth * intersectionHeight;
+    const visibleRatio = area > 0 ? visibleArea / area : 0;
+    const clipping = {
+      left_px: rounded(Math.max(0, rootRect.left - rect.left)),
+      right_px: rounded(Math.max(0, rect.right - rootRect.right)),
+      top_px: rounded(Math.max(0, rootRect.top - rect.top)),
+      bottom_px: rounded(Math.max(0, rect.bottom - rootRect.bottom)),
+    };
 
     if (style.display === 'none') reasons.push('display-none');
     if (style.visibility === 'hidden' || style.visibility === 'collapse') reasons.push(`visibility-${style.visibility}`);
     if (Number.isFinite(opacity) && opacity <= 0.01) reasons.push('opacity-zero');
     if (rect.width <= 0.5 || rect.height <= 0.5) reasons.push('zero-area');
     if (!intersectsRoot) reasons.push('outside-export-root');
+    else if (!fullyInsideRoot) reasons.push('clipped-by-export-root');
 
     let ancestor = target.parentElement;
     while (ancestor && ancestor !== root.parentElement) {
@@ -138,15 +158,17 @@ AUDIT_FINAL = """
     const uniqueReasons = [...new Set(reasons)];
     const row = {
       element: describeTarget(target),
-      opacity: Number.isFinite(opacity) ? Math.round(opacity * 1000) / 1000 : null,
+      opacity: Number.isFinite(opacity) ? rounded(opacity) : null,
       display: style.display,
       visibility: style.visibility,
       rect: {
-        x: Math.round(rect.x * 1000) / 1000,
-        y: Math.round(rect.y * 1000) / 1000,
-        width: Math.round(rect.width * 1000) / 1000,
-        height: Math.round(rect.height * 1000) / 1000,
+        x: rounded(rect.x),
+        y: rounded(rect.y),
+        width: rounded(rect.width),
+        height: rounded(rect.height),
       },
+      visible_ratio: rounded(visibleRatio),
+      clipping,
       reasons: uniqueReasons,
     };
     requiredVisible.push(row);
@@ -268,7 +290,7 @@ def main(argv=None) -> int:
                     f"{row['remaining_ms']:.1f}ms remains after last exported frame"
                 )
             else:
-                print(f"  {row['element']}: hidden final state ({', '.join(row.get('reasons', []))})")
+                print(f"  {row['element']}: invalid final state ({', '.join(row.get('reasons', []))})")
         return 1
 
     print(

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -118,6 +118,8 @@ def final_frame_finding(fragment: dict) -> dict:
             "reasons": r.get("reasons", []),
             "rect": r.get("rect"),
             "opacity": r.get("opacity"),
+            "visible_ratio": r.get("visible_ratio"),
+            "clipping": r.get("clipping"),
         }
         for r in violations[:8] if isinstance(r, dict)
     ]

--- a/tests/fixtures/final-state-clipped.html
+++ b/tests/fixtures/final-state-clipped.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body{margin:0}.artboard{position:relative;width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{position:absolute;left:100px;top:1310px;width:700px;height:100px;font:700 64px Arial;line-height:1.1;background:#fff}
+</style></head><body><div class="artboard"><div class="headline" data-final-visible>Required final headline is clipped</div></div></body></html>

--- a/tests/test_final_frame_audit.py
+++ b/tests/test_final_frame_audit.py
@@ -84,6 +84,19 @@ class FinalFrameAuditTests(unittest.TestCase):
         self.assertIn("headline", violation["element"])
         self.assertNotEqual(violation["reason"], "finite-animation-incomplete")
 
+    def test_required_final_element_that_is_partially_clipped_fails(self):
+        code, data = run_audit("final-state-clipped.html")
+        self.assertEqual(code, 1, data)
+        self.assertEqual(data["verdict"], "FAIL")
+        self.assertEqual(len(data["required_visible_elements"]), 1)
+        self.assertEqual(len(data["violations"]), 1)
+        violation = data["violations"][0]
+        self.assertEqual(violation["reason"], "required-final-element-hidden")
+        self.assertIn("clipped-by-export-root", violation["reasons"])
+        self.assertGreater(violation["clipping"]["bottom_px"], 50)
+        self.assertGreater(violation["visible_ratio"], 0)
+        self.assertLess(violation["visible_ratio"], 1)
+
     def test_missing_selector_falls_back_to_document_like_frame_capture(self):
         code, data = run_audit("final-frame-fail.html", ".missing-export-root")
         self.assertEqual(code, 1, data)

--- a/tests/test_final_frame_clipping_report.py
+++ b/tests/test_final_frame_clipping_report.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from scripts.render_report import final_frame_finding
+
+
+class FinalFrameClippingReportTests(unittest.TestCase):
+    def test_clipping_measurements_are_preserved_in_merged_evidence(self):
+        fragment = {
+            "violations": [
+                {
+                    "element": "div.headline",
+                    "reason": "required-final-element-hidden",
+                    "reasons": ["clipped-by-export-root"],
+                    "rect": {"x": 100, "y": 1310, "width": 700, "height": 100},
+                    "visible_ratio": 0.4,
+                    "clipping": {"left_px": 0, "right_px": 0, "top_px": 0, "bottom_px": 60},
+                }
+            ]
+        }
+
+        finding = final_frame_finding(fragment)
+
+        self.assertEqual(finding["status"], "FAIL")
+        evidence = finding["evidence"][0]
+        self.assertEqual(evidence["reasons"], ["clipped-by-export-root"])
+        self.assertEqual(evidence["visible_ratio"], 0.4)
+        self.assertEqual(evidence["clipping"]["bottom_px"], 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objective
Prevent load-bearing final-state elements marked with `data-final-visible` from passing QA when they are only partially inside the exported artboard.

## Evidence
The current final-frame audit only checked whether a required element intersected the export root at all. An element could therefore extend beyond the 1080×1350 artboard and still be considered visible by this gate.

## File-level changes
- `scripts/final_frame_audit.py`: require marked final-state elements to be fully contained by the export root; record per-edge clipping and visible-area ratio.
- `scripts/render_report.py`: preserve clipping measurements in merged blocking evidence.
- `tests/fixtures/final-state-clipped.html`: browser regression fixture with a required headline clipped below the artboard.
- `tests/test_final_frame_audit.py`: assert partial clipping fails with `clipped-by-export-root`.
- `tests/test_final_frame_clipping_report.py`: assert merged report evidence retains clipping diagnostics.

## Architecture / state / API impact
No workflow-order, persistence, schema-version, or public API changes. This tightens the existing `data-final-visible` visual-QA contract and adds optional evidence fields (`visible_ratio`, `clipping`) to final-frame violation rows.

## Validation
Repository diff review: branch is 5 commits ahead of starting `main` SHA `552fbe3dba3d9896ae7a2f4c0dc7286ba94e4437`, 0 behind, limited to 5 QA/test files.

The local container could not clone GitHub because outbound DNS resolution for `github.com` is unavailable, so repository commands and browser rendering could not be executed locally in this session. GitHub Actions is the authoritative full-environment validation for this PR.

## Unavailable checks
- `python3 -m unittest discover -s tests -v`
- repository strict validators from `AGENTS.md`
- Chromium/Playwright browser regression execution
- rendered screenshot/GIF visual inspection

Reason: no runnable repository checkout was available in the container; GitHub connector file access does not provide an executable workspace.

## CI state
Pending at PR creation. Exact-head checks will be inspected before handoff.

## Risks
The containment tolerance is 0.5 CSS px per edge. This is intentionally strict for elements explicitly marked as required final-state content; decorative elements remain unaffected unless marked.

## Independent verification
1. Run `python3 -m unittest tests.test_final_frame_audit tests.test_final_frame_clipping_report -v` with Playwright/Chromium available.
2. Run the full deterministic gate listed in `AGENTS.md`.
3. Render `tests/fixtures/final-state-clipped.html` at 1080×1350 and confirm the headline is visibly cropped at the bottom.
4. Confirm `final-frame.json` reports `clipped-by-export-root`, a non-zero `bottom_px`, and `0 < visible_ratio < 1`.
5. Confirm the merged render report preserves those fields as blocking evidence.

## Commits
- `346ea7f` test(qa): add clipped final-state fixture
- `589f017` test(qa): cover clipped required final state
- `292c038` qa: reject clipped required final content
- `280ca71` qa: preserve final-frame clipping evidence
- `71aec3d` test(qa): retain clipping evidence in final report

## Handoff
Independent review and full browser-environment verification are required before merge. This PR intentionally remains unmerged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Final-state audits now detect elements that are partially clipped by the export boundary.
  * Visibility reports include visible ratios and per-edge clipping measurements.
  * Audit results distinguish fully outside elements from partially clipped elements.
  * Console messages now identify broader invalid final-state conditions.

* **Tests**
  * Added coverage for clipped required elements and their diagnostic report data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->