### PR TITLE
qa: fail required final content with severe partial occlusion

### DIFF
--- a/helper/visual-contract.json
+++ b/helper/visual-contract.json
@@ -263,6 +263,18 @@
         "skills/artboard/references/design-systems.md": ["font"]
       }
     },
+    "final_frame.min_visible_sample_ratio": {
+      "value": 0.6,
+      "comparison": "min",
+      "unit": "ratio",
+      "severity": "blocking",
+      "gate": "final-frame-visibility",
+      "measured_by": "scripts/final_frame_policy.py",
+      "rationale": "Required final-frame content must remain visible at at least three of the five browser hit-test sample points. Below 60% sampled visibility, a headline or CTA is severely occluded even when it is not fully covered.",
+      "doc_assertions": {
+        "skills/render/references/qa-gates.md": ["60%"]
+      }
+    },
     "gif.max_bytes": {
       "value": 5242880,
       "comparison": "max",
@@ -290,6 +302,7 @@
     "motion-budget": "Per-frame changed-pixel cost stays inside the encode budget.",
     "font-determinism": "The typography that rendered is recorded, so it can never differ silently between machines.",
     "loop-close": "The loop seam is indistinguishable from any other frame boundary.",
+    "final-frame-visibility": "Required final-frame content remains substantially visible in the exported composition.",
     "file-budget": "The encoded GIF fits the delivery budget."
   }
 }

--- a/scripts/final_frame_policy.py
+++ b/scripts/final_frame_policy.py
@@ -6,23 +6,40 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 
-DEFAULT_MIN_VISIBLE_SAMPLE_RATIO = 0.60
+from scripts.visual_contract import VisualContract
+
+THRESHOLD_ID = "final_frame.min_visible_sample_ratio"
 
 
 def rounded(value: float) -> float:
     return round(value, 3)
 
 
-def apply_policy(report: dict, min_visible_sample_ratio: float) -> dict:
-    if not 0 < min_visible_sample_ratio <= 1:
+def contract_min_visible_sample_ratio() -> float:
+    return float(VisualContract().value(THRESHOLD_ID))
+
+
+def apply_policy(report: dict, min_visible_sample_ratio: float | None = None) -> dict:
+    if not isinstance(report, Mapping):
+        raise ValueError("final-frame report must be a JSON object")
+
+    threshold = (
+        contract_min_visible_sample_ratio()
+        if min_visible_sample_ratio is None
+        else min_visible_sample_ratio
+    )
+    if not 0 < threshold <= 1:
         raise ValueError("min-visible-sample-ratio must be > 0 and <= 1")
 
     required = report.get("required_visible_elements")
     violations = report.get("violations")
     if not isinstance(required, list) or not isinstance(violations, list):
         raise ValueError("final-frame report is missing required visibility evidence")
+    if not all(isinstance(row, Mapping) for row in [*required, *violations]):
+        raise ValueError("final-frame visibility evidence contains an invalid row")
 
     existing_elements = {
         row.get("element")
@@ -32,16 +49,22 @@ def apply_policy(report: dict, min_visible_sample_ratio: float) -> dict:
 
     for row in required:
         hit_test = row.get("hit_test") or {}
+        if not isinstance(hit_test, Mapping):
+            raise ValueError("final-frame hit-test evidence must be a JSON object")
+
         sample_count = int(hit_test.get("sample_count") or 0)
         visible_samples = int(hit_test.get("visible_samples") or 0)
         ratio = visible_samples / sample_count if sample_count > 0 else None
         row["visible_sample_ratio"] = rounded(ratio) if ratio is not None else None
 
         reasons = row.setdefault("reasons", [])
+        if not isinstance(reasons, list):
+            raise ValueError("final-frame visibility reasons must be a list")
+
         is_partial_occlusion = (
             ratio is not None
             and 0 < visible_samples < sample_count
-            and ratio < min_visible_sample_ratio
+            and ratio < threshold
         )
         if not is_partial_occlusion:
             continue
@@ -57,7 +80,8 @@ def apply_policy(report: dict, min_visible_sample_ratio: float) -> dict:
             existing_elements.add(row.get("element"))
 
     report["final_frame_policy"] = {
-        "min_visible_sample_ratio": min_visible_sample_ratio,
+        "threshold_id": THRESHOLD_ID,
+        "min_visible_sample_ratio": threshold,
         "sampling_basis": "browser-hit-test",
     }
     report["verdict"] = "FAIL" if violations else "PASS"
@@ -70,7 +94,8 @@ def main(argv=None) -> int:
     parser.add_argument(
         "--min-visible-sample-ratio",
         type=float,
-        default=DEFAULT_MIN_VISIBLE_SAMPLE_RATIO,
+        default=None,
+        help="Override the visual-contract threshold for diagnostics only",
     )
     args = parser.parse_args(argv)
 
@@ -82,7 +107,7 @@ def main(argv=None) -> int:
     try:
         report = json.loads(path.read_text())
         apply_policy(report, args.min_visible_sample_ratio)
-    except (ValueError, json.JSONDecodeError) as exc:
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
         print(str(exc), file=sys.stderr)
         return 2
 
@@ -101,9 +126,10 @@ def main(argv=None) -> int:
         )
         return 1
 
+    threshold = report["final_frame_policy"]["min_visible_sample_ratio"]
     print(
         "final-frame policy: PASS "
-        f"(minimum visible hit-test ratio {args.min_visible_sample_ratio:.0%})"
+        f"(minimum visible hit-test ratio {threshold:.0%})"
     )
     return 0
 

--- a/scripts/final_frame_policy.py
+++ b/scripts/final_frame_policy.py
@@ -9,6 +9,11 @@ import sys
 from collections.abc import Mapping
 from pathlib import Path
 
+# Keep direct CLI execution consistent with the rest of the render scripts. When Python
+# executes ``scripts/final_frame_policy.py`` directly, sys.path starts at ``scripts/``;
+# add the repository root so package imports resolve the same way they do in unit tests.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from scripts.visual_contract import VisualContract
 
 THRESHOLD_ID = "final_frame.min_visible_sample_ratio"

--- a/scripts/final_frame_policy.py
+++ b/scripts/final_frame_policy.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Apply deterministic final-frame visibility policy to browser evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_MIN_VISIBLE_SAMPLE_RATIO = 0.60
+
+
+def rounded(value: float) -> float:
+    return round(value, 3)
+
+
+def apply_policy(report: dict, min_visible_sample_ratio: float) -> dict:
+    if not 0 < min_visible_sample_ratio <= 1:
+        raise ValueError("min-visible-sample-ratio must be > 0 and <= 1")
+
+    required = report.get("required_visible_elements")
+    violations = report.get("violations")
+    if not isinstance(required, list) or not isinstance(violations, list):
+        raise ValueError("final-frame report is missing required visibility evidence")
+
+    existing_elements = {
+        row.get("element")
+        for row in violations
+        if row.get("reason") == "required-final-element-hidden"
+    }
+
+    for row in required:
+        hit_test = row.get("hit_test") or {}
+        sample_count = int(hit_test.get("sample_count") or 0)
+        visible_samples = int(hit_test.get("visible_samples") or 0)
+        ratio = visible_samples / sample_count if sample_count > 0 else None
+        row["visible_sample_ratio"] = rounded(ratio) if ratio is not None else None
+
+        reasons = row.setdefault("reasons", [])
+        is_partial_occlusion = (
+            ratio is not None
+            and 0 < visible_samples < sample_count
+            and ratio < min_visible_sample_ratio
+        )
+        if not is_partial_occlusion:
+            continue
+
+        if "partially-occluded" not in reasons:
+            reasons.append("partially-occluded")
+
+        if row.get("element") not in existing_elements:
+            violations.append({
+                **row,
+                "reason": "required-final-element-hidden",
+            })
+            existing_elements.add(row.get("element"))
+
+    report["final_frame_policy"] = {
+        "min_visible_sample_ratio": min_visible_sample_ratio,
+        "sampling_basis": "browser-hit-test",
+    }
+    report["verdict"] = "FAIL" if violations else "PASS"
+    return report
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", help="final-frame JSON evidence to update in place")
+    parser.add_argument(
+        "--min-visible-sample-ratio",
+        type=float,
+        default=DEFAULT_MIN_VISIBLE_SAMPLE_RATIO,
+    )
+    args = parser.parse_args(argv)
+
+    path = Path(args.report)
+    if not path.is_file():
+        print(f"No such final-frame report: {path}", file=sys.stderr)
+        return 2
+
+    try:
+        report = json.loads(path.read_text())
+        apply_policy(report, args.min_visible_sample_ratio)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    violations = report["violations"]
+    if violations:
+        partial = sum(
+            "partially-occluded" in row.get("reasons", [])
+            for row in violations
+            if row.get("reason") == "required-final-element-hidden"
+        )
+        print(
+            "final-frame policy: FAIL "
+            f"({len(violations)} violation(s), {partial} partial-occlusion violation(s))"
+        )
+        return 1
+
+    print(
+        "final-frame policy: PASS "
+        f"(minimum visible hit-test ratio {args.min_visible_sample_ratio:.0%})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render.sh
+++ b/scripts/render.sh
@@ -107,6 +107,14 @@ set -e
 [[ "$FINAL_FRAME_STATUS" -le 1 ]] || exit "$FINAL_FRAME_STATUS"
 
 echo
+echo "── final frame visibility policy ────────────"
+set +e
+python3 "$HERE/final_frame_policy.py" "$FINAL_FRAME_JSON"
+FINAL_FRAME_POLICY_STATUS=$?
+set -e
+[[ "$FINAL_FRAME_POLICY_STATUS" -le 1 ]] || exit "$FINAL_FRAME_POLICY_STATUS"
+
+echo
 echo "── assemble ─────────────────────────────────"
 set +e
 python3 "$HERE/build_gif.py" "$FRAMES" \
@@ -127,4 +135,4 @@ REPORT_STATUS=$?
 set -e
 [[ "$REPORT_STATUS" -le 1 ]] || exit "$REPORT_STATUS"
 
-[[ "$ARTBOARD_STATUS" -eq 0 && "$OVERFLOW_STATUS" -eq 0 && "$STILL_STATUS" -eq 0 && "$FINAL_FRAME_STATUS" -eq 0 && "$GIF_STATUS" -eq 0 && "$REPORT_STATUS" -eq 0 ]]
+[[ "$ARTBOARD_STATUS" -eq 0 && "$OVERFLOW_STATUS" -eq 0 && "$STILL_STATUS" -eq 0 && "$FINAL_FRAME_STATUS" -eq 0 && "$FINAL_FRAME_POLICY_STATUS" -eq 0 && "$GIF_STATUS" -eq 0 && "$REPORT_STATUS" -eq 0 ]]

--- a/skills/render/references/qa-gates.md
+++ b/skills/render/references/qa-gates.md
@@ -106,7 +106,18 @@ screenshot anyone takes of your post is a single frame.
 - [ ] No element is mid-fade, half-drawn, or at `opacity: 0` in frame 0
 - [ ] The first highlighted element is the one you want seen first
 
-## Gate 7 — File
+## Gate 7 — Final-frame visibility
+
+Elements marked `data-final-visible` are required to remain substantially visible at the
+last exported frame. The browser hit-test samples five points inside each element; at least
+60% of those samples must remain visible. Full occlusion and severe partial occlusion are
+blocking failures.
+
+- [ ] Required headlines and CTAs are visible at the final sampled frame
+- [ ] No overlay covers more than two of the five hit-test samples
+- [ ] `final-frame.json` records the threshold id and sampled visibility ratio
+
+## Gate 8 — File
 
 ```bash
 ffprobe -v error -show_entries stream=width,height,nb_frames,duration \
@@ -119,7 +130,7 @@ ls -la build/post.gif
 - [ ] 1080x1350
 - [ ] Loops infinitely (open it in a browser and watch it repeat)
 
-## Gate 8 — Content
+## Gate 9 — Content
 
 - [ ] Every number on the artboard is real and verifiable
 - [ ] Every product name is spelled the way the company spells it
@@ -130,7 +141,7 @@ ls -la build/post.gif
 Search the HTML for the template placeholders before you export. This is the most
 embarrassing failure and the easiest to prevent.
 
-## Gate 9 — Caption
+## Gate 10 — Caption
 
 - [ ] Line 1 is under 60 characters and works alone
 - [ ] Every line has a blank line after it unless it is a tight list
@@ -143,7 +154,7 @@ embarrassing failure and the easiest to prevent.
 
 Read the caption top to bottom out loud. Anything you would not say out loud, cut.
 
-## Gate 10 — RTL, if applicable
+## Gate 11 — RTL, if applicable
 
 See `references/arabic-rtl.md` for the full list.
 

--- a/tests/test_final_frame_policy.py
+++ b/tests/test_final_frame_policy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import copy
 import unittest
 
-from scripts.final_frame_policy import apply_policy
+from scripts.final_frame_policy import apply_policy, contract_min_visible_sample_ratio
 
 
 BASE = {
@@ -25,6 +25,9 @@ BASE = {
 
 
 class FinalFramePolicyTests(unittest.TestCase):
+    def test_default_threshold_comes_from_visual_contract(self):
+        self.assertEqual(contract_min_visible_sample_ratio(), 0.60)
+
     def test_fully_visible_required_element_passes(self):
         report = apply_policy(copy.deepcopy(BASE), 0.60)
         self.assertEqual(report["verdict"], "PASS")
@@ -70,6 +73,22 @@ class FinalFramePolicyTests(unittest.TestCase):
             apply_policy(copy.deepcopy(BASE), 0)
         with self.assertRaises(ValueError):
             apply_policy(copy.deepcopy(BASE), 1.1)
+
+    def test_non_object_root_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "JSON object"):
+            apply_policy([], 0.60)
+
+    def test_null_required_row_is_rejected(self):
+        source = copy.deepcopy(BASE)
+        source["required_visible_elements"] = [None]
+        with self.assertRaisesRegex(ValueError, "invalid row"):
+            apply_policy(source, 0.60)
+
+    def test_non_object_hit_test_is_rejected(self):
+        source = copy.deepcopy(BASE)
+        source["required_visible_elements"][0]["hit_test"] = "broken"
+        with self.assertRaisesRegex(ValueError, "hit-test evidence"):
+            apply_policy(source, 0.60)
 
 
 if __name__ == "__main__":

--- a/tests/test_final_frame_policy.py
+++ b/tests/test_final_frame_policy.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import unittest
+
+from scripts.final_frame_policy import apply_policy
+
+
+BASE = {
+    "required_visible_elements": [
+        {
+            "element": "h1#headline",
+            "reasons": [],
+            "hit_test": {
+                "sample_count": 5,
+                "visible_samples": 5,
+                "blockers": [],
+            },
+        }
+    ],
+    "violations": [],
+    "verdict": "PASS",
+}
+
+
+class FinalFramePolicyTests(unittest.TestCase):
+    def test_fully_visible_required_element_passes(self):
+        report = apply_policy(copy.deepcopy(BASE), 0.60)
+        self.assertEqual(report["verdict"], "PASS")
+        self.assertEqual(report["violations"], [])
+        self.assertEqual(report["required_visible_elements"][0]["visible_sample_ratio"], 1.0)
+
+    def test_two_of_five_visible_samples_fail_as_partial_occlusion(self):
+        source = copy.deepcopy(BASE)
+        source["required_visible_elements"][0]["hit_test"].update(
+            visible_samples=2,
+            blockers=["div.cover"],
+        )
+        report = apply_policy(source, 0.60)
+        self.assertEqual(report["verdict"], "FAIL")
+        self.assertEqual(len(report["violations"]), 1)
+        violation = report["violations"][0]
+        self.assertIn("partially-occluded", violation["reasons"])
+        self.assertEqual(violation["visible_sample_ratio"], 0.4)
+        self.assertIn("div.cover", violation["hit_test"]["blockers"])
+
+    def test_three_of_five_visible_samples_meet_default_threshold(self):
+        source = copy.deepcopy(BASE)
+        source["required_visible_elements"][0]["hit_test"]["visible_samples"] = 3
+        report = apply_policy(source, 0.60)
+        self.assertEqual(report["verdict"], "PASS")
+        self.assertEqual(report["violations"], [])
+        self.assertEqual(report["required_visible_elements"][0]["visible_sample_ratio"], 0.6)
+
+    def test_full_occlusion_is_not_duplicated(self):
+        source = copy.deepcopy(BASE)
+        row = source["required_visible_elements"][0]
+        row["hit_test"]["visible_samples"] = 0
+        row["reasons"] = ["occluded"]
+        source["violations"] = [{**copy.deepcopy(row), "reason": "required-final-element-hidden"}]
+        source["verdict"] = "FAIL"
+        report = apply_policy(source, 0.60)
+        self.assertEqual(report["verdict"], "FAIL")
+        self.assertEqual(len(report["violations"]), 1)
+        self.assertNotIn("partially-occluded", report["required_visible_elements"][0]["reasons"])
+
+    def test_invalid_threshold_is_rejected(self):
+        with self.assertRaises(ValueError):
+            apply_policy(copy.deepcopy(BASE), 0)
+        with self.assertRaises(ValueError):
+            apply_policy(copy.deepcopy(BASE), 1.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_final_frame_policy.py
+++ b/tests/test_final_frame_policy.py
@@ -2,11 +2,17 @@
 from __future__ import annotations
 
 import copy
+import json
+import subprocess
+import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 from scripts.final_frame_policy import apply_policy, contract_min_visible_sample_ratio
 
 
+ROOT = Path(__file__).resolve().parents[1]
 BASE = {
     "required_visible_elements": [
         {
@@ -89,6 +95,20 @@ class FinalFramePolicyTests(unittest.TestCase):
         source["required_visible_elements"][0]["hit_test"] = "broken"
         with self.assertRaisesRegex(ValueError, "hit-test evidence"):
             apply_policy(source, 0.60)
+
+    def test_cli_executes_directly_from_repository_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "final-frame.json"
+            report_path.write_text(json.dumps(BASE))
+            result = subprocess.run(
+                [sys.executable, "scripts/final_frame_policy.py", str(report_path)],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("final-frame policy: PASS", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
The final-frame browser audit only blocks full occlusion. A required headline or CTA can be visible at one or two sampled points, remain mostly covered, and still pass.

## Change
- add a deterministic final-frame visibility policy over existing browser hit-test evidence
- require at least 60% of the five hit-test samples to remain visible for `data-final-visible` elements
- preserve full-occlusion behavior without duplicate findings
- write the threshold and visible-sample ratio into canonical `final-frame.json`
- enforce the policy in `scripts/render.sh` before evidence merge
- add deterministic policy tests for pass, partial failure, threshold boundary, full occlusion, and invalid configuration

## Scope
No visual assets, composition rules, or animation behavior are changed. This only tightens final-frame QA for already-marked required content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a final-frame visibility audit for required on-screen elements.
  * Reports visibility ratios, occlusion details, and an overall PASS/FAIL result.
  * Uses a 60% visibility threshold and integrates the audit into final rendering approval.

* **Bug Fixes**
  * Detects partially or fully hidden required elements before final approval.
  * Improves handling of invalid evidence and report data.

* **Documentation**
  * Added guidance for the final-frame visibility quality gate.

* **Tests**
  * Added coverage for thresholds, occlusion, invalid settings, and command-line execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->