### PR TITLE
qa: detect occluded required final-frame content

### DIFF
--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -66,6 +66,20 @@ AUDIT_FINAL = """
     return Math.round(value * 1000) / 1000;
   }
 
+  function isPaintVisible(node) {
+    let current = node;
+    while (current instanceof Element) {
+      const style = getComputedStyle(current);
+      const opacity = Number.parseFloat(style.opacity);
+      if (style.display === 'none') return false;
+      if (style.visibility === 'hidden' || style.visibility === 'collapse') return false;
+      if (Number.isFinite(opacity) && opacity <= 0.01) return false;
+      if (current === root) break;
+      current = current.parentElement;
+    }
+    return true;
+  }
+
   function finalHitTest(target, rect, rootRect) {
     const left = Math.max(rect.left, rootRect.left, 0);
     const right = Math.min(rect.right, rootRect.right, window.innerWidth);
@@ -84,23 +98,23 @@ AUDIT_FINAL = """
     ];
     const blockers = new Set();
     let visibleSamples = 0;
-    const previousPointerEvents = target.style.pointerEvents;
-    target.style.pointerEvents = 'auto';
+    const probeStyle = document.createElement('style');
+    probeStyle.textContent = '* { pointer-events: auto !important; }';
+    document.head.appendChild(probeStyle);
     try {
       for (const [fx, fy] of fractions) {
         const x = left + (right - left) * fx;
         const y = top + (bottom - top) * fy;
-        const stack = document.elementsFromPoint(x, y);
+        const stack = document.elementsFromPoint(x, y).filter(isPaintVisible);
         const targetIndex = stack.findIndex(node => node === target || target.contains(node));
         if (targetIndex === 0) {
           visibleSamples += 1;
         } else if (stack.length) {
-          const blocker = targetIndex > 0 ? stack[0] : stack[0];
-          blockers.add(describeTarget(blocker));
+          blockers.add(describeTarget(stack[0]));
         }
       }
     } finally {
-      target.style.pointerEvents = previousPointerEvents;
+      probeStyle.remove();
     }
     return {
       sample_count: fractions.length,

--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -66,6 +66,50 @@ AUDIT_FINAL = """
     return Math.round(value * 1000) / 1000;
   }
 
+  function finalHitTest(target, rect, rootRect) {
+    const left = Math.max(rect.left, rootRect.left, 0);
+    const right = Math.min(rect.right, rootRect.right, window.innerWidth);
+    const top = Math.max(rect.top, rootRect.top, 0);
+    const bottom = Math.min(rect.bottom, rootRect.bottom, window.innerHeight);
+    if (right - left <= 1 || bottom - top <= 1) {
+      return {sample_count: 0, visible_samples: 0, blockers: []};
+    }
+
+    const xs = [0.2, 0.5, 0.8];
+    const ys = [0.2, 0.5, 0.8];
+    const fractions = [
+      [xs[1], ys[1]],
+      [xs[0], ys[0]],
+      [xs[2], ys[0]],
+      [xs[0], ys[2]],
+      [xs[2], ys[2]],
+    ];
+    const blockers = new Set();
+    let visibleSamples = 0;
+    const previousPointerEvents = target.style.pointerEvents;
+    target.style.pointerEvents = 'auto';
+    try {
+      for (const [fx, fy] of fractions) {
+        const x = left + (right - left) * fx;
+        const y = top + (bottom - top) * fy;
+        const stack = document.elementsFromPoint(x, y);
+        const targetIndex = stack.findIndex(node => node === target || target.contains(node));
+        if (targetIndex >= 0) {
+          visibleSamples += 1;
+        } else if (stack.length) {
+          blockers.add(describeTarget(stack[0]));
+        }
+      }
+    } finally {
+      target.style.pointerEvents = previousPointerEvents;
+    }
+    return {
+      sample_count: fractions.length,
+      visible_samples: visibleSamples,
+      blockers: [...blockers].slice(0, 5),
+    };
+  }
+
   document.getAnimations().forEach((animation, index) => {
     const effect = animation.effect;
     if (!effect || !effect.getTiming || !effect.getComputedTiming) return;
@@ -155,6 +199,11 @@ AUDIT_FINAL = """
       ancestor = ancestor.parentElement;
     }
 
+    const hitTest = finalHitTest(target, rect, rootRect);
+    if (reasons.length === 0 && hitTest.sample_count > 0 && hitTest.visible_samples === 0) {
+      reasons.push('occluded');
+    }
+
     const uniqueReasons = [...new Set(reasons)];
     const row = {
       element: describeTarget(target),
@@ -169,6 +218,7 @@ AUDIT_FINAL = """
       },
       visible_ratio: rounded(visibleRatio),
       clipping,
+      hit_test: hitTest,
       reasons: uniqueReasons,
     };
     requiredVisible.push(row);

--- a/scripts/final_frame_audit.py
+++ b/scripts/final_frame_audit.py
@@ -75,14 +75,12 @@ AUDIT_FINAL = """
       return {sample_count: 0, visible_samples: 0, blockers: []};
     }
 
-    const xs = [0.2, 0.5, 0.8];
-    const ys = [0.2, 0.5, 0.8];
     const fractions = [
-      [xs[1], ys[1]],
-      [xs[0], ys[0]],
-      [xs[2], ys[0]],
-      [xs[0], ys[2]],
-      [xs[2], ys[2]],
+      [0.5, 0.5],
+      [0.2, 0.2],
+      [0.8, 0.2],
+      [0.2, 0.8],
+      [0.8, 0.8],
     ];
     const blockers = new Set();
     let visibleSamples = 0;
@@ -94,10 +92,11 @@ AUDIT_FINAL = """
         const y = top + (bottom - top) * fy;
         const stack = document.elementsFromPoint(x, y);
         const targetIndex = stack.findIndex(node => node === target || target.contains(node));
-        if (targetIndex >= 0) {
+        if (targetIndex === 0) {
           visibleSamples += 1;
         } else if (stack.length) {
-          blockers.add(describeTarget(stack[0]));
+          const blocker = targetIndex > 0 ? stack[0] : stack[0];
+          blockers.add(describeTarget(blocker));
         }
       }
     } finally {

--- a/scripts/render_report.py
+++ b/scripts/render_report.py
@@ -120,6 +120,7 @@ def final_frame_finding(fragment: dict) -> dict:
             "opacity": r.get("opacity"),
             "visible_ratio": r.get("visible_ratio"),
             "clipping": r.get("clipping"),
+            "hit_test": r.get("hit_test"),
         }
         for r in violations[:8] if isinstance(r, dict)
     ]

--- a/tests/fixtures/final-state-occluded.html
+++ b/tests/fixtures/final-state-occluded.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <html><head><meta charset="utf-8"><style>
-html,body{margin:0}.artboard{position:relative;width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{position:absolute;left:120px;top:180px;width:760px;font:700 64px Arial;line-height:1.1}.cover{position:absolute;left:80px;top:130px;width:900px;height:220px;background:#faf8f4;z-index:10}
+html,body{margin:0}.artboard{position:relative;width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{position:absolute;left:120px;top:180px;width:760px;font:700 64px Arial;line-height:1.1}.cover{position:absolute;left:80px;top:130px;width:900px;height:220px;background:#faf8f4;z-index:10;pointer-events:none}
 </style></head><body><div id="artboard" class="artboard"><div class="headline" data-final-visible>Important final message</div><div class="cover" aria-hidden="true"></div></div></body></html>

--- a/tests/fixtures/final-state-occluded.html
+++ b/tests/fixtures/final-state-occluded.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body{margin:0}.artboard{position:relative;width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{position:absolute;left:120px;top:180px;width:760px;font:700 64px Arial;line-height:1.1}.cover{position:absolute;left:80px;top:130px;width:900px;height:220px;background:#faf8f4;z-index:10}
+</style></head><body><div id="artboard" class="artboard"><div class="headline" data-final-visible>Important final message</div><div class="cover" aria-hidden="true"></div></div></body></html>

--- a/tests/fixtures/final-state-transparent-overlay.html
+++ b/tests/fixtures/final-state-transparent-overlay.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body{margin:0}.artboard{position:relative;width:1080px;height:1350px;background:#faf8f4;overflow:hidden}.headline{position:absolute;left:120px;top:180px;width:760px;font:700 64px Arial;line-height:1.1}.cover{position:absolute;left:80px;top:130px;width:900px;height:220px;background:#111;z-index:10;opacity:0}
+</style></head><body><div id="artboard" class="artboard"><div class="headline" data-final-visible>Important final message</div><div class="cover" aria-hidden="true"></div></div></body></html>

--- a/tests/test_final_frame_audit.py
+++ b/tests/test_final_frame_audit.py
@@ -98,7 +98,7 @@ class FinalFrameAuditTests(unittest.TestCase):
         self.assertGreater(violation["visible_ratio"], 0)
         self.assertLess(violation["visible_ratio"], 1)
 
-    def test_required_final_element_fully_covered_by_overlay_fails(self):
+    def test_required_final_element_fully_covered_by_noninteractive_overlay_fails(self):
         code, data = run_audit("final-state-occluded.html")
         self.assertEqual(code, 1, data)
         self.assertEqual(data["verdict"], "FAIL")
@@ -110,6 +110,15 @@ class FinalFrameAuditTests(unittest.TestCase):
         self.assertEqual(violation["hit_test"]["visible_samples"], 0)
         self.assertGreaterEqual(violation["hit_test"]["sample_count"], 5)
         self.assertTrue(any("cover" in blocker for blocker in violation["hit_test"]["blockers"]))
+
+    def test_fully_transparent_overlay_does_not_count_as_occlusion(self):
+        code, data = run_audit("final-state-transparent-overlay.html")
+        self.assertEqual(code, 0, data)
+        self.assertEqual(data["verdict"], "PASS")
+        self.assertEqual(data["violations"], [])
+        required = data["required_visible_elements"][0]
+        self.assertNotIn("occluded", required["reasons"])
+        self.assertGreater(required["hit_test"]["visible_samples"], 0)
 
     def test_missing_selector_falls_back_to_document_like_frame_capture(self):
         code, data = run_audit("final-frame-fail.html", ".missing-export-root")

--- a/tests/test_final_frame_audit.py
+++ b/tests/test_final_frame_audit.py
@@ -59,6 +59,7 @@ class FinalFrameAuditTests(unittest.TestCase):
         required = data["required_visible_elements"][0]
         self.assertEqual(required["reasons"], [])
         self.assertGreater(required["opacity"], 0.99)
+        self.assertGreater(required["hit_test"]["visible_samples"], 0)
 
     def test_animation_that_only_finishes_at_loop_endpoint_fails(self):
         code, data = run_audit("final-frame-fail.html")
@@ -96,6 +97,19 @@ class FinalFrameAuditTests(unittest.TestCase):
         self.assertGreater(violation["clipping"]["bottom_px"], 50)
         self.assertGreater(violation["visible_ratio"], 0)
         self.assertLess(violation["visible_ratio"], 1)
+
+    def test_required_final_element_fully_covered_by_overlay_fails(self):
+        code, data = run_audit("final-state-occluded.html")
+        self.assertEqual(code, 1, data)
+        self.assertEqual(data["verdict"], "FAIL")
+        self.assertEqual(len(data["required_visible_elements"]), 1)
+        self.assertEqual(len(data["violations"]), 1)
+        violation = data["violations"][0]
+        self.assertEqual(violation["reason"], "required-final-element-hidden")
+        self.assertIn("occluded", violation["reasons"])
+        self.assertEqual(violation["hit_test"]["visible_samples"], 0)
+        self.assertGreaterEqual(violation["hit_test"]["sample_count"], 5)
+        self.assertTrue(any("cover" in blocker for blocker in violation["hit_test"]["blockers"]))
 
     def test_missing_selector_falls_back_to_document_like_frame_capture(self):
         code, data = run_audit("final-frame-fail.html", ".missing-export-root")

--- a/tests/test_final_frame_occlusion_report.py
+++ b/tests/test_final_frame_occlusion_report.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from scripts.render_report import final_frame_finding
+
+
+class FinalFrameOcclusionReportTests(unittest.TestCase):
+    def test_hit_test_blockers_are_preserved_in_merged_evidence(self):
+        fragment = {
+            "violations": [
+                {
+                    "element": "div.headline",
+                    "reason": "required-final-element-hidden",
+                    "reasons": ["occluded"],
+                    "rect": {"x": 120, "y": 180, "width": 760, "height": 142},
+                    "visible_ratio": 1.0,
+                    "clipping": {"left_px": 0, "right_px": 0, "top_px": 0, "bottom_px": 0},
+                    "hit_test": {
+                        "sample_count": 5,
+                        "visible_samples": 0,
+                        "blockers": ["div.cover"],
+                    },
+                }
+            ]
+        }
+
+        finding = final_frame_finding(fragment)
+
+        self.assertEqual(finding["status"], "FAIL")
+        evidence = finding["evidence"][0]
+        self.assertEqual(evidence["reasons"], ["occluded"])
+        self.assertEqual(evidence["hit_test"]["visible_samples"], 0)
+        self.assertEqual(evidence["hit_test"]["blockers"], ["div.cover"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Initiative
Add browser-backed occlusion detection for elements marked `data-final-visible`

## Failure mode
A required final element can be fully inside the export root, non-clipped, `display`/`visibility` valid, and `opacity: 1`, yet still be completely covered by a higher painted layer. Existing final-frame gates could report PASS in that case

## Implementation
- sample five points within each required final element's visible intersection
- use browser hit-testing to verify the required element or one of its descendants is the top hit
- record blocking elements as evidence
- fail with `occluded` only when all sampled points are blocked and no earlier visibility/clipping failure already explains the state
- add an adversarial overlay fixture and preserve a passing fixture assertion

## Verification target
Plugin Validation browser suite, Security Gates, Plugin Scanner, Qlty, and independent final diff review before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Final-frame audits now verify that required visible elements can be interacted with at multiple points, not just that they are visually laid out.
  * Audit results identify fully occluded elements and report the elements blocking them.

* **Bug Fixes**
  * Prevented falsely passing audits when required content is completely covered by an overlay.

* **Tests**
  * Added coverage for successful hit testing and fully occluded required elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->